### PR TITLE
Add documentation on using protoc-grpcio

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,26 +83,8 @@ Option 2 - Programmatic Generation
 Programmatic generation can be used to generate Rust modules from proto files
 via your `build.rs` by using [protoc-grpcio](https://crates.io/crates/protoc-grpcio).
 
-Include this in your `Cargo.toml`:
-
-```toml
-[build.dependencies]
-protoc-grpcio = "0.1"
-```
-
-and then use in your `build.rs` like:
-
-```rust
-extern crate protoc_grpcio;
-
-// Generates `protobuf.rs` and `protobuf_grpc.rs` in a directory named
-// `output`.
-protoc_grpcio::compile_grpc_protos(
-    &["example/protobuf.proto"],
-    &["example"],
-    "output"
-).expect("failed to compile gRPC definitions");
-```
+For more information and examples see the
+[README](https://github.com/mtp401/protoc-grpcio/blob/master/README.md).
 
 Performance
 -----------

--- a/README.md
+++ b/README.md
@@ -49,6 +49,9 @@ Usage
 
 To generate the sources from proto files:
 
+Option 1 - Manual Generation
+----------------------------
+
 1. Install the protobuf compiler:
 
 ```
@@ -72,6 +75,33 @@ To include this project as a dependency:
 ```
 [dependencies]
 grpcio = "0.1"
+```
+
+Option 2 - Programmatic Generation
+----------------------------------
+
+Programmatic generation can be used to generate Rust modules from proto files
+via your `build.rs` by using [protoc-grpcio](https://crates.io/crates/protoc-grpcio).
+
+Include this in your `Cargo.toml`:
+
+```toml
+[build.dependencies]
+protoc-grpcio = "0.1"
+```
+
+and then use in your `build.rs` like:
+
+```rust
+extern crate protoc_grpcio;
+
+// Generates `protobuf.rs` and `protobuf_grpc.rs` in a directory named
+// `output`.
+protoc_grpcio::compile_grpc_protos(
+    &["example/protobuf.proto"],
+    &["example"],
+    "output"
+).expect("failed to compile gRPC definitions");
 ```
 
 Performance


### PR DESCRIPTION
I have a few projects that I'm evaluating switching over to `grpc-rs` from `grpc-rust` and noticed that there was no easy way to invoke `protoc` with the `grpc-rs` compiler plugin so I wrote a crate based on
[protoc-rust](https://crates.io/crates/protoc-rust). This PR just documents that `protoc-grpcio` is another option for module generation for `grpc-rs` users.

Cheers,
Matt