### PR TITLE
grpc-sys: adjust dependency

### DIFF
--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -9,10 +9,10 @@ clippy = { version = "*", optional = true }
 
 [build-dependencies]
 gcc = "0.3"
-cmake = "0.1"
+cmake = { version = "0.1", optional = true }
 pkg-config = "0.3"
 
 [features]
 default = []
-static-link = []
+static-link = ["cmake"]
 dev = ["clippy"]

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 extern crate gcc;
+#[cfg(feature = "static-link")]
 extern crate cmake;
 extern crate pkg_config;
 


### PR DESCRIPTION
Only depend on cmake when necessary.