### PR TITLE
Client methods take a reference to a request

### DIFF
--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -230,7 +230,7 @@ impl<B: Backoff + Send + 'static> RequestExecutor<B> {
                 break;
             }
             let latency_timer = Instant::now();
-            self.client.unary_call(self.req.clone()).unwrap();
+            self.client.unary_call(&self.req).unwrap();
             let elapsed = latency_timer.elapsed();
             self.ctx.observe_latency(elapsed);
             self.ctx.backoff();
@@ -241,7 +241,7 @@ impl<B: Backoff + Send + 'static> RequestExecutor<B> {
         let client = self.client.clone();
         let f = future::loop_fn(self, move |mut executor| {
             let latency_timer = Instant::now();
-            let handler = executor.client.unary_call_async(executor.req.clone());
+            let handler = executor.client.unary_call_async(&executor.req);
 
             handler.map_err(Error::from).and_then(move |_| {
                 let elapsed = latency_timer.elapsed();

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -147,7 +147,7 @@ impl<'a> MethodGen<'a> {
     // Method signatures
     fn unary(&self, method_name: &str) -> String {
         format!(
-            "{}(&self, req: {}) -> {}<{}>",
+            "{}(&self, req: &{}) -> {}<{}>",
             method_name,
             self.input(),
             fq_grpc("Result"),
@@ -157,7 +157,7 @@ impl<'a> MethodGen<'a> {
 
     fn unary_opt(&self, method_name: &str) -> String {
         format!(
-            "{}_opt(&self, req: {}, opt: {}) -> {}<{}>",
+            "{}_opt(&self, req: &{}, opt: {}) -> {}<{}>",
             method_name,
             self.input(),
             fq_grpc("CallOption"),
@@ -168,7 +168,7 @@ impl<'a> MethodGen<'a> {
 
     fn unary_async(&self, method_name: &str) -> String {
         format!(
-            "{}_async(&self, req: {}) -> {}<{}>",
+            "{}_async(&self, req: &{}) -> {}<{}>",
             method_name,
             self.input(),
             fq_grpc("ClientUnaryReceiver"),
@@ -178,7 +178,7 @@ impl<'a> MethodGen<'a> {
 
     fn unary_async_opt(&self, method_name: &str) -> String {
         format!(
-            "{}_async_opt(&self, req: {}, opt: {}) -> {}<{}>",
+            "{}_async_opt(&self, req: &{}, opt: {}) -> {}<{}>",
             method_name,
             self.input(),
             fq_grpc("CallOption"),
@@ -212,7 +212,7 @@ impl<'a> MethodGen<'a> {
 
     fn server_streaming(&self, method_name: &str) -> String {
         format!(
-            "{}(&self, req: {}) -> {}<{}>",
+            "{}(&self, req: &{}) -> {}<{}>",
             method_name,
             self.input(),
             fq_grpc("ClientSStreamReceiver"),
@@ -222,7 +222,7 @@ impl<'a> MethodGen<'a> {
 
     fn server_streaming_opt(&self, method_name: &str) -> String {
         format!(
-            "{}_opt(&self, req: {}, opt: {}) -> {}<{}>",
+            "{}_opt(&self, req: &{}, opt: {}) -> {}<{}>",
             method_name,
             self.input(),
             fq_grpc("CallOption"),

--- a/examples/hello_world/client.rs
+++ b/examples/hello_world/client.rs
@@ -32,6 +32,6 @@ fn main() {
 
     let mut req = HelloRequest::new();
     req.set_name("world".to_owned());
-    let reply = client.say_hello(req).expect("rpc");
+    let reply = client.say_hello(&req).expect("rpc");
     info!("Greeter received: {}", reply.get_message());
 }

--- a/examples/route_guide/client.rs
+++ b/examples/route_guide/client.rs
@@ -56,7 +56,7 @@ fn new_note(lat: i32, lon: i32, msg: &str) -> RouteNote {
 }
 
 fn get_feature(client: &RouteGuideClient, point: &Point) {
-    let get_feature = client.get_feature_async(point.clone());
+    let get_feature = client.get_feature_async(point);
     match get_feature.wait() {
         Err(e) => panic!("RPC failed: {:?}", e),
         Ok(f) => {
@@ -80,7 +80,7 @@ fn get_feature(client: &RouteGuideClient, point: &Point) {
 fn list_features(client: &RouteGuideClient) {
     let rect = new_rect(400_000_000, -750_000_000, 420_000_000, -730_000_000);
     info!("Looking for features between 40, -75 and 42, -73");
-    let mut list_features = client.list_features(rect);
+    let mut list_features = client.list_features(&rect);
     loop {
         let f = list_features.into_future();
         match f.wait() {

--- a/interop/src/client.rs
+++ b/interop/src/client.rs
@@ -40,7 +40,7 @@ impl Client {
     pub fn empty_unary(&self) {
         print!("testing empty unary ... ");
         let req = Empty::new();
-        let resp = self.client.empty_call(req.clone()).unwrap();
+        let resp = self.client.empty_call(&req).unwrap();
         assert_eq!(req, resp);
         println!("pass");
     }
@@ -50,7 +50,7 @@ impl Client {
         let mut req = SimpleRequest::new();
         req.set_response_size(314159);
         req.set_payload(util::new_payload(271828));
-        let resp = self.client.unary_call(req).unwrap();
+        let resp = self.client.unary_call(&req).unwrap();
         assert_eq!(314159, resp.get_payload().get_body().len());
         println!("pass");
     }
@@ -80,7 +80,7 @@ impl Client {
             req.mut_response_parameters()
                 .push(util::new_parameters(*size));
         }
-        let resp = self.client.streaming_output_call(req);
+        let resp = self.client.streaming_output_call(&req);
         let resp_sizes = resp.map(|r| r.get_payload().get_body().len() as i32)
             .collect()
             .wait()
@@ -189,7 +189,7 @@ impl Client {
         status.set_message(error_msg.to_owned());
         let mut req = SimpleRequest::new();
         req.set_response_status(status.clone());
-        match self.client.unary_call(req).unwrap_err() {
+        match self.client.unary_call(&req).unwrap_err() {
             grpc::Error::RpcFailure(s) => {
                 assert_eq!(s.status, RpcStatusCode::Unknown);
                 assert_eq!(s.details.as_ref().unwrap(), error_msg);
@@ -213,7 +213,7 @@ impl Client {
 
     pub fn unimplemented_method(&self) {
         print!("testing unimplemented_method ... ");
-        match self.client.unimplemented_call(Empty::new()).unwrap_err() {
+        match self.client.unimplemented_call(&Empty::new()).unwrap_err() {
             grpc::Error::RpcFailure(s) => assert_eq!(s.status, RpcStatusCode::Unimplemented),
             e => panic!("expected rpc failure: {:?}", e),
         }
@@ -223,7 +223,7 @@ impl Client {
     pub fn unimplemented_service(&self) {
         print!("testing unimplemented_service ... ");
         let client = UnimplementedServiceClient::new(self.channel.clone());
-        match client.unimplemented_call(Empty::new()).unwrap_err() {
+        match client.unimplemented_call(&Empty::new()).unwrap_err() {
             grpc::Error::RpcFailure(s) => assert_eq!(s.status, RpcStatusCode::Unimplemented),
             e => panic!("expected rpc failure: {:?}", e),
         }

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -95,12 +95,12 @@ impl Call {
     pub fn unary_async<P, Q>(
         channel: &Channel,
         method: &Method<P, Q>,
-        req: P,
+        req: &P,
         opt: CallOption,
     ) -> ClientUnaryReceiver<Q> {
         let call = channel.create_call(method, &opt);
         let mut payload = vec![];
-        (method.req_ser())(&req, &mut payload);
+        (method.req_ser())(req, &mut payload);
         let cq_f = check_run(BatchType::CheckRead, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_unary(
                 call.call,
@@ -144,12 +144,12 @@ impl Call {
     pub fn server_streaming<P, Q>(
         channel: &Channel,
         method: &Method<P, Q>,
-        req: P,
+        req: &P,
         opt: CallOption,
     ) -> ClientSStreamReceiver<Q> {
         let call = channel.create_call(method, &opt);
         let mut payload = vec![];
-        (method.req_ser())(&req, &mut payload);
+        (method.req_ser())(req, &mut payload);
         let cq_f = check_run(BatchType::Finish, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_server_streaming(
                 call.call,

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,7 +33,7 @@ impl Client {
     }
 
     /// Create a synchronized unary rpc call.
-    pub fn unary_call<P, Q>(&self, method: &Method<P, Q>, req: P, opt: CallOption) -> Result<Q> {
+    pub fn unary_call<P, Q>(&self, method: &Method<P, Q>, req: &P, opt: CallOption) -> Result<Q> {
         let f = self.unary_call_async(method, req, opt);
         f.wait()
     }
@@ -42,7 +42,7 @@ impl Client {
     pub fn unary_call_async<P, Q>(
         &self,
         method: &Method<P, Q>,
-        req: P,
+        req: &P,
         opt: CallOption,
     ) -> ClientUnaryReceiver<Q> {
         Call::unary_async(&self.channel, method, req, opt)
@@ -65,7 +65,7 @@ impl Client {
     pub fn server_streaming<P, Q>(
         &self,
         method: &Method<P, Q>,
-        req: P,
+        req: &P,
         opt: CallOption,
     ) -> ClientSStreamReceiver<Q> {
         Call::server_streaming(&self.channel, method, req, opt)


### PR DESCRIPTION
There's no reason to require ownership here. We only ever actually use a
reference to the request anyway.

I have a use case where I call a method multiple times in a loop, and
needing to clone the request each time is unnecessarily wasteful.

Bump version to 0.2.0 because this is an incompatible change.