### PR TITLE
*: support log

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,7 @@ grpcio-sys = { path = "grpc-sys", version = "0.1.0" }
 libc = "0.2"
 futures = "^0.1.15"
 protobuf = { version = "1.2", optional = true }
+log = "0.3"
 
 [workspace]
 members = ["proto", "benchmark", "compiler", "interop"]

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -12,6 +12,7 @@ grpcio-sys = { path = "../grpc-sys" }
 rand = "0.3"
 tokio-timer = "0.1"
 clap = "2.23"
+log = "0.3"
 
 [[bin]]
 name = "qps_worker"

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -50,39 +50,6 @@ impl BenchmarkService for Benchmark {
                 .map(|_| {}),
         )
     }
-
-    fn streaming_from_client(
-        &self,
-        ctx: RpcContext,
-        _: RequestStream<SimpleRequest>,
-        sink: ClientStreamingSink<SimpleResponse>,
-    ) {
-        let f = sink.fail(RpcStatus::new(RpcStatusCode::Unimplemented, None))
-            .map_err(|e| error!("failed to report unimplemented method: {:?}", e));
-        ctx.spawn(f)
-    }
-
-    fn streaming_from_server(
-        &self,
-        ctx: RpcContext,
-        _: SimpleRequest,
-        sink: ServerStreamingSink<SimpleResponse>,
-    ) {
-        let f = sink.fail(RpcStatus::new(RpcStatusCode::Unimplemented, None))
-            .map_err(|e| error!("failed to report unimplemented method: {:?}", e));
-        ctx.spawn(f)
-    }
-
-    fn streaming_both_ways(
-        &self,
-        ctx: RpcContext,
-        _: RequestStream<SimpleRequest>,
-        sink: DuplexSink<SimpleResponse>,
-    ) {
-        let f = sink.fail(RpcStatus::new(RpcStatusCode::Unimplemented, None))
-            .map_err(|e| error!("failed to report unimplemented method: {:?}", e));
-        ctx.spawn(f)
-    }
 }
 
 #[derive(Clone)]

--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -202,9 +202,7 @@ impl<B: Backoff + Send + 'static> GenericExecutor<B> {
                 r.into_future().map(|_| e).map_err(|(e, _)| Error::from(e))
             })
             .map(|_| ())
-            .map_err(|e| {
-                println!("failed to execute streaming ping pong: {:?}", e)
-            });
+            .map_err(|e| error!("failed to execute streaming ping pong: {:?}", e));
         client.spawn(f)
     }
 }
@@ -263,7 +261,7 @@ impl<B: Backoff + Send + 'static> RequestExecutor<B> {
                     Ok(Async::Ready(l))
                 })
             })
-        }).map_err(|e| println!("failed to execute unary async: {:?}", e));
+        }).map_err(|e| error!("failed to execute unary async: {:?}", e));
         client.spawn(f);
     }
 
@@ -306,9 +304,7 @@ impl<B: Backoff + Send + 'static> RequestExecutor<B> {
                 r.into_future().map(|_| e).map_err(|(e, _)| Error::from(e))
             })
             .map(|_| ())
-            .map_err(|e| {
-                println!("failed to execute streaming ping pong: {:?}", e)
-            });
+            .map_err(|e| error!("failed to execute streaming ping pong: {:?}", e));
         client.spawn(f)
     }
 }
@@ -360,7 +356,7 @@ impl Client {
         }
         let env = Arc::new(builder.build());
         if cfg.get_core_limit() > 0 {
-            println!("client config core limit is set but ignored");
+            error!("client config core limit is set but ignored");
         }
 
         let ch_env = env.clone();

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -20,6 +20,8 @@ extern crate grpcio_proto as grpc_proto;
 extern crate grpcio_sys as grpc_sys;
 #[cfg(not(target_os = "macos"))]
 extern crate libc;
+#[macro_use]
+extern crate log;
 extern crate rand;
 extern crate tokio_timer;
 

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -16,6 +16,8 @@ extern crate clap;
 extern crate futures;
 extern crate grpcio as grpc;
 extern crate grpcio_proto as grpc_proto;
+#[macro_use]
+extern crate log;
 
 use std::sync::Arc;
 
