### PR TITLE
allow disabling secure feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,7 @@ members = ["proto", "benchmark", "compiler", "interop"]
 [features]
 default = ["protobuf-codec"]
 protobuf-codec = ["protobuf"]
+secure = ["grpcio-sys/secure"]
 
 [[example]]
 name = "route_guide_client"

--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Prerequisites
 -------------
 
 - CMake >= 3.8.0
-- Go (to build ssl support) >=1.7
 - Rust >= 1.19.0
+- If you want to enable secure feature, Go (>=1.7) is required.
 
 For Linux and MacOS, you also need to install gcc (or clang) too.
 

--- a/compiler/src/util.rs
+++ b/compiler/src/util.rs
@@ -13,7 +13,6 @@
 
 
 use std::str;
-use std::ascii::AsciiExt;
 
 // A struct that divide a name into serveral parts that meets rust's guidelines.
 struct NameSpliter<'a> {
@@ -23,9 +22,6 @@ struct NameSpliter<'a> {
 
 impl<'a> NameSpliter<'a> {
     fn new(s: &str) -> NameSpliter {
-        // TODO: remove following assert once split pattern is stable.
-        assert!(s.is_ascii());
-
         NameSpliter {
             name: s.as_bytes(),
             pos: 0,

--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -37,6 +37,10 @@ exclude = [
 [dependencies]
 libc = "0.2"
 
+[features]
+default = []
+secure = []
+
 [build-dependencies]
 cc = "1.0"
 cmake = "0.1"

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -26,23 +26,25 @@ use pkg_config::Config as PkgConfig;
 
 const GRPC_VERSION: &'static str = "1.6.1";
 
-fn link_grpc(cc: &mut Build) {
-    if let Ok(lib) = PkgConfig::new().atleast_version(GRPC_VERSION).probe("grpc") {
-        for inc_path in lib.include_paths {
+fn link_grpc(cc: &mut Build, library: &str) {
+    match PkgConfig::new().atleast_version(GRPC_VERSION).probe(library) {
+        Ok(lib) => for inc_path in lib.include_paths {
             cc.include(inc_path);
         }
-    } else {
-        panic!("can't find a grpc library via pkg-config");
+        Err(e) => panic!("can't find library {} via pkg-config: {:?}", library, e),
     }
 }
 
 fn prepare_grpc() {
-    let modules = vec![
+    let mut modules = vec![
         "grpc",
         "grpc/third_party/zlib",
-        "grpc/third_party/boringssl",
         "grpc/third_party/cares/cares",
     ];
+
+    if cfg!(feature = "secure") {
+        modules.push("grpc/third_party/boringssl");
+    }
 
     for module in modules {
         if is_directory_empty(module).unwrap_or(true) {
@@ -60,10 +62,10 @@ fn is_directory_empty<P: AsRef<Path>>(p: P) -> Result<bool, io::Error> {
     Ok(entries.next().is_none())
 }
 
-fn build_grpc(cc: &mut Build) {
+fn build_grpc(cc: &mut Build, library: &str) {
     prepare_grpc();
 
-    let dst = Config::new("grpc").build_target("grpc").build();
+    let dst = Config::new("grpc").build_target(library).build();
 
     let mut zlib = "z";
     let build_dir = format!("{}/build", dst.display());
@@ -122,9 +124,12 @@ fn build_grpc(cc: &mut Build) {
     println!("cargo:rustc-link-lib=static={}", zlib);
     println!("cargo:rustc-link-lib=static=cares");
     println!("cargo:rustc-link-lib=static=gpr");
-    println!("cargo:rustc-link-lib=static=grpc");
-    println!("cargo:rustc-link-lib=static=ssl");
-    println!("cargo:rustc-link-lib=static=crypto");
+    println!("cargo:rustc-link-lib=static={}", library);
+
+    if cfg!(feature = "secure") {
+        println!("cargo:rustc-link-lib=static=ssl");
+        println!("cargo:rustc-link-lib=static=crypto");
+    }
 
     cc.include("grpc/include");
 }
@@ -143,10 +148,16 @@ fn get_env(name: &str) -> Option<String> {
 fn main() {
     let mut cc = Build::new();
 
-    if get_env("GRPCIO_SYS_USE_PKG_CONFIG").map_or(false, |s| s == "1") {
-        link_grpc(&mut cc);
+    let library = if cfg!(feature = "secure") {
+        "grpc"
     } else {
-        build_grpc(&mut cc);
+        "grpc_unsecure"
+    };
+
+    if get_env("GRPCIO_SYS_USE_PKG_CONFIG").map_or(false, |s| s == "1") {
+        link_grpc(&mut cc, library);
+    } else {
+        build_grpc(&mut cc, library);
     }
 
     cc.file("grpc_wrap.c");

--- a/interop/tests/tests.rs
+++ b/interop/tests/tests.rs
@@ -27,9 +27,9 @@ macro_rules! mk_test {
 
             builder = if $use_tls {
                 let creds = util::create_test_server_credentials();
-                builder.bind_secure("localhost", 0, creds)
+                builder.bind_secure("127.0.0.1", 0, creds)
             } else {
-                builder.bind("localhost", 0)
+                builder.bind("127.0.0.1", 0)
             };
 
             let mut server = builder.build().unwrap();

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 protobuf = "1.2"
 futures = "0.1"
-grpcio = { path = "..", version = "0.1.2" }
+grpcio = { path = "..", version = "0.1.2", features = ["secure"] }
 
 [build-dependencies]
 protobuf = "1.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,6 +32,7 @@ mod channel;
 mod codec;
 mod cq;
 mod client;
+#[cfg(feature = "secure")]
 mod credentials;
 mod env;
 mod error;
@@ -50,6 +51,7 @@ pub use client::Client;
 pub use codec::Marshaller;
 #[cfg(feature = "protobuf-codec")]
 pub use codec::pb_codec::{de as pb_de, ser as pb_ser};
+#[cfg(feature = "secure")]
 pub use credentials::{ChannelCredentials, ChannelCredentialsBuilder, ServerCredentials,
                       ServerCredentialsBuilder};
 pub use env::{EnvBuilder, Environment};


### PR DESCRIPTION
So if secure feature is not used, we can drop the dependency of go.

Close #109