### PR TITLE
grpc-sys: use submodule instead

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "grpc-sys/grpc"]
+	path = grpc-sys/grpc
+	url = https://github.com/pingcap/grpc.git
+	branch = rs-release

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -16,14 +16,12 @@ extern crate gcc;
 extern crate cmake;
 extern crate pkg_config;
 
-const GRPC_VERSION: &'static str = "1.4.0";
-
 #[cfg(feature = "link-sys")]
 mod imp {
     use gcc::Config as GccConfig;
     use pkg_config::Config as PkgConfig;
-
-    use super::GRPC_VERSION;
+    
+    const GRPC_VERSION: &'static str = "1.4.0";
 
     pub fn build_or_link_grpc(cc: &mut GccConfig) {
         if let Ok(lib) = PkgConfig::new().atleast_version(GRPC_VERSION).probe("grpc") {
@@ -38,73 +36,31 @@ mod imp {
 
 #[cfg(not(feature = "link-sys"))]
 mod imp {
-    use std::env;
-    use std::process::Command;
+    use std::path::Path;
 
     use cmake::Config as CMakeConfig;
     use gcc::Config as GccConfig;
 
-    use super::GRPC_VERSION;
+    fn prepare_grpc() {
+        let modules = vec![
+            "grpc",
+            "grpc/third_party/zlib",
+            "grpc/third_party/boringssl",
+            "grpc/third_party/cares/cares",
+        ];
 
-    const ZLIB_VERSION: &'static str = "v1.2.11";
-    const BORINGSSL_COMMIT_HASH: &'static str = "78684e5b222645828ca302e56b40b9daff2b2d27";
-    const CARES_TAG: &'static str = "cares-1_12_0";
-
-    fn execute(cmd: &mut Command) {
-        match cmd.status() {
-            Err(e) => panic!("failed to execute {:?}: {}", cmd, e),
-            Ok(status) => {
-                if !status.success() {
-                    panic!("command {:?} exit with {}", cmd, status);
-                }
+        for module in modules {
+            if !Path::new(&format!("{}/.git", module)).exists() {
+                panic!("Can't find module {}. You need to run `git submodule \
+                        update --init --recursive` first to build the project.", module);
             }
         }
     }
 
-    fn fetch_and_extract(account: &str, repo: &str, arch_tag: &str, to_dir: &str) {
-        let url = format!("https://github.com/{}/{}/archive/{}.tar.gz",
-                          account,
-                          repo,
-                          arch_tag);
-        let out_dir = env::var("OUT_DIR").unwrap();
-        let tgz_file_name = format!("{}-{}.tar.gz", repo, arch_tag);
-        let cmds = vec![
-            vec!["wget", "-q", "-O", &tgz_file_name, &url],
-            vec!["rm", "-rf", &to_dir],
-            vec!["mkdir", "-p", &to_dir],
-            vec!["tar", "zxf", &tgz_file_name, "-C", to_dir, "--strip-components", "1"],
-        ];
-        for cmd in cmds {
-            execute(Command::new(cmd[0]).args(&cmd[1..]).current_dir(&out_dir));
-        }
-    }
-
-    fn prepare_grpc() {
-        fetch_and_extract("grpc", "grpc", &format!("v{}", GRPC_VERSION), "grpc");
-
-        let submodules =
-            vec![
-                ("madler", "zlib", ZLIB_VERSION, "grpc/third_party/zlib"),
-                ("google", "boringssl", BORINGSSL_COMMIT_HASH, "grpc/third_party/boringssl"),
-                ("c-ares", "c-ares", CARES_TAG, "grpc/third_party/cares/cares"),
-            ];
-
-        for (account, repo, tag, to_dir) in submodules {
-            fetch_and_extract(account, repo, tag, to_dir);
-        }
-    }
-
     pub fn build_or_link_grpc(cc: &mut GccConfig) {
-        let out_dir = env::var("OUT_DIR").expect("Can't access OUT_DIR");
-
         prepare_grpc();
 
-        // fix multiple _main symbols
-        execute(Command::new("rm")
-                    .current_dir(&format!("{}/grpc/third_party/cares/cares", out_dir))
-                    .args(&["acountry.c", "adig.c", "ahost.c"]));
-
-        let dst = CMakeConfig::new(format!("{}/grpc", out_dir))
+        let dst = CMakeConfig::new("grpc")
             .build_target("grpc")
             .build();
 
@@ -126,7 +82,7 @@ mod imp {
         println!("cargo:rustc-link-lib=static=ssl");
         println!("cargo:rustc-link-lib=static=crypto");
 
-        cc.include(format!("{}/grpc/include", out_dir));
+        cc.include("grpc/include");
     }
 }
 


### PR DESCRIPTION
If we are going to publish this project to *crates.io*, it will be more appropriate to use submodule instead of downloading sources at compile time.

To use the official release, we need to wait till grpc/grpc#11565 is merged.