### PR TITLE
use environment variable to select link target

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ script:
   - export RUSTFLAGS=-Dwarnings
   - cargo build
   - cargo test --all
-  - cargo test --all --features link-sys
+  - GRPCIO_SYS_USE_PKG_CONFIG cargo test --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,4 +35,4 @@ script:
   - export RUSTFLAGS=-Dwarnings
   - cargo build
   - cargo test --all
-  - GRPCIO_SYS_USE_PKG_CONFIG cargo test --all
+  - GRPCIO_SYS_USE_PKG_CONFIG=1 cargo test --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,6 @@ before_cache:
   - find $TRAVIS_BUILD_DIR/target/debug -maxdepth 1 -type f -delete
 os:
   - linux
-  - osx
 rust:
   - stable
   - beta
@@ -18,6 +17,9 @@ rust:
 matrix:
   allow_failures:
     - rust: nightly
+  include:
+  - os: osx
+    rust: stable
 before_script:
   - export PATH="$PATH:$HOME/.cache/bin:$HOME/.cargo/bin"
   - GRPC_HEADER="$HOME/.cache/include/grpc/grpc.h"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,6 @@ members = ["proto", "benchmark", "compiler", "interop"]
 [features]
 default = ["protobuf-codec"]
 protobuf-codec = ["protobuf"]
-link-sys = ["grpcio-sys/link-sys"]
 
 [[example]]
 name = "route_guide_client"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -22,5 +22,6 @@ install:
 build: false
 
 test_script:
+  - SET RUSTFLAGS=-Dwarnings
   - cargo build
   - cargo test --all

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -18,7 +18,7 @@ extern crate futures;
 extern crate grpcio as grpc;
 extern crate grpcio_proto as grpc_proto;
 extern crate grpcio_sys as grpc_sys;
-#[cfg(not(target_os = "macos"))]
+#[cfg(target_os = "linux")]
 extern crate libc;
 #[macro_use]
 extern crate log;

--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -38,10 +38,6 @@ exclude = [
 libc = "0.2"
 
 [build-dependencies]
-gcc = "0.3.53"
+cc = "1.0"
 cmake = "0.1"
 pkg-config = "0.3"
-
-[features]
-default = []
-link-sys = []

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -55,12 +55,12 @@ fn prepare_grpc() {
     }
 }
 
-pub fn is_directory_empty<P: AsRef<Path>>(p: P) -> Result<bool, io::Error> {
+fn is_directory_empty<P: AsRef<Path>>(p: P) -> Result<bool, io::Error> {
     let mut entries = try!(fs::read_dir(p));
     Ok(entries.next().is_none())
 }
 
-pub fn build_grpc(cc: &mut Build) {
+fn build_grpc(cc: &mut Build) {
     prepare_grpc();
 
     let dst = Config::new("grpc").build_target("grpc").build();

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -153,7 +153,7 @@ fn main() {
 
     if cfg!(target_os = "windows") {
         // At lease win7
-        cc.define("_WIN32_WINNT", Some("0x0700")).warnings(false);
+        cc.define("_WIN32_WINNT", Some("0x0700"));
     }
 
     cc.warnings_into_errors(true).compile("libgrpc_wrap.a");


### PR DESCRIPTION
As discussed in pingcap/tikv#198 and considering the solutions other native crates have chosen (sfackler/rust-openssl#653), let's use environment variable to check link target.