### PR TITLE
grpcio-sys: fix call convention

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,9 @@ cache:
   - C:\ProgramData\chocolatey\lib -> appveyor.yml
 
 environment:
-  TARGET: x86_64-pc-windows-msvc
+  matrix:
+  - TARGET: x86_64-pc-windows-msvc
+  - TARGET: i686-pc-windows-msvc
 
 install:
   - ps: Start-FileDownload "https://static.rust-lang.org/dist/rust-nightly-${env:TARGET}.exe"

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,5 +25,5 @@ build: false
 
 test_script:
   - SET RUSTFLAGS=-Dwarnings
-  - cargo build
-  - cargo test --all
+  - cargo build --target %TARGET%
+  - cargo test --all --target %TARGET%

--- a/grpc-sys/grpc_wrap.c
+++ b/grpc-sys/grpc_wrap.c
@@ -62,7 +62,7 @@
 
 #ifdef GPR_WINDOWS
 #define GPR_EXPORT __declspec(dllexport)
-#define GPR_CALLTYPE __stdcall
+#define GPR_CALLTYPE __cdecl
 #endif
 
 #ifndef GPR_EXPORT


### PR DESCRIPTION
In Rust gRPC FFI declaration, we assumes the call convention is `__cdecl`. However, we set the call convention to `__stdcall` in the actual ABI on Windows, just follow the same way as C# does accidentally. On 64bit target, there is only [one calling convention][1], so `__stdcall` is [accepted and ignored][2] by the msvc compiler, our tests can pass on Windows. But for 32bit target, `__stdcall`  is actually taken into consideration, so our tests can't pass any more.

This pr sets the call convention on Windows to `__cdecl` explicitly.

Close #95.

[1]: https://msdn.microsoft.com/en-us/library/ms235286.aspx
[2]: https://msdn.microsoft.com/en-us/library/zxk0tw93.aspx