### PR TITLE
travis: remove rustfmt check

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,9 +30,7 @@ before_script:
   - export DYLD_LIBRARY_PATH="$HOME/.cache/lib"
   - export LIBRARY_PATH="$HOME/.cache/lib"
   - export PKG_CONFIG_PATH="$HOME/.cache/lib/pkgconfig"
-  - if [[ $TRAVIS_RUST_VERSION == "stable" ]] && [[ $TRAVIS_OS_NAME == "linux" ]]; then which rustfmt || cargo install rustfmt; fi
 script:
-  - if [[ $TRAVIS_RUST_VERSION == "stable" ]] && [[ $TRAVIS_OS_NAME == "linux" ]]; then cargo fmt -- --write-mode=diff; fi
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then FEATURES="dev"; else FEATURES="default"; fi
   - export RUSTFLAGS=-Dwarnings
   - cargo build


### PR DESCRIPTION
rustfmt just gets upgraded and its format changes again. Let's remove the check for now, we may need to figure out a long-term policy later.