### PR TITLE
introduce alarm

### DIFF
--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -178,6 +178,7 @@ pub enum GrpcBatchContext {}
 pub enum GrpcServer {}
 pub enum GrpcServerCredentials {}
 pub enum GrpcRequestCallContext {}
+pub enum GrpcAlarm {}
 
 pub const GRPC_MAX_COMPLETION_QUEUE_PLUCKERS: usize = 6;
 
@@ -408,6 +409,13 @@ extern "C" {
                                                   force_client_auth: c_int)
                                                   -> *mut GrpcServerCredentials;
     pub fn grpc_server_credentials_release(credentials: *mut GrpcServerCredentials);
+
+    pub fn grpc_alarm_create(cq: *mut GrpcCompletionQueue,
+                             deadline: GprTimespec,
+                             tag: *mut c_void)
+                             -> *mut GrpcAlarm;
+    pub fn grpc_alarm_cancel(alarm: *mut GrpcAlarm);
+    pub fn grpc_alarm_destroy(alarm: *mut GrpcAlarm);
 }
 
 // TODO: more tests.

--- a/src/async/callback.rs
+++ b/src/async/callback.rs
@@ -40,7 +40,7 @@ impl Request {
             return;
         }
 
-        match self.ctx.handle_stream_req(&inner) {
+        match self.ctx.handle_stream_req(cq, &inner) {
             Ok(_) => server::request_call(inner, cq),
             Err(ctx) => ctx.handle_unary_req(inner, cq),
         }
@@ -73,7 +73,8 @@ impl UnaryRequest {
         }
 
         let data = self.ctx.batch_ctx().recv_message();
-        self.ctx.handle(&inner, data.as_ref().map(|v| v.as_slice()));
+        self.ctx
+            .handle(&inner, cq, data.as_ref().map(|v| v.as_slice()));
         server::request_call(inner, cq);
     }
 }

--- a/src/async/executor.rs
+++ b/src/async/executor.rs
@@ -1,0 +1,148 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+use std::ptr;
+use std::sync::Arc;
+
+use futures::executor::{self, Spawn, Unpark};
+use futures::future::BoxFuture;
+use futures::{Async, Future};
+use grpc_sys::{self, GprTimespec, GrpcAlarm};
+
+use cq::CompletionQueue;
+use super::lock::SpinLock;
+use super::CallTag;
+
+/// A handle to an alarm.
+///
+/// Alarm acts as a notification hook that wakes up poll thread once
+/// inner future is ready to make progress.
+pub struct AlarmHandle {
+    f: Spawn<BoxFuture<(), ()>>,
+    finished: bool,
+    alarm: *mut GrpcAlarm,
+}
+
+impl AlarmHandle {
+    /// Create an alarm for the future.
+    ///
+    /// `alarm` will be initialized lazily.
+    pub fn new(s: Spawn<BoxFuture<(), ()>>) -> AlarmHandle {
+        AlarmHandle {
+            f: s,
+            finished: false,
+            alarm: ptr::null_mut(),
+        }
+    }
+
+    /// Notify the alarm.
+    pub fn alarm(&mut self) {
+        self.finished = true;
+        if self.alarm.is_null() {
+            // So the handle is notified but not polled again (yet).
+            return;
+        }
+        unsafe {
+            // hack: because grpc's alarm feels more like a timer,
+            // but what we need here is a notification hook. Hence
+            // use cancel to implement the alarm behaviour.
+            grpc_sys::grpc_alarm_cancel(self.alarm)
+        }
+    }
+}
+
+impl Drop for AlarmHandle {
+    fn drop(&mut self) {
+        if self.alarm.is_null() {
+            return;
+        }
+        unsafe { grpc_sys::grpc_alarm_destroy(self.alarm) }
+    }
+}
+
+/// A custom unpark implemented with Alarm.
+pub struct AlarmUnpark {
+    handle: SpinLock<AlarmHandle>,
+}
+
+impl AlarmUnpark {
+    fn new(s: Spawn<BoxFuture<(), ()>>) -> AlarmUnpark {
+        AlarmUnpark { handle: SpinLock::new(AlarmHandle::new(s)) }
+    }
+}
+
+unsafe impl Send for AlarmUnpark {}
+unsafe impl Sync for AlarmUnpark {}
+
+impl Unpark for AlarmUnpark {
+    fn unpark(&self) {
+        let mut handle = self.handle.lock();
+        handle.alarm()
+    }
+}
+
+/// A call tag for custom asynchronious notification.
+pub struct Alarm {
+    unpark: Arc<AlarmUnpark>,
+}
+
+impl Alarm {
+    pub fn resolve(self, cq: &CompletionQueue, success: bool) {
+        // it should always be canceled for now.
+        assert!(!success);
+        spawn(cq, self.unpark);
+    }
+}
+
+// TODO: support timeout and trace future.
+fn spawn(cq: &CompletionQueue, unpark: Arc<AlarmUnpark>) {
+    let mut handle = unpark.handle.lock();
+    match handle.f.poll_future(unpark.clone()) {
+        Err(_) |
+        Ok(Async::Ready(_)) => return,
+        _ => {}
+    }
+
+    // handle.f is not resolved yet, need to register another alarm for notification.
+    let tag = Box::new(CallTag::Alarm(Alarm { unpark: unpark.clone() }));
+    handle.alarm = unsafe {
+        grpc_sys::grpc_alarm_create(cq.as_ptr(),
+                                    GprTimespec::inf_future(),
+                                    Box::into_raw(tag) as _)
+    };
+}
+
+/// An executor that drives a future in the grpc poll thread, which
+/// can reduce thread context switching.
+pub struct Executor<'a> {
+    cq: &'a CompletionQueue,
+}
+
+impl<'a> Executor<'a> {
+    pub fn new(cq: &CompletionQueue) -> Executor {
+        Executor { cq: cq }
+    }
+
+    /// Spawn the future into inner poll loop.
+    ///
+    /// If you want to trace the future, you may need to create a sender/receiver
+    /// pair by yourself.
+    pub fn spawn<F>(&self, f: F)
+        where F: Future<Item = (), Error = ()> + Send + 'static
+    {
+        let s = executor::spawn(f.boxed());
+        let unpark = Arc::new(AlarmUnpark::new(s));
+        spawn(self.cq, unpark)
+    }
+}

