### PR TITLE
build: trigger build when c sources change

### DIFF
--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -133,6 +133,9 @@ fn get_env(name: &str) -> Option<String> {
 fn main() {
     let mut cc = Build::new();
 
+    println!("cargo:rerun-if-changed=grpc_wrap.c");
+    println!("cargo:rerun-if-changed=grpc");
+
     let library = if cfg!(feature = "secure") {
         cc.define("GRPC_SYS_SECURE", None);
         "grpc"


### PR DESCRIPTION
When using `rerun-if-env-changed`, changes in grpc-sys won't trigger a rebuild automatically anymore. This pr fixes it by setting what changes need a rebuild explicitly.