### PR TITLE
reexport RpcStatusCode

### DIFF
--- a/src/async/promise.rs
+++ b/src/async/promise.rs
@@ -14,9 +14,7 @@
 
 use std::sync::Arc;
 
-use grpc_sys::GrpcStatusCode;
-
-use call::BatchContext;
+use call::{BatchContext, RpcStatusCode};
 use error::Error;
 use super::{BatchMessage, Inner};
 
@@ -63,7 +61,7 @@ impl Batch {
             return;
         }
         let status = self.ctx.rpc_status();
-        if status.status != GrpcStatusCode::Ok {
+        if status.status != RpcStatusCode::Ok {
             guard.set_result(Err(Error::RpcFailure(status)));
             return;
         }
@@ -74,7 +72,7 @@ impl Batch {
     fn handle_unary_response(&mut self) {
         let mut guard = self.inner.lock();
         let status = self.ctx.rpc_status();
-        if status.status != GrpcStatusCode::Ok {
+        if status.status != RpcStatusCode::Ok {
             guard.set_result(Err(Error::RpcFailure(status)));
             return;
         }

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -22,11 +22,13 @@ use std::{ptr, result, slice, usize};
 use std::sync::{Arc, Mutex};
 
 use futures::{Async, Future, Poll};
-use grpc_sys::{self, GrpcBatchContext, GrpcCall, GrpcCallStatus, GrpcStatusCode};
+use grpc_sys::{self, GrpcBatchContext, GrpcCall, GrpcCallStatus};
 use libc::c_void;
 
 use async::{BatchFuture, BatchType, CallTag};
 use error::{Error, Result};
+
+pub use grpc_sys::GrpcStatusCode as RpcStatusCode;
 
 #[derive(Clone, Copy)]
 pub enum MethodType {
@@ -51,12 +53,12 @@ impl Method {
 /// Status return from server.
 #[derive(Debug)]
 pub struct RpcStatus {
-    pub status: GrpcStatusCode,
+    pub status: RpcStatusCode,
     pub details: Option<String>,
 }
 
 impl RpcStatus {
-    pub fn new(status: GrpcStatusCode, details: Option<String>) -> RpcStatus {
+    pub fn new(status: RpcStatusCode, details: Option<String>) -> RpcStatus {
         RpcStatus {
             status: status,
             details: details,
@@ -65,7 +67,7 @@ impl RpcStatus {
 
     /// Generate an Ok status.
     pub fn ok() -> RpcStatus {
-        RpcStatus::new(GrpcStatusCode::Ok, None)
+        RpcStatus::new(RpcStatusCode::Ok, None)
     }
 }
 
@@ -87,7 +89,7 @@ impl BatchContext {
     pub fn rpc_status(&self) -> RpcStatus {
         let status =
             unsafe { grpc_sys::grpcwrap_batch_context_recv_status_on_client_status(self.ctx) };
-        let details = if status == GrpcStatusCode::Ok {
+        let details = if status == RpcStatusCode::Ok {
             None
         } else {
             unsafe {

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -17,11 +17,11 @@ use std::marker::PhantomData;
 use std::sync::{Arc, Mutex};
 
 use futures::{Async, AsyncSink, Future, Poll, Sink, StartSend, Stream};
-use grpc_sys::{self, GprClockType, GprTimespec, GrpcRequestCallContext, GrpcStatusCode};
+use grpc_sys::{self, GprClockType, GprTimespec, GrpcRequestCallContext};
 use protobuf::{self, Message, MessageStatic};
 
 use async::BatchFuture;
-use call::{Call, SinkBase, StreamingBase};
+use call::{Call, RpcStatusCode, SinkBase, StreamingBase};
 use error::Error;
 use super::{CallHolder, RpcStatus};
 
@@ -362,7 +362,7 @@ pub fn execute_unary<P, Q, F>(mut ctx: RpcContext, payload: &[u8], f: &F)
         Ok(f) => f,
         Err(e) => {
             let status =
-                RpcStatus::new(GrpcStatusCode::Internal,
+                RpcStatus::new(RpcStatusCode::Internal,
                                Some(format!("Failed to deserialize response message: {:?}", e)));
             call.abort(status);
             return;
@@ -402,7 +402,7 @@ pub fn execute_server_streaming<P, Q, F>(mut ctx: RpcContext, payload: &[u8], f:
         Ok(t) => t,
         Err(e) => {
             let status =
-                RpcStatus::new(GrpcStatusCode::Internal,
+                RpcStatus::new(RpcStatusCode::Internal,
                                Some(format!("Failed to deserialize response message: {:?}", e)));
             call.abort(status);
             return;
@@ -434,5 +434,5 @@ pub fn execute_duplex_streaming<P, Q, F>(mut ctx: RpcContext, f: &F)
 pub fn execute_unimplemented(mut ctx: RequestContext) {
     let mut call = ctx.take_call().unwrap();
     call.start_server_side();
-    call.abort(RpcStatus::new(GrpcStatusCode::Unimplemented, None))
+    call.abort(RpcStatus::new(RpcStatusCode::Unimplemented, None))
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,7 +31,7 @@ mod cq;
 mod env;
 mod error;
 
-pub use call::{Method, MethodType, RpcStatus};
+pub use call::{Method, MethodType, RpcStatus, RpcStatusCode};
 pub use call::client::{CallOption, ClientStreamingCallHandler, DuplexCallHandler,
                        ServerStreamingCallHandler, UnaryCallHandler};
 pub use call::server::{ClientStreamingSink, ClientStreamingSinkResult, Deadline, DuplexSink,


### PR DESCRIPTION
So user can use `RpcStatusCode` without adding grpc-sys as dependency explicitly.