### PR TITLE
CallOptions are passed by reference

### DIFF
--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -167,7 +167,7 @@ impl<B: Backoff + Send + 'static> GenericExecutor<B> {
         let (sender, receiver) = self.client
             .duplex_streaming(
                 &bench::METHOD_BENCHMARK_SERVICE_GENERIC_CALL,
-                CallOption::default(),
+                &CallOption::default(),
             )
             .unwrap();
         let f = future::loop_fn(

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -157,7 +157,7 @@ impl<'a> MethodGen<'a> {
 
     fn unary_opt(&self, method_name: &str) -> String {
         format!(
-            "{}_opt(&self, req: &{}, opt: {}) -> {}<{}>",
+            "{}_opt(&self, req: &{}, opt: &{}) -> {}<{}>",
             method_name,
             self.input(),
             fq_grpc("CallOption"),
@@ -179,7 +179,7 @@ impl<'a> MethodGen<'a> {
 
     fn unary_async_opt(&self, method_name: &str) -> String {
         format!(
-            "{}_async_opt(&self, req: &{}, opt: {}) -> {}<{}<{}>>",
+            "{}_async_opt(&self, req: &{}, opt: &{}) -> {}<{}<{}>>",
             method_name,
             self.input(),
             fq_grpc("CallOption"),
@@ -203,7 +203,7 @@ impl<'a> MethodGen<'a> {
 
     fn client_streaming_opt(&self, method_name: &str) -> String {
         format!(
-            "{}_opt(&self, opt: {}) -> {}<({}<{}>, {}<{}>)>",
+            "{}_opt(&self, opt: &{}) -> {}<({}<{}>, {}<{}>)>",
             method_name,
             fq_grpc("CallOption"),
             fq_grpc("Result"),
@@ -227,7 +227,7 @@ impl<'a> MethodGen<'a> {
 
     fn server_streaming_opt(&self, method_name: &str) -> String {
         format!(
-            "{}_opt(&self, req: &{}, opt: {}) -> {}<{}<{}>>",
+            "{}_opt(&self, req: &{}, opt: &{}) -> {}<{}<{}>>",
             method_name,
             self.input(),
             fq_grpc("CallOption"),
@@ -251,7 +251,7 @@ impl<'a> MethodGen<'a> {
 
     fn duplex_streaming_opt(&self, method_name: &str) -> String {
         format!(
-            "{}_opt(&self, opt: {}) -> {}<({}<{}>, {}<{}>)>",
+            "{}_opt(&self, opt: &{}) -> {}<({}<{}>, {}<{}>)>",
             method_name,
             fq_grpc("CallOption"),
             fq_grpc("Result"),
@@ -277,7 +277,7 @@ impl<'a> MethodGen<'a> {
 
                 w.pub_fn(&self.unary(&method_name), |w| {
                     w.write_line(&format!(
-                        "self.{}_opt(req, {})",
+                        "self.{}_opt(req, &{})",
                         method_name,
                         fq_grpc("CallOption::default()")
                     ));
@@ -294,7 +294,7 @@ impl<'a> MethodGen<'a> {
 
                 w.pub_fn(&self.unary_async(&method_name), |w| {
                     w.write_line(&format!(
-                        "self.{}_async_opt(req, {})",
+                        "self.{}_async_opt(req, &{})",
                         method_name,
                         fq_grpc("CallOption::default()")
                     ));
@@ -313,7 +313,7 @@ impl<'a> MethodGen<'a> {
 
                 w.pub_fn(&self.client_streaming(&method_name), |w| {
                     w.write_line(&format!(
-                        "self.{}_opt({})",
+                        "self.{}_opt(&{})",
                         method_name,
                         fq_grpc("CallOption::default()")
                     ));
@@ -332,7 +332,7 @@ impl<'a> MethodGen<'a> {
 
                 w.pub_fn(&self.server_streaming(&method_name), |w| {
                     w.write_line(&format!(
-                        "self.{}_opt(req, {})",
+                        "self.{}_opt(req, &{})",
                         method_name,
                         fq_grpc("CallOption::default()")
                     ));
@@ -351,7 +351,7 @@ impl<'a> MethodGen<'a> {
 
                 w.pub_fn(&self.duplex_streaming(&method_name), |w| {
                     w.write_line(&format!(
-                        "self.{}_opt({})",
+                        "self.{}_opt(&{})",
                         method_name,
                         fq_grpc("CallOption::default()")
                     ));

--- a/interop/src/client.rs
+++ b/interop/src/client.rs
@@ -167,7 +167,7 @@ impl Client {
     pub fn timeout_on_sleeping_server(&self) {
         print!("testing timeout_of_sleeping_server ... ");
         let opt = CallOption::default().timeout(Duration::new(0, 10_000));
-        let (sender, receiver) = self.client.full_duplex_call_opt(opt).unwrap();
+        let (sender, receiver) = self.client.full_duplex_call_opt(&opt).unwrap();
         let mut req = StreamingOutputCallRequest::new();
         req.set_payload(util::new_payload(27182));
         let _ = sender.send((req, WriteFlags::default())).wait();

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -96,9 +96,9 @@ impl Call {
         channel: &Channel,
         method: &Method<P, Q>,
         req: &P,
-        opt: CallOption,
+        opt: &CallOption,
     ) -> Result<ClientUnaryReceiver<Q>> {
-        let call = channel.create_call(method, &opt)?;
+        let call = channel.create_call(method, opt)?;
         let mut payload = vec![];
         (method.req_ser())(req, &mut payload);
         let cq_f = check_run(BatchType::CheckRead, |ctx, tag| unsafe {
@@ -119,9 +119,9 @@ impl Call {
     pub fn client_streaming<P, Q>(
         channel: &Channel,
         method: &Method<P, Q>,
-        opt: CallOption,
+        opt: &CallOption,
     ) -> Result<(ClientCStreamSender<P>, ClientCStreamReceiver<Q>)> {
-        let call = channel.create_call(method, &opt)?;
+        let call = channel.create_call(method, opt)?;
         let cq_f = check_run(BatchType::CheckRead, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_client_streaming(
                 call.call,
@@ -145,9 +145,9 @@ impl Call {
         channel: &Channel,
         method: &Method<P, Q>,
         req: &P,
-        opt: CallOption,
+        opt: &CallOption,
     ) -> Result<ClientSStreamReceiver<Q>> {
-        let call = channel.create_call(method, &opt)?;
+        let call = channel.create_call(method, opt)?;
         let mut payload = vec![];
         (method.req_ser())(req, &mut payload);
         let cq_f = check_run(BatchType::Finish, |ctx, tag| unsafe {
@@ -174,9 +174,9 @@ impl Call {
     pub fn duplex_streaming<P, Q>(
         channel: &Channel,
         method: &Method<P, Q>,
-        opt: CallOption,
+        opt: &CallOption,
     ) -> Result<(ClientDuplexSender<P>, ClientDuplexReceiver<Q>)> {
-        let call = channel.create_call(method, &opt)?;
+        let call = channel.create_call(method, opt)?;
         let cq_f = check_run(BatchType::Finish, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_duplex_streaming(
                 call.call,

--- a/src/client.rs
+++ b/src/client.rs
@@ -33,7 +33,7 @@ impl Client {
     }
 
     /// Create a synchronized unary rpc call.
-    pub fn unary_call<P, Q>(&self, method: &Method<P, Q>, req: &P, opt: CallOption) -> Result<Q> {
+    pub fn unary_call<P, Q>(&self, method: &Method<P, Q>, req: &P, opt: &CallOption) -> Result<Q> {
         let f = self.unary_call_async(method, req, opt)?;
         f.wait()
     }
@@ -43,7 +43,7 @@ impl Client {
         &self,
         method: &Method<P, Q>,
         req: &P,
-        opt: CallOption,
+        opt: &CallOption,
     ) -> Result<ClientUnaryReceiver<Q>> {
         Call::unary_async(&self.channel, method, req, opt)
     }
@@ -54,7 +54,7 @@ impl Client {
     pub fn client_streaming<P, Q>(
         &self,
         method: &Method<P, Q>,
-        opt: CallOption,
+        opt: &CallOption,
     ) -> Result<(ClientCStreamSender<P>, ClientCStreamReceiver<Q>)> {
         Call::client_streaming(&self.channel, method, opt)
     }
@@ -66,7 +66,7 @@ impl Client {
         &self,
         method: &Method<P, Q>,
         req: &P,
-        opt: CallOption,
+        opt: &CallOption,
     ) -> Result<ClientSStreamReceiver<Q>> {
         Call::server_streaming(&self.channel, method, req, opt)
     }
@@ -79,7 +79,7 @@ impl Client {
     pub fn duplex_streaming<P, Q>(
         &self,
         method: &Method<P, Q>,
-        opt: CallOption,
+        opt: &CallOption,
     ) -> Result<(ClientDuplexSender<P>, ClientDuplexReceiver<Q>)> {
         Call::duplex_streaming(&self.channel, method, opt)
     }


### PR DESCRIPTION
This allows them to be re-used for multiple calls, rather than requiring
frequent re-construction.