### PR TITLE
compiler: gen server code.

### DIFF
--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -342,8 +342,7 @@ impl<'a> ServiceGen<'a> {
 
         w.write_line("");
 
-        w.pub_fn(&*format!("bind_{}<S: {} + Send + Sync + 'static>(mut builder: \
-                          {}, s: S) -> {2}",
+        w.pub_fn(&*format!("bind_{}<S: {} + Send + 'static>(mut builder: {}, s: S) -> {2}",
                            snake_name(self.service_name()),
                            self.service_name(),
                            fq_grpc("ServerBuilder")),

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -259,7 +259,7 @@ impl<'a> MethodGen<'a> {
                           self.input(),
                           fq_grpc(resp),
                           self.output());
-        w.fn_def(&*sig);
+        w.fn_def(&sig);
     }
 
     fn write_bind(&self, w: &mut CodeWriter) {
@@ -269,12 +269,12 @@ impl<'a> MethodGen<'a> {
             MethodType::ServerStreaming => "add_server_streaming_handler",
             MethodType::Dulex => "add_duplex_streaming_handler",
         };
-        w.block(&*format!("builder = builder.{}(&{}, move |ctx, req, resp| {{",
+        w.block(&format!("builder = builder.{}(&{}, move |ctx, req, resp| {{",
                           add,
                           self.const_method_name()),
                 "});",
                 |w| {
-                    w.write_line(&*format!("instance.{}(ctx, req, resp)", self.name()));
+                    w.write_line(&format!("instance.{}(ctx, req, resp)", self.name()));
                 });
     }
 }
@@ -342,7 +342,7 @@ impl<'a> ServiceGen<'a> {
 
         w.write_line("");
 
-        w.pub_fn(&*format!("bind_{}<S: {} + Send + 'static>(mut builder: {}, s: S) -> {2}",
+        w.pub_fn(&format!("bind_{}<S: {} + Send + 'static>(mut builder: {}, s: S) -> {2}",
                            snake_name(self.service_name()),
                            self.service_name(),
                            fq_grpc("ServerBuilder")),

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -348,7 +348,7 @@ impl<'a> ServiceGen<'a> {
                            self.service_name(),
                            fq_grpc("ServerBuilder")),
                  |w| {
-            w.write_line("let service = Arc::new(s);");
+            w.write_line("let service = ::std::sync::Arc::new(s);");
             for method in &self.methods {
                 w.write_line("let instance = service.clone();");
                 method.write_bind(w);

--- a/examples/generated/route_guide_grpc.rs
+++ b/examples/generated/route_guide_grpc.rs
@@ -97,7 +97,7 @@ pub trait RouteGuide {
     fn route_chat(&self, ctx: ::grpc::RpcContext, req: ::grpc::RequestStream<super::route_guide::RouteNote>, resp: ::grpc::ResponseSink<super::route_guide::RouteNote>);
 }
 
-pub fn bind_route_guide<S: RouteGuide + Send + Sync + 'static>(mut builder: ::grpc::ServerBuilder, s: S) -> ::grpc::ServerBuilder {
+pub fn bind_route_guide<S: RouteGuide + Send + 'static>(mut builder: ::grpc::ServerBuilder, s: S) -> ::grpc::ServerBuilder {
     let service = ::std::sync::Arc::new(s);
     let instance = service.clone();
     builder = builder.add_unary_handler(&METHOD_GET_FEATURE, move |ctx, req, resp| {

--- a/examples/generated/route_guide_grpc.rs
+++ b/examples/generated/route_guide_grpc.rs
@@ -98,7 +98,7 @@ pub trait RouteGuide {
 }
 
 pub fn bind_route_guide<S: RouteGuide + Send + Sync + 'static>(mut builder: ::grpc::ServerBuilder, s: S) -> ::grpc::ServerBuilder {
-    let service = Arc::new(s);
+    let service = ::std::sync::Arc::new(s);
     let instance = service.clone();
     builder = builder.add_unary_handler(&METHOD_GET_FEATURE, move |ctx, req, resp| {
         instance.get_feature(ctx, req, resp)

--- a/examples/server.rs
+++ b/examples/server.rs
@@ -2,16 +2,18 @@ extern crate grpc;
 extern crate protobuf;
 extern crate futures;
 
+#[path="./generated/route_guide.rs"]
 mod route_guide;
+#[path="./generated/route_guide_grpc.rs"]
 mod route_guide_grpc;
 
 use std::sync::Arc;
 
-use grpc::{ServerBuilder, Environment, ChannelBuilder, Result};
+use grpc::*;
 use futures::{Future, Stream, stream, Sink};
 
-use route_guide::{Point, Rectangle, RouteNote};
-use route_guide_grpc::{self, RouteGuide};
+use route_guide::*;
+use route_guide_grpc::RouteGuide;
 
 fn new_point(lat: i32, lon: i32) -> Point {
     let mut point = Point::new();
@@ -41,7 +43,7 @@ impl RouteGuide for RouteGuideService {
         unimplemented!()
     }
 
-    fn list_features(&self, ctx: RpcContext, point: UnaryRequest<Point>, resp: ResponseSink<Feature>) {
+    fn list_features(&self, ctx: RpcContext, point: UnaryRequest<Rectangle>, resp: ResponseSink<Feature>) {
         unimplemented!()
     }
 
@@ -57,7 +59,7 @@ impl RouteGuide for RouteGuideService {
 fn main() {
     let env = Arc::new(Environment::new(2));
     let instance = RouteGuideService;
-    let server = route_guide_grpc::bind_service(ServerBuilder::new(env), instance).bind("127.0.0.1", 50051).build();
+    let server = route_guide_grpc::bind_route_guide(ServerBuilder::new(env), instance).bind("127.0.0.1", 50051).build();
     server.start();
     
 }


### PR DESCRIPTION
Remain 2 compile errors defer to @BusyJay 
```
$ cargo build --example server
   Compiling grpc v0.1.0 (file:///home/menglong/dev/rust/grpc-rs)
error[E0308]: mismatched types
  --> server.rs:62:93
   |
62 |     let server = route_guide_grpc::bind_route_guide(ServerBuilder::new(env), instance).bind("127.0.0.1", 50051).build();
   |                                                                                             ^^^^^^^^^^^ expected struct `std::string::String`, found reference
   |
   = note: expected type `std::string::String`
              found type `&'static str`
   = help: here are some functions which might fulfill your needs:
           - .escape_debug()
           - .escape_default()
           - .escape_unicode()
           - .to_lowercase()
           - .to_uppercase()

error: method `start` is private
  --> server.rs:63:12
   |
63 |     server.start();
   |            ^^^^^

error: aborting due to 2 previous errors

error: Could not compile `grpc`.
```