@@ -51,7 +53,7 @@ fn main() {
         .unwrap();
 
     for &(ref host, port) in server.bind_addrs() {
-        println!("listening on {}:{}", host, port);
+        info!("listening on {}:{}", host, port);
     }
 
     server.start();

--- a/benchmark/src/server.rs
+++ b/benchmark/src/server.rs
@@ -38,7 +38,7 @@ impl Server {
         }
         let env = Arc::new(builder.build());
         if cfg.get_core_limit() > 0 {
-            println!("server config core limit is set but ignored");
+            warn!("server config core limit is set but ignored");
         }
         let service = match cfg.get_server_type() {
             ServerType::ASYNC_SERVER => services_grpc::create_benchmark_service(Benchmark),

--- a/benchmark/src/worker.rs
+++ b/benchmark/src/worker.rs
@@ -51,7 +51,7 @@ impl WorkerService for Worker {
             .map_err(|(e, _)| Error::from(e))
             .and_then(|(arg, stream)| {
                 let cfg = arg.as_ref().unwrap().get_setup();
-                println!("receive server setup: {:?}", cfg);
+                info!("receive server setup: {:?}", cfg);
                 let server = try!(Server::new(cfg));
                 let status = server.get_status();
                 Ok(
@@ -59,7 +59,7 @@ impl WorkerService for Worker {
                         .and_then(|sink| {
                             stream.fold((sink, server), |(sink, mut server), arg| {
                                 let mark = arg.get_mark();
-                                println!("receive server mark: {:?}", mark);
+                                info!("receive server mark: {:?}", mark);
                                 let stats = server.get_stats(mark.get_reset());
                                 let mut status = server.get_status();
                                 status.set_stats(stats);
@@ -73,8 +73,8 @@ impl WorkerService for Worker {
                 )
             })
             .flatten()
-            .map_err(|e| println!("run server failed: {:?}", e))
-            .map(|_| println!("server shutdown."));
+            .map_err(|e| error!("run server failed: {:?}", e))
+            .map(|_| info!("server shutdown."));
         ctx.spawn(f)
     }
 
@@ -89,13 +89,13 @@ impl WorkerService for Worker {
             .map_err(|(e, _)| Error::from(e))
             .and_then(|(arg, stream)| {
                 let cfg = arg.as_ref().unwrap().get_setup();
-                println!("receive client setup: {:?}", cfg);
+                info!("receive client setup: {:?}", cfg);
                 let client = Client::new(cfg);
                 sink.send((ClientStatus::new(), WriteFlags::default()))
                     .and_then(|sink| {
                         stream.fold((sink, client), |(sink, mut client), arg| {
                             let mark = arg.get_mark();
-                            println!("receive client mark: {:?}", mark);
+                            info!("receive client mark: {:?}", mark);
                             let stats = client.get_stats(mark.get_reset());
                             let mut status = ClientStatus::new();
                             status.set_stats(stats);
@@ -109,8 +109,8 @@ impl WorkerService for Worker {
                         future::poll_fn(move || sink.close().map_err(From::from))
                     })
             })
-            .map_err(|e| println!("run client failed: {:?}", e))
-            .map(|_| println!("client shutdown."));
+            .map_err(|e| error!("run client failed: {:?}", e))
+            .map(|_| info!("client shutdown."));
         ctx.spawn(f)
     }
 
@@ -120,7 +120,7 @@ impl WorkerService for Worker {
         resp.set_cores(cpu_count as i32);
         ctx.spawn(
             sink.success(resp)
-                .map_err(|e| println!("failed to report cpu count: {:?}", e)),
+                .map_err(|e| error!("failed to report cpu count: {:?}", e)),
         )
     }
 
@@ -131,7 +131,7 @@ impl WorkerService for Worker {
         }
         ctx.spawn(
             sink.success(Void::new())
-                .map_err(|e| println!("failed to report quick worker: {:?}", e)),
+                .map_err(|e| error!("failed to report quick worker: {:?}", e)),
         );
     }
 }

--- a/examples/hello_world/client.rs
+++ b/examples/hello_world/client.rs
@@ -14,14 +14,18 @@
 
 extern crate grpcio;
 extern crate grpcio_proto;
+#[macro_use]
+extern crate log;
 
 use std::sync::Arc;
 
 use grpcio::{ChannelBuilder, EnvBuilder};
 use grpcio_proto::example::helloworld::HelloRequest;
 use grpcio_proto::example::helloworld_grpc::GreeterClient;
+use grpcio_proto::util;
 
 fn main() {
+    let _guard = util::init_log();
     let env = Arc::new(EnvBuilder::new().build());
     let ch = ChannelBuilder::new(env).connect("localhost:50051");
     let client = GreeterClient::new(ch);
@@ -29,5 +33,5 @@ fn main() {
     let mut req = HelloRequest::new();
     req.set_name("world".to_owned());
     let reply = client.say_hello(req).expect("rpc");
-    println!("Greeter received: {}", reply.get_message());
+    info!("Greeter received: {}", reply.get_message());
 }

--- a/examples/hello_world/server.rs
+++ b/examples/hello_world/server.rs
@@ -18,6 +18,8 @@
 extern crate futures;
 extern crate grpcio;
 extern crate grpcio_proto;
+#[macro_use]
+extern crate log;
 
 use std::io::Read;
 use std::sync::Arc;
@@ -29,6 +31,7 @@ use grpcio::{Environment, RpcContext, ServerBuilder, UnarySink};
 
 use grpcio_proto::example::helloworld::{HelloReply, HelloRequest};
 use grpcio_proto::example::helloworld_grpc::{self, Greeter};
+use grpcio_proto::util;
 
 #[derive(Clone)]
 struct GreeterService;
@@ -39,12 +42,13 @@ impl Greeter for GreeterService {
         let mut resp = HelloReply::new();
         resp.set_message(msg);
         let f = sink.success(resp)
-            .map_err(move |e| println!("failed to reply {:?}: {:?}", req, e));
+            .map_err(move |e| error!("failed to reply {:?}: {:?}", req, e));
         ctx.spawn(f)
     }
 }
 
 fn main() {
+    let _guard = util::init_log();
     let env = Arc::new(Environment::new(1));
     let service = helloworld_grpc::create_greeter(GreeterService);
     let mut server = ServerBuilder::new(env)
@@ -54,11 +58,11 @@ fn main() {
         .unwrap();
     server.start();
     for &(ref host, port) in server.bind_addrs() {
-        println!("listening on {}:{}", host, port);
+        info!("listening on {}:{}", host, port);
     }
     let (tx, rx) = oneshot::channel();
     thread::spawn(move || {
-        println!("Press ENTER to exit...");
+        info!("Press ENTER to exit...");
         let _ = io::stdin().read(&mut [0]).unwrap();
         tx.send(())
     });

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -164,6 +164,22 @@ pub enum GrpcServerRegisterMethodPayloadHandling {
     ReadInitialByteBuffer,
 }
 
+#[repr(C)]
+#[derive(Clone, Copy)]
+pub enum GprLogSeverity {
+    Debug,
+    Info,
+    Error,
+}
+
+#[repr(C)]
+pub struct GprLogFuncArgs {
+    pub file: *const c_char,
+    pub line: c_int,
+    pub severity: GprLogSeverity,
+    pub message: *const c_char,
+}
+
 pub const GRPC_INITIAL_METADATA_IDEMPOTENT_REQUEST: uint32_t = 0x00000010;
 pub const GRPC_INITIAL_METADATA_WAIT_FOR_READY: uint32_t = 0x00000020;
 pub const GRPC_INITIAL_METADATA_CACHEABLE_REQUEST: uint32_t = 0x00000040;
@@ -201,6 +217,9 @@ extern "C" {
     pub fn gpr_now(clock_type: GprClockType) -> GprTimespec;
     pub fn gpr_time_cmp(lhs: GprTimespec, rhs: GprTimespec) -> c_int;
     pub fn gpr_convert_clock_type(t: GprTimespec, clock_type: GprClockType) -> GprTimespec;
+
+    pub fn gpr_set_log_verbosity(severity: GprLogSeverity);
+    pub fn gpr_set_log_function(func: Option<extern "C" fn(*mut GprLogFuncArgs)>);
 
     pub fn gpr_cpu_num_cores() -> c_uint;
 

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -9,6 +9,7 @@ grpcio-sys = { path = "../grpc-sys" }
 grpcio-proto = { path = "../proto" }
 protobuf = "1.2"
 futures = "0.1"
+log = "0.3"
 clap = "2.23"
 
 [[bin]]

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -17,6 +17,8 @@ extern crate futures;
 extern crate grpcio as grpc;
 extern crate grpcio_proto as grpc_proto;
 extern crate interop;
+#[macro_use]
+extern crate log;
 
 use std::sync::Arc;
 
@@ -74,7 +76,7 @@ fn main() {
 
     let mut server = builder.build().unwrap();
     for &(ref host, port) in server.bind_addrs() {
-        println!("listening on {}:{}", host, port);
+        info!("listening on {}:{}", host, port);
     }
     server.start();
 

--- a/interop/src/client.rs
+++ b/interop/src/client.rs
@@ -57,15 +57,16 @@ impl Client {
 
     pub fn client_streaming(&self) {
         print!("testing client streaming ... ");
-        let reqs = vec![27182, 8, 1828, 45904]
-            .into_iter()
-            .map(|s| {
-                let mut req = StreamingInputCallRequest::new();
-                req.set_payload(util::new_payload(s));
-                (req, WriteFlags::default())
-            });
+        let reqs = vec![27182, 8, 1828, 45904].into_iter().map(|s| {
+            let mut req = StreamingInputCallRequest::new();
+            req.set_payload(util::new_payload(s));
+            (req, WriteFlags::default())
+        });
         let (sender, receiver) = self.client.streaming_input_call();
-        sender.send_all(stream::iter_ok::<_, grpc::Error>(reqs)).wait().unwrap();
+        sender
+            .send_all(stream::iter_ok::<_, grpc::Error>(reqs))
+            .wait()
+            .unwrap();
         let resp = receiver.wait().unwrap();
         assert_eq!(74922, resp.get_aggregated_payload_size());
         println!("pass");

--- a/interop/src/lib.rs
+++ b/interop/src/lib.rs
@@ -18,6 +18,8 @@
 extern crate futures;
 extern crate grpcio as grpc;
 extern crate grpcio_proto as grpc_proto;
+#[macro_use]
+extern crate log;
 
 mod client;
 mod server;

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -8,6 +8,12 @@ publish = false
 protobuf = "1.2"
 futures = "0.1"
 grpcio = { path = ".." }
+log = "0.3"
+slog = "2.0"
+slog-async = "2.1"
+slog-stdlog = "3.0"
+slog-scope = "4.0"
+slog-term = "2.2"
 
 [build-dependencies]
 protobuf = "1.2"

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -14,7 +14,14 @@
 
 extern crate futures;
 extern crate grpcio;
+extern crate log;
 extern crate protobuf;
+#[macro_use(slog_o, slog_kv)]
+extern crate slog;
+extern crate slog_async;
+extern crate slog_stdlog;
+extern crate slog_scope;
+extern crate slog_term;
 
 pub mod testing {
     include!(concat!(env!("OUT_DIR"), "/testing/mod.rs"));

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -14,7 +14,6 @@
 
 extern crate futures;
 extern crate grpcio;
-extern crate log;
 extern crate protobuf;
 #[macro_use(slog_o, slog_kv)]
 extern crate slog;

--- a/proto/src/util.rs
+++ b/proto/src/util.rs
@@ -14,6 +14,11 @@
 
 use grpcio::{ChannelCredentials, ChannelCredentialsBuilder, ServerCredentials,
              ServerCredentialsBuilder};
+use slog_async;
+use slog::{Drain, Logger};
+use slog_scope::{self, GlobalLoggerGuard};
+use slog_stdlog;
+use slog_term::{FullFormat, TermDecorator};
 
 use testing::messages::{Payload, ResponseParameters};
 
@@ -41,4 +46,15 @@ pub fn create_test_server_credentials() -> ServerCredentials {
 pub fn create_test_channel_credentials() -> ChannelCredentials {
     let ca = include_str!("../data/ca.pem");
     ChannelCredentialsBuilder::new().root_cert(ca).build()
+}
+
+pub fn init_log() -> GlobalLoggerGuard {
+    let decorator = TermDecorator::new().build();
+    let drain = FullFormat::new(decorator).build().fuse();
+    let drain = slog_async::Async::new(drain).build().fuse();
+    let logger = Logger::root(drain, slog_o!());
+
+    let guard = slog_scope::set_global_logger(logger);
+    slog_stdlog::init().unwrap();
+    guard
 }

--- a/src/async/executor.rs
+++ b/src/async/executor.rs
@@ -23,7 +23,7 @@ use cq::CompletionQueue;
 use super::lock::SpinLock;
 use super::CallTag;
 
-type BoxFuture<T, E> = Box<Future<Item=T, Error=E> + Send>;
+type BoxFuture<T, E> = Box<Future<Item = T, Error = E> + Send>;
 
 struct Alarm {
     alarm: *mut GrpcAlarm,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,6 +21,8 @@
 extern crate futures;
 extern crate grpcio_sys as grpc_sys;
 extern crate libc;
+#[macro_use]
+extern crate log;
 #[cfg(feature = "protobuf-codec")]
 extern crate protobuf;
 
@@ -33,6 +35,7 @@ mod client;
 mod credentials;
 mod env;
 mod error;
+mod log_util;
 mod server;
 
 pub use call::{Method, MethodType, RpcStatus, RpcStatusCode, WriteFlags};
@@ -51,4 +54,5 @@ pub use credentials::{ChannelCredentials, ChannelCredentialsBuilder, ServerCrede
                       ServerCredentialsBuilder};
 pub use env::{EnvBuilder, Environment};
 pub use error::{Error, Result};
+pub use log_util::redirect_log;
 pub use server::{Server, ServerBuilder, Service, ServiceBuilder, ShutdownFuture};

--- a/src/log_util.rs
+++ b/src/log_util.rs
@@ -1,0 +1,68 @@
+// Copyright 2017 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+use std::ffi::CStr;
+
+use grpc_sys::{self, GprLogFuncArgs, GprLogSeverity};
+use log::{self, LogLevel, LogLevelFilter, LogLocation};
+
+#[inline]
+fn severity_to_log_level(severity: GprLogSeverity) -> LogLevel {
+    match severity {
+        GprLogSeverity::Debug => LogLevel::Debug,
+        GprLogSeverity::Info => LogLevel::Info,
+        GprLogSeverity::Error => LogLevel::Error,
+    }
+}
+
+extern "C" fn delegate(c_args: *mut GprLogFuncArgs) {
+    let args = unsafe { &*c_args };
+    let level = severity_to_log_level(args.severity);
+    if !log_enabled!(level) {
+        return;
+    }
+
+    // can't panic.
+    let file_str = unsafe { CStr::from_ptr(args.file).to_str().unwrap() };
+    let line = args.line as u32;
+
+    // use hidden API for now, will
+    // TODO: use public API once available.
+    let location = LogLocation {
+        __module_path: module_path!(),
+        __file: file_str,
+        __line: line,
+    };
+    let msg = unsafe { CStr::from_ptr(args.message).to_string_lossy() };
+    log::__log(level, module_path!(), &location, format_args!("{}", msg));
+}
+
+/// Redirect grpc log to rust's log implementation.
+pub fn redirect_log() {
+    let level = match log::max_log_level() {
+        LogLevelFilter::Off => unsafe {
+            // disable log.
+            grpc_sys::gpr_set_log_function(None);
+            return;
+        },
+        LogLevelFilter::Error | LogLevelFilter::Warn => GprLogSeverity::Error,
+        LogLevelFilter::Info => GprLogSeverity::Info,
+        LogLevelFilter::Debug | LogLevelFilter::Trace => GprLogSeverity::Debug,
+    };
+
+    unsafe {
+        grpc_sys::gpr_set_log_verbosity(level);
+        grpc_sys::gpr_set_log_function(Some(delegate));
+    }
+}


### PR DESCRIPTION
When we want to debug grpc, its log will output to stderr which is not useful for deployment. So this pr provides a function that can redirect grpc log to the standard rust log.