### PR TITLE
*: expose StreamingCallSink into documents.

### DIFF
--- a/src/async/executor.rs
+++ b/src/async/executor.rs
@@ -23,7 +23,7 @@ use cq::CompletionQueue;
 use super::lock::SpinLock;
 use super::CallTag;
 
-type BoxFuture<T, E> = Box<Future<Item=T, Error=E> + Send>;
+type BoxFuture<T, E> = Box<Future<Item = T, Error = E> + Send>;
 
 struct Alarm {
     alarm: *mut GrpcAlarm,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@ mod server;
 pub use call::{Method, MethodType, RpcStatus, RpcStatusCode, WriteFlags};
 pub use call::client::{CallOption, ClientCStreamReceiver, ClientCStreamSender,
                        ClientDuplexReceiver, ClientDuplexSender, ClientSStreamReceiver,
-                       ClientUnaryReceiver};
+                       ClientUnaryReceiver, StreamingCallSink};
 pub use call::server::{ClientStreamingSink, ClientStreamingSinkResult, Deadline, DuplexSink,
                        DuplexSinkFailure, RequestStream, RpcContext, ServerStreamingSink,
                        ServerStreamingSinkFailure, UnarySink, UnarySinkResult};


### PR DESCRIPTION
Previously we can't see `StreamingCallSink` in document. This PR fix this.