--- a/src/async/promise.rs
+++ b/src/async/promise.rs
@@ -13,6 +13,7 @@
 
 
 use std::sync::Arc;
+use std::fmt::{self, Debug, Formatter};
 
 use call::{BatchContext, RpcStatusCode};
 use error::Error;
@@ -99,6 +100,12 @@ impl Batch {
                 self.read_one_msg(success);
             }
         }
+    }
+}
+
+impl Debug for Batch {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        write!(f, "Batch [{:?}]", self.ty)
     }
 }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -286,4 +286,8 @@ impl Channel {
 
         unsafe { Call::from_raw(raw_call) }
     }
+
+    pub fn cq(&self) -> &CompletionQueue {
+        self.cq.as_ref()
+    }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -76,7 +76,9 @@ impl ServiceBuilder {
               F: Fn(RpcContext, P, UnarySink<Q>) + 'static
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx, payload: &[u8]| execute_unary(ctx, ser, de, payload, &handler));
+        let h = Box::new(move |ctx: RpcContext, payload: &[u8]| {
+                             execute_unary(ctx, ser, de, payload, &handler)
+                         });
         self.handlers
             .insert(method.name.as_bytes(), Handler::new(MethodType::Unary, h));
         self
@@ -92,7 +94,9 @@ impl ServiceBuilder {
               F: Fn(RpcContext, RequestStream<P>, ClientStreamingSink<Q>) + 'static
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx, _: &[u8]| execute_client_streaming(ctx, ser, de, &handler));
+        let h = Box::new(move |ctx: RpcContext, _: &[u8]| {
+                             execute_client_streaming(ctx, ser, de, &handler)
+                         });
         self.handlers
             .insert(method.name.as_bytes(),
                     Handler::new(MethodType::ClientStreaming, h));
@@ -109,7 +113,7 @@ impl ServiceBuilder {
               F: Fn(RpcContext, P, ServerStreamingSink<Q>) + 'static
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx, payload: &[u8]| {
+        let h = Box::new(move |ctx: RpcContext, payload: &[u8]| {
                              execute_server_streaming(ctx, ser, de, payload, &handler)
                          });
         self.handlers
@@ -128,7 +132,9 @@ impl ServiceBuilder {
               F: Fn(RpcContext, RequestStream<P>, DuplexSink<Q>) + 'static
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx, _: &[u8]| execute_duplex_streaming(ctx, ser, de, &handler));
+        let h = Box::new(move |ctx: RpcContext, _: &[u8]| {
+                             execute_duplex_streaming(ctx, ser, de, &handler)
+                         });
         self.handlers
             .insert(method.name.as_bytes(), Handler::new(MethodType::Duplex, h));
         self


### PR DESCRIPTION
Alarm provides a way to drive future in the grpc poll thread, which can reduce a lot of context switching.