### PR TITLE
add reset-submodule script

### DIFF
--- a/scripts/reset-submodule
+++ b/scripts/reset-submodule
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+git submodule update --init grpc-sys/grpc
+cd grpc-sys/grpc
+git submodule update --init third_party/boringssl
+git submodule update --init third_party/cares/cares
+git submodule update --init third_party/zlib
+cd third_party/zlib
+git clean -f
+git reset --hard


### PR DESCRIPTION
So when switching branch/tag, we can cleanup workspace conveniently.