### PR TITLE
build: support build and test on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+environment:
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+install:
+  - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"
+  - rust-nightly-%TARGET%.exe /VERYSILENT /NORESTART /DIR="C:\Program Files (x86)\Rust"
+  - SET PATH=%PATH%;C:\Program Files (x86)\Rust\bin
+  - rustc -V
+  - cargo -V
+    
+build: false
+
+test_script:
+  - cargo build --no-default-features
+  - cargo test --all


### PR DESCRIPTION
After this pr, this project should be able to be built and tested on windows. We may need to adopt Appveyor CI later.

If you are using Visual Studio 2017, you may need to use latest nightly rustc to build any rust program.

If you meet code page related error, you may need to set environment `_CL_` to "/utf-8".