### PR TITLE
Added support for Google default credentials.

### DIFF
--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -486,6 +486,7 @@ mod secure_component {
             reserved: *mut c_void,
         ) -> *mut GrpcChannel;
 
+        pub fn grpc_google_default_credentials_create() -> *mut GrpcChannelCredentials;
         pub fn grpc_server_add_secure_http2_port(
             server: *mut GrpcServer,
             addr: *const c_char,

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::ffi::CString;
 use std::ptr;
 
@@ -199,6 +198,23 @@ pub struct ChannelCredentials {
 impl ChannelCredentials {
     pub fn as_mut_ptr(&mut self) -> *mut GrpcChannelCredentials {
         self.creds
+    }
+
+    /// Attempts to construct a `ChannelCredentials` that is authenticated with
+    /// Google OAuth credentials.
+    pub fn google_default_credentials() -> Result<ChannelCredentials, String> {
+        // Initialize the runtime here. Because this is an associated method
+        // that can be called before construction of an `Environment`, we
+        // need to call this here too.
+        unsafe {
+            grpc_sys::grpc_init();
+        }
+        let creds = unsafe { grpc_sys::grpc_google_default_credentials_create() };
+        if creds.is_null() {
+            Err(String::from("Could not create google default credentials."))
+        } else {
+            Ok(ChannelCredentials { creds: creds })
+        }
     }
 }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -15,6 +15,7 @@ use std::ffi::CString;
 use std::ptr;
 
 use grpc_sys::{self, GrpcChannelCredentials, GrpcServerCredentials};
+use error::{Error, Result};
 use libc::c_char;
 
 fn clear_key_securely(key: &mut [u8]) {
@@ -202,7 +203,7 @@ impl ChannelCredentials {
 
     /// Attempts to construct a `ChannelCredentials` that is authenticated with
     /// Google OAuth credentials.
-    pub fn google_default_credentials() -> Result<ChannelCredentials, String> {
+    pub fn google_default_credentials() -> Result<ChannelCredentials> {
         // Initialize the runtime here. Because this is an associated method
         // that can be called before construction of an `Environment`, we
         // need to call this here too.
@@ -211,7 +212,7 @@ impl ChannelCredentials {
         }
         let creds = unsafe { grpc_sys::grpc_google_default_credentials_create() };
         if creds.is_null() {
-            Err(String::from("Could not create google default credentials."))
+            Err(Error::GoogleAuthenticationFailed)
         } else {
             Ok(ChannelCredentials { creds: creds })
         }

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,7 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 use std::{error, result};
 use std::fmt::{self, Display, Formatter};
 
@@ -34,6 +33,8 @@ pub enum Error {
     ShutdownFailed,
     BindFail(String, u16),
     QueueShutdown,
+    // Return when Google Default Credentials failed.
+    GoogleAuthenticationFailed,
 }
 
 impl Display for Error {
@@ -53,6 +54,7 @@ impl error::Error for Error {
             Error::ShutdownFailed => "Failed to shutdown.",
             Error::BindFail(_, _) => "gRPC Bind Error",
             Error::QueueShutdown => "gRPC completion queue shutdown",
+            Error::GoogleAuthenticationFailed => "Could not create google default credentials.",
         }
     }
 


### PR DESCRIPTION
This change adds support for authenticating with [Google Application Default Credentials](https://developers.google.com/identity/protocols/application-default-credentials).

This is necessary to connect to Google APIs via gRPC.