### PR TITLE
use builder to specify custom name prefix instead

### DIFF
--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -17,7 +17,7 @@
 
 extern crate libc;
 
-use libc::{c_char, c_int, c_void, int32_t, int64_t, size_t, uint32_t};
+use libc::{c_char, c_int, c_uint, c_void, int32_t, int64_t, size_t, uint32_t};
 use std::time::Duration;
 
 #[derive(Clone, Copy)]
@@ -169,6 +169,8 @@ extern "C" {
     pub fn gpr_now(clock_type: GprClockType) -> GprTimespec;
     pub fn gpr_time_cmp(lhs: GprTimespec, rhs: GprTimespec) -> c_int;
     pub fn gpr_convert_clock_type(t: GprTimespec, clock_type: GprClockType) -> GprTimespec;
+
+    pub fn gpr_cpu_num_cores() -> c_uint;
 
     pub fn grpc_completion_queue_create(reserved: *mut c_void) -> *mut GrpcCompletionQueue;
     pub fn grpc_completion_queue_next(cq: *mut GrpcCompletionQueue,

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -174,7 +174,7 @@ mod tests {
 
     #[test]
     fn test_resolve() {
-        let env = Environment::new("test", 1);
+        let env = Environment::new(1);
 
         let (cq_f1, tag1) = CallTag::shutdown_pair();
         let (cq_f2, tag2) = CallTag::shutdown_pair();

--- a/src/env.rs
+++ b/src/env.rs
@@ -38,6 +38,56 @@ fn poll_queue(cq: Arc<CompletionQueue>) {
     }
 }
 
+pub struct EnvBuilder {
+    cq_count: usize,
+    name_prefix: Option<String>,
+}
+
+impl EnvBuilder {
+    pub fn new() -> EnvBuilder {
+        EnvBuilder {
+            cq_count: unsafe { grpc_sys::gpr_cpu_num_cores() as usize },
+            name_prefix: None,
+        }
+    }
+
+    pub fn cq_count(mut self, count: usize) -> EnvBuilder {
+        assert!(count > 0);
+        self.cq_count = count;
+        self
+    }
+
+    pub fn name_prefix<S: Into<String>>(mut self, prefix: S) -> EnvBuilder {
+        self.name_prefix = Some(prefix.into());
+        self
+    }
+
+    pub fn build(self) -> Environment {
+        unsafe {
+            grpc_sys::grpc_init();
+        }
+        let mut cqs = Vec::with_capacity(self.cq_count);
+        let mut handles = Vec::with_capacity(self.cq_count);
+        for i in 0..self.cq_count {
+            let cq = Arc::new(CompletionQueue::new());
+            let cq_ = cq.clone();
+            let mut builder = ThreadBuilder::new();
+            if let Some(ref prefix) = self.name_prefix {
+                builder = builder.name(format!("{}-{}", prefix, i));
+            }
+            let handle = builder.spawn(move || poll_queue(cq_)).unwrap();
+            cqs.push(cq);
+            handles.push(handle);
+        }
+
+        Environment {
+            cqs: cqs,
+            idx: AtomicUsize::new(0),
+            _handles: handles,
+        }
+    }
+}
+
 /// An object that used to control concurrency and start event loop.
 pub struct Environment {
     cqs: Vec<Arc<CompletionQueue>>,
@@ -49,29 +99,12 @@ impl Environment {
     /// Initialize grpc and create a threadpool to poll event loop.
     ///
     /// Each thread in threadpool will have one event loop.
-    pub fn new(name: &str, cq_count: usize) -> Environment {
+    pub fn new(cq_count: usize) -> Environment {
         assert!(cq_count > 0);
-        unsafe {
-            grpc_sys::grpc_init();
-        }
-        let mut cqs = Vec::with_capacity(cq_count);
-        let mut handles = Vec::with_capacity(cq_count);
-        for i in 0..cq_count {
-            let cq = Arc::new(CompletionQueue::new());
-            let cq_ = cq.clone();
-            let handle = ThreadBuilder::new()
-                .name(format!("grpc-{}-{}", name, i))
-                .spawn(move || poll_queue(cq_))
-                .unwrap();
-            cqs.push(cq);
-            handles.push(handle);
-        }
-
-        Environment {
-            cqs: cqs,
-            idx: AtomicUsize::new(0),
-            _handles: handles,
-        }
+        EnvBuilder::new()
+            .name_prefix("grpc-poll")
+            .cq_count(cq_count)
+            .build()
     }
 
     /// Get all the created completion queues.
@@ -101,7 +134,7 @@ mod tests {
 
     #[test]
     fn test_basic_loop() {
-        let mut env = Environment::new("test", 2);
+        let mut env = Environment::new(2);
 
         let q1_ptr = env.pick_cq();
         let q2_ptr = env.pick_cq();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,5 +37,5 @@ pub use call::client::{CallOption, ClientStreamingCallHandler, DuplexCallHandler
 pub use call::server::{ClientStreamingSink, ClientStreamingSinkResult, Deadline, DuplexSink,
                        DuplexSinkFailure, RequestStream, RpcContext, ServerStreamingSink,
                        ServerStreamingSinkFailure, UnarySink, UnarySinkResult};
-pub use env::Environment;
+pub use env::{EnvBuilder, Environment};
 pub use error::{Error, Result};


### PR DESCRIPTION
So the old API won't break and it will be more convenient to add extra configuration in the future.