### PR TITLE
*: support zero copy

### DIFF
--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -19,9 +19,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use grpc_proto::testing::services_grpc::BenchmarkService;
 use grpc_proto::testing::messages::{SimpleRequest, SimpleResponse};
 use grpc_proto::util;
-use grpc::{self, ClientStreamingSink, DuplexSink, Method, MethodType, RequestStream, RpcContext,
-           RpcStatus, RpcStatusCode, ServerStreamingSink, ServiceBuilder, UnarySink, WriteFlags,
-           MessageReader};
+use grpc::{self, ClientStreamingSink, DuplexSink, MessageReader, Method, MethodType,
+           RequestStream, RpcContext, RpcStatus, RpcStatusCode, ServerStreamingSink,
+           ServiceBuilder, UnarySink, WriteFlags};
 use futures::{Future, Sink, Stream};
 
 fn gen_resp(req: SimpleRequest) -> SimpleResponse {

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -12,11 +12,14 @@
 // limitations under the License.
 
 
+use std::io::Read;
+
 use grpc_proto::testing::services_grpc::BenchmarkService;
 use grpc_proto::testing::messages::{SimpleRequest, SimpleResponse};
 use grpc_proto::util;
 use grpc::{self, ClientStreamingSink, DuplexSink, Method, MethodType, RequestStream, RpcContext,
-           RpcStatus, RpcStatusCode, ServerStreamingSink, ServiceBuilder, UnarySink, WriteFlags};
+           RpcStatus, RpcStatusCode, ServerStreamingSink, ServiceBuilder, UnarySink, WriteFlags,
+           MessageReader};
 use futures::{Future, Sink, Stream};
 
 fn gen_resp(req: SimpleRequest) -> SimpleResponse {
@@ -115,7 +118,9 @@ pub fn bin_ser(t: &Vec<u8>, buf: &mut Vec<u8>) {
 }
 
 #[inline]
-pub fn bin_de(buf: Vec<u8>) -> grpc::Result<Vec<u8>> {
+pub fn bin_de(mut reader: MessageReader) -> grpc::Result<Vec<u8>> {
+    let mut buf = vec![];
+    reader.read_to_end(&mut buf).unwrap();
     Ok(buf)
 }
 

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -115,8 +115,8 @@ pub fn bin_ser(t: &Vec<u8>, buf: &mut Vec<u8>) {
 }
 
 #[inline]
-pub fn bin_de(buf: &[u8]) -> grpc::Result<Vec<u8>> {
-    Ok(buf.to_vec())
+pub fn bin_de(buf: Vec<u8>) -> grpc::Result<Vec<u8>> {
+    Ok(buf)
 }
 
 pub const METHOD_BENCHMARK_SERVICE_GENERIC_CALL: Method<Vec<u8>, Vec<u8>> = Method {

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -198,7 +198,18 @@ pub enum GrpcBatchContext {}
 pub enum GrpcServer {}
 pub enum GrpcRequestCallContext {}
 pub enum GrpcAlarm {}
-pub enum GrpcWrapByteBufferReader {}
+
+#[repr(C)]
+pub union GrpcByteBufferReaderCurrent {
+    pub index: c_uint,
+}
+
+#[repr(C)]
+pub struct GrpcByteBufferReader {
+    pub buffer_in: *mut GrpcByteBuffer,
+    pub buffer_out: *mut GrpcByteBuffer,
+    pub current: GrpcByteBufferReaderCurrent,
+}
 
 pub const GRPC_MAX_COMPLETION_QUEUE_PLUCKERS: usize = 6;
 
@@ -277,15 +288,25 @@ extern "C" {
     ) -> *mut GrpcChannel;
     pub fn grpc_channel_destroy(channel: *mut GrpcChannel);
 
-    pub fn grpcwrap_byte_buffer_reader_next(reader: *mut GrpcWrapByteBufferReader, len: *mut size_t) -> *const c_char;
-    pub fn grpcwrap_byte_buffer_reader_destroy(reader: *mut GrpcWrapByteBufferReader);
+    pub fn grpc_byte_buffer_reader_init(
+        reader: *mut GrpcByteBufferReader,
+        buf: *mut GrpcByteBuffer,
+    ) -> c_int;
+    pub fn grpcwrap_byte_buffer_reader_next(
+        reader: *mut GrpcByteBufferReader,
+        len: *mut size_t,
+    ) -> *const c_char;
+    pub fn grpc_byte_buffer_reader_destroy(reader: *mut GrpcByteBufferReader);
+    pub fn grpc_byte_buffer_destroy(buf: *mut GrpcByteBuffer);
 
     pub fn grpcwrap_batch_context_create() -> *mut GrpcBatchContext;
     pub fn grpcwrap_batch_context_destroy(ctx: *mut GrpcBatchContext);
     pub fn grpcwrap_batch_context_recv_initial_metadata(
         ctx: *mut GrpcBatchContext,
     ) -> *const GrpcMetadataArray;
-    pub fn grpcwrap_batch_context_take_recv_message(ctx: *mut GrpcBatchContext) -> *mut GrpcWrapByteBufferReader;
+    pub fn grpcwrap_batch_context_take_recv_message(
+        ctx: *mut GrpcBatchContext,
+    ) -> *mut GrpcByteBuffer;
     pub fn grpcwrap_batch_context_recv_status_on_client_status(
         ctx: *mut GrpcBatchContext,
     ) -> GrpcStatusCode;

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -324,6 +324,7 @@ extern "C" {
     pub fn grpc_channel_destroy(channel: *mut GrpcChannel);
 
     pub fn grpc_slice_unref(slice: GrpcSlice);
+    pub fn grpc_byte_buffer_length(buf: *const GrpcByteBuffer) -> size_t;
     pub fn grpcwrap_slice_raw(slice: *const GrpcSlice, len: *mut size_t) -> *const c_char;
     pub fn grpc_byte_buffer_reader_init(
         reader: *mut GrpcByteBufferReader,

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -241,8 +241,8 @@ pub union GrpcByteBufferReaderCurrent {
 
 #[repr(C)]
 pub struct GrpcByteBufferReader {
-    buffer_in: *mut GrpcByteBuffer,
-    buffer_out: *mut GrpcByteBuffer,
+    pub buffer_in: *mut GrpcByteBuffer,
+    pub buffer_out: *mut GrpcByteBuffer,
     current: GrpcByteBufferReaderCurrent,
 }
 

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -565,6 +565,8 @@ mod secure_component {
     }
 }
 
+/// Make sure the complicated struct written in rust is the same with
+/// its C one.
 pub unsafe fn sanity_check() {
     grpcwrap_sanity_check_slice(mem::size_of::<GrpcSlice>(), mem::align_of::<GrpcSlice>());
     grpcwrap_sanity_check_byte_buffer_reader(

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -198,6 +198,7 @@ pub enum GrpcBatchContext {}
 pub enum GrpcServer {}
 pub enum GrpcRequestCallContext {}
 pub enum GrpcAlarm {}
+pub enum GrpcWrapByteBufferReader {}
 
 pub const GRPC_MAX_COMPLETION_QUEUE_PLUCKERS: usize = 6;
 
@@ -276,17 +277,15 @@ extern "C" {
     ) -> *mut GrpcChannel;
     pub fn grpc_channel_destroy(channel: *mut GrpcChannel);
 
+    pub fn grpcwrap_byte_buffer_reader_next(reader: *mut GrpcWrapByteBufferReader, len: *mut size_t) -> *const c_char;
+    pub fn grpcwrap_byte_buffer_reader_destroy(reader: *mut GrpcWrapByteBufferReader);
+
     pub fn grpcwrap_batch_context_create() -> *mut GrpcBatchContext;
     pub fn grpcwrap_batch_context_destroy(ctx: *mut GrpcBatchContext);
     pub fn grpcwrap_batch_context_recv_initial_metadata(
         ctx: *mut GrpcBatchContext,
     ) -> *const GrpcMetadataArray;
-    pub fn grpcwrap_batch_context_recv_message_length(ctx: *mut GrpcBatchContext) -> size_t;
-    pub fn grpcwrap_batch_context_recv_message_to_buffer(
-        ctx: *mut GrpcBatchContext,
-        buffer: *mut c_char,
-        buffer_len: size_t,
-    );
+    pub fn grpcwrap_batch_context_take_recv_message(ctx: *mut GrpcBatchContext) -> *mut GrpcWrapByteBufferReader;
     pub fn grpcwrap_batch_context_recv_status_on_client_status(
         ctx: *mut GrpcBatchContext,
     ) -> GrpcStatusCode;

--- a/src/async/callback.rs
+++ b/src/async/callback.rs
@@ -72,7 +72,7 @@ impl UnaryRequest {
             return;
         }
 
-        let reader = self.ctx.batch_ctx().recv_message();
+        let reader = self.ctx.batch_ctx_mut().recv_message();
         self.ctx.handle(&inner, cq, reader);
         server::request_call(inner, cq);
     }

--- a/src/async/callback.rs
+++ b/src/async/callback.rs
@@ -72,8 +72,8 @@ impl UnaryRequest {
             return;
         }
 
-        let data = self.ctx.batch_ctx().recv_message();
-        self.ctx.handle(&inner, cq, data);
+        let reader = self.ctx.batch_ctx().recv_message();
+        self.ctx.handle(&inner, cq, reader);
         server::request_call(inner, cq);
     }
 }

--- a/src/async/callback.rs
+++ b/src/async/callback.rs
@@ -73,8 +73,7 @@ impl UnaryRequest {
         }
 
         let data = self.ctx.batch_ctx().recv_message();
-        self.ctx
-            .handle(&inner, cq, data.as_ref().map(|v| v.as_slice()));
+        self.ctx.handle(&inner, cq, data);
         server::request_call(inner, cq);
     }
 }

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -23,7 +23,7 @@ use std::sync::Arc;
 use futures::{Async, Future, Poll};
 use futures::task::{self, Task};
 
-use call::{BatchContext, Call};
+use call::{BatchContext, Call, MessageReader};
 use call::server::RequestContext;
 use cq::CompletionQueue;
 use error::{Error, Result};
@@ -116,9 +116,8 @@ impl<T> Future for CqFuture<T> {
     }
 }
 
-pub type BatchMessage = Option<Vec<u8>>;
 /// Future object for batch jobs.
-pub type BatchFuture = CqFuture<BatchMessage>;
+pub type BatchFuture = CqFuture<Option<MessageReader>>;
 
 /// A result holder for asynchronous execution.
 // This enum is going to be passed to FFI, so don't use trait or generic here.

--- a/src/async/promise.rs
+++ b/src/async/promise.rs
@@ -15,9 +15,9 @@
 use std::sync::Arc;
 use std::fmt::{self, Debug, Formatter};
 
-use call::{BatchContext, RpcStatusCode};
+use call::{BatchContext, RpcStatusCode, MessageReader};
 use error::Error;
-use super::{BatchMessage, Inner};
+use super::Inner;
 
 /// Batch job type.
 #[derive(PartialEq, Debug)]
@@ -34,11 +34,11 @@ pub enum BatchType {
 pub struct Batch {
     ty: BatchType,
     ctx: BatchContext,
-    inner: Arc<Inner<BatchMessage>>,
+    inner: Arc<Inner<Option<MessageReader>>>,
 }
 
 impl Batch {
-    pub fn new(ty: BatchType, inner: Arc<Inner<BatchMessage>>) -> Batch {
+    pub fn new(ty: BatchType, inner: Arc<Inner<Option<MessageReader>>>) -> Batch {
         Batch {
             ty: ty,
             ctx: BatchContext::new(),

--- a/src/async/promise.rs
+++ b/src/async/promise.rs
@@ -15,7 +15,7 @@
 use std::sync::Arc;
 use std::fmt::{self, Debug, Formatter};
 
-use call::{BatchContext, RpcStatusCode, MessageReader};
+use call::{BatchContext, MessageReader, RpcStatusCode};
 use error::Error;
 use super::Inner;
 

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -233,7 +233,7 @@ impl<T> Future for ClientUnaryReceiver<T> {
 
     fn poll(&mut self) -> Poll<T, Error> {
         let data = try_ready!(self.resp_f.poll());
-        let t = (self.resp_de)(&data.unwrap())?;
+        let t = (self.resp_de)(data.unwrap())?;
         Ok(Async::Ready(t))
     }
 }
@@ -261,7 +261,7 @@ impl<T> Future for ClientCStreamReceiver<T> {
             let mut call = self.call.lock();
             try_ready!(call.poll_finish())
         };
-        let t = (self.resp_de)(&data.unwrap())?;
+        let t = (self.resp_de)(data.unwrap())?;
         Ok(Async::Ready(t))
     }
 }
@@ -393,7 +393,7 @@ impl<H: ShareCallHolder, T> ResponseStreamImpl<H, T> {
             self.msg_f.take();
             let msg_f = self.call.call(|c| c.call.start_recv_message())?;
             self.msg_f = Some(msg_f);
-            if let Some(ref data) = bytes {
+            if let Some(data) = bytes {
                 let msg = (self.resp_de)(data)?;
                 return Ok(Async::Ready(Some(msg)));
             }

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -19,8 +19,8 @@ use std::time::Duration;
 use futures::{Async, AsyncSink, Future, Poll, Sink, StartSend, Stream};
 use grpc_sys;
 
-use async::{BatchFuture, BatchMessage, BatchType, CqFuture, SpinLock};
-use call::{check_run, Call, Method};
+use async::{BatchFuture, BatchType, CqFuture, SpinLock};
+use call::{check_run, Call, Method, MessageReader};
 use channel::Channel;
 use codec::{DeserializeFn, SerializeFn};
 use error::{Error, Result};
@@ -204,14 +204,14 @@ impl Call {
 /// The future is resolved once response is received.
 pub struct ClientUnaryReceiver<T> {
     call: Call,
-    resp_f: CqFuture<BatchMessage>,
+    resp_f: CqFuture<Option<MessageReader>>,
     resp_de: DeserializeFn<T>,
 }
 
 impl<T> ClientUnaryReceiver<T> {
     fn new(
         call: Call,
-        resp_f: CqFuture<BatchMessage>,
+        resp_f: CqFuture<Option<MessageReader>>,
         de: DeserializeFn<T>,
     ) -> ClientUnaryReceiver<T> {
         ClientUnaryReceiver {
@@ -409,7 +409,7 @@ pub struct ClientSStreamReceiver<Q> {
 impl<Q> ClientSStreamReceiver<Q> {
     fn new(
         call: Call,
-        finish_f: CqFuture<BatchMessage>,
+        finish_f: CqFuture<Option<MessageReader>>,
         de: DeserializeFn<Q>,
     ) -> ClientSStreamReceiver<Q> {
         let share_call = ShareCall::new(call, finish_f);

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -20,7 +20,7 @@ use futures::{Async, AsyncSink, Future, Poll, Sink, StartSend, Stream};
 use grpc_sys;
 
 use async::{BatchFuture, BatchType, CqFuture, SpinLock};
-use call::{check_run, Call, Method, MessageReader};
+use call::{check_run, Call, MessageReader, Method};
 use channel::Channel;
 use codec::{DeserializeFn, SerializeFn};
 use error::{Error, Result};

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -90,6 +90,10 @@ impl RpcStatus {
     }
 }
 
+/// `MessageReader` is a zero-copy reader for the message payload.
+///
+/// To achieve zero-copy, use the BufRead API `fill_buf` and `consume`
+/// to operate the reader.
 pub struct MessageReader {
     buf: *mut GrpcByteBuffer,
     reader: GrpcByteBufferReader,
@@ -102,6 +106,7 @@ pub struct MessageReader {
 }
 
 impl MessageReader {
+    /// Get the available bytes count of the reader.
     #[inline]
     pub fn pending_bytes_count(&self) -> usize {
         self.length

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -19,7 +19,7 @@ use futures::{Async, AsyncSink, Future, Poll, Sink, StartSend, Stream};
 use grpc_sys::{self, GprClockType, GprTimespec, GrpcCallStatus, GrpcRequestCallContext};
 
 use async::{BatchFuture, CallTag, Executor, SpinLock};
-use call::{BatchContext, Call, MethodType, RpcStatusCode, SinkBase, StreamingBase, MessageReader};
+use call::{BatchContext, Call, MessageReader, MethodType, RpcStatusCode, SinkBase, StreamingBase};
 use codec::{DeserializeFn, SerializeFn};
 use cq::CompletionQueue;
 use error::Error;
@@ -177,7 +177,12 @@ impl UnaryRequestContext {
         self.inner.take()
     }
 
-    pub fn handle(mut self, inner: &Arc<Inner>, cq: &CompletionQueue, reader: Option<MessageReader>) {
+    pub fn handle(
+        mut self,
+        inner: &Arc<Inner>,
+        cq: &CompletionQueue,
+        reader: Option<MessageReader>,
+    ) {
         let handler = inner.get_handler(self.request.method()).unwrap();
         if let Some(reader) = reader {
             return execute(self.request, cq, Some(reader), handler.cb());

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -169,6 +169,10 @@ impl UnaryRequestContext {
         &self.batch
     }
 
+    pub fn batch_ctx_mut(&mut self) -> &mut BatchContext {
+        &mut self.batch
+    }
+
     pub fn request_ctx(&self) -> &RequestContext {
         &self.request
     }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -14,7 +14,7 @@
 
 use error::Result;
 
-pub type DeserializeFn<T> = fn(&[u8]) -> Result<T>;
+pub type DeserializeFn<T> = fn(Vec<u8>) -> Result<T>;
 pub type SerializeFn<T> = fn(&T, &mut Vec<u8>);
 
 /// Marshaller defines how to serialize and deserialize between T and byte slice.
@@ -44,7 +44,7 @@ pub mod pb_codec {
     }
 
     #[inline]
-    pub fn de<T: MessageStatic>(buf: &[u8]) -> Result<T> {
-        protobuf::parse_from_bytes(buf).map_err(From::from)
+    pub fn de<T: MessageStatic>(buf: Vec<u8>) -> Result<T> {
+        protobuf::parse_from_bytes(&buf).map_err(From::from)
     }
 }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -35,7 +35,7 @@ pub struct Marshaller<T> {
 
 #[cfg(feature = "protobuf-codec")]
 pub mod pb_codec {
-    use protobuf::{Message, MessageStatic, CodedInputStream};
+    use protobuf::{CodedInputStream, Message, MessageStatic};
 
     use error::Result;
     use call::MessageReader;

--- a/src/env.rs
+++ b/src/env.rs
@@ -66,6 +66,7 @@ impl EnvBuilder {
 
     pub fn build(self) -> Environment {
         unsafe {
+            grpc_sys::sanity_check();
             grpc_sys::grpc_init();
         }
         let mut cqs = Vec::with_capacity(self.cq_count);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ mod error;
 mod log_util;
 mod server;
 
-pub use call::{Method, MethodType, RpcStatus, RpcStatusCode, WriteFlags};
+pub use call::{Method, MethodType, RpcStatus, RpcStatusCode, WriteFlags, MessageReader};
 pub use call::client::{CallOption, ClientCStreamReceiver, ClientCStreamSender,
                        ClientDuplexReceiver, ClientDuplexSender, ClientSStreamReceiver,
                        ClientUnaryReceiver, StreamingCallSink};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@ mod error;
 mod log_util;
 mod server;
 
-pub use call::{Method, MethodType, RpcStatus, RpcStatusCode, WriteFlags, MessageReader};
+pub use call::{MessageReader, Method, MethodType, RpcStatus, RpcStatusCode, WriteFlags};
 pub use call::client::{CallOption, ClientCStreamReceiver, ClientCStreamSender,
                        ClientDuplexReceiver, ClientDuplexSender, ClientSStreamReceiver,
                        ClientUnaryReceiver, StreamingCallSink};

--- a/src/server.rs
+++ b/src/server.rs
@@ -33,7 +33,7 @@ use error::{Error, Result};
 
 const DEFAULT_REQUEST_SLOTS_PER_CQ: usize = 1024;
 
-pub type CallBack = Box<Fn(RpcContext, &[u8])>;
+pub type CallBack = Box<Fn(RpcContext, Vec<u8>)>;
 
 /// Handler is an rpc call holder.
 pub struct Handler {
@@ -141,7 +141,7 @@ impl ServiceBuilder {
         F: Fn(RpcContext, P, UnarySink<Q>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx: RpcContext, payload: &[u8]| {
+        let h = Box::new(move |ctx: RpcContext, payload: Vec<u8>| {
             execute_unary(ctx, ser, de, payload, &handler)
         });
         self.handlers
@@ -161,7 +161,7 @@ impl ServiceBuilder {
         F: Fn(RpcContext, RequestStream<P>, ClientStreamingSink<Q>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx: RpcContext, _: &[u8]| {
+        let h = Box::new(move |ctx: RpcContext, _: Vec<u8>| {
             execute_client_streaming(ctx, ser, de, &handler)
         });
         self.handlers.insert(
@@ -183,7 +183,7 @@ impl ServiceBuilder {
         F: Fn(RpcContext, P, ServerStreamingSink<Q>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx: RpcContext, payload: &[u8]| {
+        let h = Box::new(move |ctx: RpcContext, payload: Vec<u8>| {
             execute_server_streaming(ctx, ser, de, payload, &handler)
         });
         self.handlers.insert(
@@ -205,7 +205,7 @@ impl ServiceBuilder {
         F: Fn(RpcContext, RequestStream<P>, DuplexSink<Q>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx: RpcContext, _: &[u8]| {
+        let h = Box::new(move |ctx: RpcContext, _: Vec<u8>| {
             execute_duplex_streaming(ctx, ser, de, &handler)
         });
         self.handlers

--- a/src/server.rs
+++ b/src/server.rs
@@ -24,7 +24,7 @@ use grpc_sys::{self, GrpcCallStatus, GrpcServer};
 
 use RpcContext;
 use async::{CallTag, CqFuture};
-use call::{Method, MethodType, MessageReader};
+use call::{MessageReader, Method, MethodType};
 use call::server::*;
 use channel::ChannelArgs;
 use cq::CompletionQueue;


### PR DESCRIPTION
In the past, deserialization introduces two times of copy. First is loading the message payload from gRPC core buffer to rust wrapper buffer, the second time is deserialization in codec, which only accepts a slice of bytes as parameter.

This pr exposes the underlying byte buffer as a zero copy reader: `MessageReader`. So implementer can choose whether to copy or not.