### PR TITLE
Explicitly link against libc++ on Darwin

### DIFF
--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -43,5 +43,5 @@ secure = []
 
 [build-dependencies]
 cc = "1.0"
-cmake = "0.1"
+cmake = "0.1.27"
 pkg-config = "0.3"

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -30,7 +30,7 @@ fn link_grpc(cc: &mut Build, library: &str) {
     match PkgConfig::new().atleast_version(GRPC_VERSION).probe(library) {
         Ok(lib) => for inc_path in lib.include_paths {
             cc.include(inc_path);
-        }
+        },
         Err(e) => panic!("can't find library {} via pkg-config: {:?}", library, e),
     }
 }
@@ -65,7 +65,17 @@ fn is_directory_empty<P: AsRef<Path>>(p: P) -> Result<bool, io::Error> {
 fn build_grpc(cc: &mut Build, library: &str) {
     prepare_grpc();
 
-    let dst = Config::new("grpc").build_target(library).build();
+    let dst = {
+        let mut config = Config::new("grpc");
+        let target = match env::var("TARGET") {
+            Ok(v) => v,
+            Err(..) => panic!("Could not find TARGET environment variable"),
+        };
+        if target.contains("-darwin") {
+            config.cxxflag("-stdlib=libc++");
+        }
+        config.build_target(library).uses_cxx11().build()
+    };
 
     let mut zlib = "z";
     let build_dir = format!("{}/build", dst.display());

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -67,11 +67,7 @@ fn build_grpc(cc: &mut Build, library: &str) {
 
     let dst = {
         let mut config = Config::new("grpc");
-        let target = match env::var("TARGET") {
-            Ok(v) => v,
-            Err(..) => panic!("Could not find TARGET environment variable"),
-        };
-        if target.contains("-darwin") {
+        if cfg!(target_os = "macos") {
             config.cxxflag("-stdlib=libc++");
         }
         config.build_target(library).uses_cxx11().build()


### PR DESCRIPTION
I have had complaints from a couple of developers that their builds are
failing on Darwin because clang is defaulting to linking against
libstdc++ on https://github.com/pantsbuild/pants/issues/4975.