### PR TITLE
benchmark: fix shutdown failure

### DIFF
--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -143,17 +143,6 @@ impl<B: Backoff> ExecutorContext<B> {
     }
 }
 
-// Since impl trait is not stable yet, implement this as a function is impossible without box.
-macro_rules! spawn {
-    ($client:ident, $keep_running:expr, $tag: expr, $f:expr) => {
-        $client.spawn($f.map(|_| ()).map_err(move |e| {
-            if $keep_running.load(Ordering::SeqCst) {
-                error!("failed to execute {}: {:?}", $tag, e);
-            }
-        }))
-    };
-}
-
 /// An executor that executes generic requests.
 struct GenericExecutor<B> {
     ctx: ExecutorContext<B>,

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -25,6 +25,17 @@ extern crate log;
 extern crate rand;
 extern crate tokio_timer;
 
+// Since impl trait is not stable yet, implement this as a function is impossible without box.
+macro_rules! spawn {
+    ($exec:ident, $keep_running:expr, $tag: expr, $f:expr) => {
+        $exec.spawn($f.map(|_| ()).map_err(move |e| {
+            if $keep_running.load(Ordering::SeqCst) {
+                error!("failed to execute {}: {:?}", $tag, e);
+            }
+        }))
+    };
+}
+
 mod bench;
 mod client;
 mod error;

--- a/benchmark/src/worker.rs
+++ b/benchmark/src/worker.rs
@@ -104,9 +104,10 @@ impl WorkerService for Worker {
                         })
                     })
                     .map_err(Error::from)
-                    .and_then(|(sink, mut client)| client.shutdown().map(|_| sink))
-                    .and_then(|mut sink| {
-                        future::poll_fn(move || sink.close().map_err(From::from))
+                    .and_then(|(mut sink, mut client)| {
+                        client
+                            .shutdown()
+                            .join(future::poll_fn(move || sink.close().map_err(From::from)))
                     })
             })
             .map_err(|e| error!("run client failed: {:?}", e))


### PR DESCRIPTION
This pr fixes an hang-up-forever issue during benchmark.

To add all the stats 1.7.2 introduces, we need a public API and compatible rust-protobuf. See grpc/grpc#13705 and stepancheg/rust-protobuf#260.

/cc #107 #118 

After this pr is merged, I think we are ready to release 0.2.0.