### PR TITLE
Cancel RPC when senders and receivers are dropped

### DIFF
--- a/interop/src/client.rs
+++ b/interop/src/client.rs
@@ -62,7 +62,8 @@ impl Client {
             (req, WriteFlags::default())
         });
         let (sender, receiver) = self.client.streaming_input_call().unwrap();
-        sender
+        // Keep the sender, so that receiver will not receive Cancelled error.
+        let _sender = sender
             .send_all(stream::iter_ok::<_, grpc::Error>(reqs))
             .wait()
             .unwrap();
@@ -169,7 +170,8 @@ impl Client {
         let (sender, receiver) = self.client.full_duplex_call_opt(opt).unwrap();
         let mut req = StreamingOutputCallRequest::new();
         req.set_payload(util::new_payload(27182));
-        let _ = sender.send((req, WriteFlags::default())).wait();
+        // Keep the sender, so that receiver will not receive Cancelled error.
+        let _sender = sender.send((req, WriteFlags::default())).wait();
         match receiver.into_future().wait() {
             Err((grpc::Error::RpcFailure(s), _)) => {
                 assert_eq!(s.status, RpcStatusCode::DeadlineExceeded)
@@ -198,7 +200,8 @@ impl Client {
         let mut req = StreamingOutputCallRequest::new();
         req.set_response_status(status);
         let (sender, receiver) = self.client.full_duplex_call().unwrap();
-        let _ = sender.send((req, WriteFlags::default())).wait();
+        // Keep the sender, so that receiver will not receive Cancelled error.
+        let _sender = sender.send((req, WriteFlags::default())).wait();
         match receiver.into_future().wait() {
             Err((grpc::Error::RpcFailure(s), _)) => {
                 assert_eq!(s.status, RpcStatusCode::Unknown);

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -225,7 +225,7 @@ impl Call {
 /// A receiver for unary request.
 ///
 /// The future is resolved once response is received.
-#[must_use]
+#[must_use = "if unused the ClientUnaryReceiver may immediately cancel the RPC"]
 pub struct ClientUnaryReceiver<T> {
     call: Call,
     resp_f: CqFuture<BatchMessage>,
@@ -269,7 +269,7 @@ impl<T> Future for ClientUnaryReceiver<T> {
 ///
 /// [`RpcFailure`]: ./enum.Error.html#variant.RpcFailure
 /// [`Cancelled`]: ./enum.RpcStatusCode.html#variant.Cancelled
-#[must_use]
+#[must_use = "if unused the ClientCStreamReceiver may immediately cancel the RPC"]
 pub struct ClientCStreamReceiver<T> {
     call: Arc<SpinLock<ShareCall>>,
     resp_de: DeserializeFn<T>,
@@ -310,7 +310,7 @@ impl<T> Future for ClientCStreamReceiver<T> {
 }
 
 /// A sink for client streaming call and duplex streaming call.
-#[must_use]
+#[must_use = "if unused the StreamingCallSink may immediately cancel the RPC"]
 pub struct StreamingCallSink<Req> {
     call: Arc<SpinLock<ShareCall>>,
     sink_base: SinkBase,
@@ -472,7 +472,7 @@ impl<H: ShareCallHolder, T> ResponseStreamImpl<H, T> {
 }
 
 /// A receiver for server streaming call.
-#[must_use]
+#[must_use = "if unused the ClientSStreamReceiver may immediately cancel the RPC"]
 pub struct ClientSStreamReceiver<Resp> {
     imp: ResponseStreamImpl<ShareCall, Resp>,
 }
@@ -510,7 +510,7 @@ impl<Resp> Stream for ClientSStreamReceiver<Resp> {
 ///
 /// [`RpcFailure`]: ./enum.Error.html#variant.RpcFailure
 /// [`Cancelled`]: ./enum.RpcStatusCode.html#variant.Cancelled
-#[must_use]
+#[must_use = "if unused the ClientDuplexReceiver may immediately cancel the RPC"]
 pub struct ClientDuplexReceiver<Resp> {
     imp: ResponseStreamImpl<Arc<SpinLock<ShareCall>>, Resp>,
 }

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -310,6 +310,9 @@ impl<T> Future for ClientCStreamReceiver<T> {
 }
 
 /// A sink for client streaming call and duplex streaming call.
+/// To close the sink properly, you should call [`close`] before dropping.
+///
+/// [`close`]: #method.close
 #[must_use = "if unused the StreamingCallSink may immediately cancel the RPC"]
 pub struct StreamingCallSink<Req> {
     call: Arc<SpinLock<ShareCall>>,
@@ -392,7 +395,17 @@ impl<Req> Sink for StreamingCallSink<Req> {
     }
 }
 
+/// A sink for client streaming call.
+///
+/// To close the sink properly, you should call [`close`] before dropping.
+///
+/// [`close`]: #method.close
 pub type ClientCStreamSender<T> = StreamingCallSink<T>;
+/// A sink for duplex streaming call.
+///
+/// To close the sink properly, you should call [`close`] before dropping.
+///
+/// [`close`]: #method.close
 pub type ClientDuplexSender<T> = StreamingCallSink<T>;
 
 struct ResponseStreamImpl<H, T> {

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -317,9 +317,14 @@ impl<P> StreamingCallSink<P> {
 }
 
 impl<P> Drop for StreamingCallSink<P> {
-    /// The corresponding RPC will be canceled when the value is dropped.
+    /// The corresponding RPC will be canceled if the sink did not call
+    /// [`close`] before dropping.
+    ///
+    /// [`close`]: #method.close
     fn drop(&mut self) {
-        self.cancel();
+        if self.close_f.is_none() {
+            self.cancel();
+        }
     }
 }
 

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -223,6 +223,7 @@ impl Call {
 /// A receiver for unary request.
 ///
 /// The future is resolved once response is received.
+#[must_use]
 pub struct ClientUnaryReceiver<T> {
     call: Call,
     resp_f: CqFuture<BatchMessage>,
@@ -266,6 +267,7 @@ impl<T> Future for ClientUnaryReceiver<T> {
 ///
 /// [`RpcFailure`]: ./enum.Error.html#variant.RpcFailure
 /// [`Cancelled`]: ./enum.RpcStatusCode.html#variant.Cancelled
+#[must_use]
 pub struct ClientCStreamReceiver<T> {
     call: Arc<SpinLock<ShareCall>>,
     resp_de: DeserializeFn<T>,
@@ -306,6 +308,7 @@ impl<T> Future for ClientCStreamReceiver<T> {
 }
 
 /// A sink for client streaming call and duplex streaming call.
+#[must_use]
 pub struct StreamingCallSink<P> {
     call: Arc<SpinLock<ShareCall>>,
     sink_base: SinkBase,
@@ -467,6 +470,7 @@ impl<H: ShareCallHolder, T> ResponseStreamImpl<H, T> {
 }
 
 /// A receiver for server streaming call.
+#[must_use]
 pub struct ClientSStreamReceiver<Q> {
     imp: ResponseStreamImpl<ShareCall, Q>,
 }
@@ -504,6 +508,7 @@ impl<Q> Stream for ClientSStreamReceiver<Q> {
 ///
 /// [`RpcFailure`]: ./enum.Error.html#variant.RpcFailure
 /// [`Cancelled`]: ./enum.RpcStatusCode.html#variant.Cancelled
+#[must_use]
 pub struct ClientDuplexReceiver<Q> {
     imp: ResponseStreamImpl<Arc<SpinLock<ShareCall>>, Q>,
 }

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -432,14 +432,9 @@ impl<H: ShareCallHolder, T> ResponseStreamImpl<H, T> {
     }
 
     fn poll(&mut self) -> Poll<Option<T>, Error> {
-        {
+        if !self.finished {
             let finished = &mut self.finished;
             self.call.call(|c| {
-                if c.finished {
-                    *finished = true;
-                    return Ok(());
-                }
-
                 let res = c.poll_finish().map(|_| ());
                 *finished = c.finished;
                 res

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -483,6 +483,14 @@ impl StreamingBase {
             Ok(Async::Ready(bytes))
         }
     }
+
+    // Cancel the call if we still have some messages or did not
+    // receive status code.
+    fn on_drop<C: ShareCallHolder>(&self, call: &mut C) {
+        if !self.read_done || self.close_f.is_some() {
+            call.call(|c| c.call.cancel());
+        }
+    }
 }
 
 #[derive(Default, Clone, Copy)]

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -252,6 +252,7 @@ impl<T> Drop for RequestStream<T> {
 // `CallHolder` or `Call` to caller.
 macro_rules! impl_unary_sink {
     ($t:ident, $rt:ident, $holder:ty) => (
+        #[must_use]
         pub struct $rt {
             call: $holder,
             cq_f: Option<BatchFuture>,
@@ -451,6 +452,7 @@ macro_rules! impl_stream_sink {
             }
         }
 
+        #[must_use]
         pub struct $ft {
             call: $holder,
             fail_f: Option<BatchFuture>,

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -268,7 +268,7 @@ impl<T> Drop for RequestStream<T> {
 // TODO: Use type alias to be friendly for documentation.
 macro_rules! impl_unary_sink {
     ($t:ident, $rt:ident, $holder:ty) => {
-        #[must_use]
+        #[must_use = "if unused the sink may immediately cancel the RPC"]
         pub struct $rt {
             call: $holder,
             cq_f: Option<BatchFuture>,
@@ -475,7 +475,7 @@ macro_rules! impl_stream_sink {
             }
         }
 
-        #[must_use]
+        #[must_use = "if unused the sink failure may immediately cancel the RPC"]
         pub struct $ft {
             call: $holder,
             fail_f: Option<BatchFuture>,

--- a/tests/cases/cancel.rs
+++ b/tests/cases/cancel.rs
@@ -41,18 +41,18 @@ impl CancelService {
 }
 
 impl RouteGuide for CancelService {
-    fn get_feature(&self, _: RpcContext, _: Point, sink: UnarySink<Feature>) {
+    fn get_feature(&mut self, _: RpcContext, _: Point, sink: UnarySink<Feature>) {
         // Drop the sink, client should receive Cancelled.
         drop(sink);
     }
 
-    fn list_features(&self, _: RpcContext, _: Rectangle, sink: ServerStreamingSink<Feature>) {
+    fn list_features(&mut self, _: RpcContext, _: Rectangle, sink: ServerStreamingSink<Feature>) {
         // Drop the sink, client should receive Cancelled.
         drop(sink);
     }
 
     fn record_route(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<Point>,
         sink: ClientStreamingSink<RouteSummary>,
@@ -65,7 +65,7 @@ impl RouteGuide for CancelService {
     }
 
     fn route_chat(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<RouteNote>,
         sink: DuplexSink<RouteNote>,

--- a/tests/cases/cancel.rs
+++ b/tests/cases/cancel.rs
@@ -1,0 +1,193 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Debug;
+use std::sync::{Arc, Mutex};
+
+use futures::*;
+use grpcio::*;
+use grpcio_proto::example::route_guide::*;
+use grpcio_proto::example::route_guide_grpc::*;
+
+type Handler<T> = Arc<Mutex<Option<Box<T>>>>;
+type BoxFuture = Box<Future<Item = (), Error = ()> + Send + 'static>;
+type RecordRouteHandler =
+    Handler<Fn(RequestStream<Point>, ClientStreamingSink<RouteSummary>) -> BoxFuture + Send>;
+type RouteChatHandler =
+    Handler<Fn(RequestStream<RouteNote>, DuplexSink<RouteNote>) -> BoxFuture + Send>;
+
+#[derive(Clone)]
+struct CancelService {
+    record_route_handler: RecordRouteHandler,
+    route_chat_handler: RouteChatHandler,
+}
+
+impl CancelService {
+    fn new() -> CancelService {
+        CancelService {
+            record_route_handler: Arc::new(Mutex::new(None)),
+            route_chat_handler: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl RouteGuide for CancelService {
+    fn get_feature(&self, _: RpcContext, _: Point, sink: UnarySink<Feature>) {
+        // Drop the sink, client should receive Cancelled.
+        drop(sink);
+    }
+
+    fn list_features(&self, _: RpcContext, _: Rectangle, sink: ServerStreamingSink<Feature>) {
+        // Drop the sink, client should receive Cancelled.
+        drop(sink);
+    }
+
+    fn record_route(
+        &self,
+        ctx: RpcContext,
+        stream: RequestStream<Point>,
+        sink: ClientStreamingSink<RouteSummary>,
+    ) {
+        let handler = self.record_route_handler.lock().unwrap();
+        if handler.is_some() {
+            let f = (handler.as_ref().unwrap())(stream, sink);
+            ctx.spawn(f);
+        }
+    }
+
+    fn route_chat(
+        &self,
+        ctx: RpcContext,
+        stream: RequestStream<RouteNote>,
+        sink: DuplexSink<RouteNote>,
+    ) {
+        let handler = self.route_chat_handler.lock().unwrap();
+        if handler.is_some() {
+            let f = (handler.as_ref().unwrap())(stream, sink);
+            ctx.spawn(f);
+        }
+    }
+}
+
+fn check_cancel<S, T>(rx: S)
+where
+    S: Stream<Item = T, Error = Error>,
+    T: Debug,
+{
+    match rx.into_future().wait() {
+        Err((Error::RpcFailure(s), _)) => assert_eq!(s.status, RpcStatusCode::Cancelled),
+        Err((e, _)) => panic!("expected cancel, but got: {:?}", e),
+        Ok((r, _)) => panic!("expected error, but got: {:?}", r),
+    }
+}
+
+fn run_suite() -> (CancelService, RouteGuideClient, Server) {
+    let env = Arc::new(EnvBuilder::new().build());
+    let service = CancelService::new();
+    let mut server = ServerBuilder::new(env.clone())
+        .register_service(create_route_guide(service.clone()))
+        .bind("127.0.0.1", 0)
+        .build()
+        .unwrap();
+    server.start();
+    let port = server.bind_addrs()[0].1;
+    let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+    let client = RouteGuideClient::new(ch);
+    (service, client, server)
+}
+
+#[test]
+fn test_client_cancel_on_dropping() {
+    let (service, client, _server) = run_suite();
+
+    // Client streaming.
+    {
+        let mut record_route_handler = service.record_route_handler.lock().unwrap();
+        *record_route_handler = Some(Box::new(|stream, sink| {
+            // Start the call and keep the stream and the sink.
+            let f = stream.for_each(|_| Ok(())).then(|_| {
+                let _sink = sink;
+                Ok(())
+            });
+            Box::new(f)
+        }));
+    }
+    let (tx, rx) = client.record_route().unwrap();
+    drop(tx);
+    check_cancel(rx.into_stream());
+
+    // Duplex streaming.
+    {
+        let mut record_route_handler = service.record_route_handler.lock().unwrap();
+        *record_route_handler = Some(Box::new(|stream, sink| {
+            // Start the call and keep the stream and the sink.
+            let f = stream.for_each(|_| Ok(())).then(|_| {
+                let _sink = sink;
+                Ok(())
+            });
+            Box::new(f)
+        }));
+    }
+    let (tx, rx) = client.route_chat().unwrap();
+    drop(tx);
+    check_cancel(rx);
+}
+
+#[test]
+fn test_server_cancel_on_dropping() {
+    let (service, client, _server) = run_suite();
+
+    // Unary
+    let rx = client.get_feature_async(&Default::default()).unwrap();
+    check_cancel(rx.into_stream());
+
+    // Client streaming
+    {
+        // let timer = service.timer.clone();
+        let mut record_route_handler = service.record_route_handler.lock().unwrap();
+        *record_route_handler = Some(Box::new(|stream, sink| {
+            // let sleep = timer.sleep(Duration::from_millis(500));
+            // Start the call, keep the stream and drop the sink.
+            let f = stream
+                .for_each(|_| Ok(()))
+                .join(future::result(Ok(())).map(move |_| {
+                    drop(sink);
+                }))
+                .then(|_| Ok(()));
+            Box::new(f)
+        }));
+    }
+    let (_tx, rx) = client.record_route().unwrap();
+    check_cancel(rx.into_stream());
+
+    // Server streaming
+    let rx = client.list_features(&Default::default()).unwrap();
+    check_cancel(rx);
+
+    // Duplex streaming
+    {
+        let mut route_chat_handler = service.route_chat_handler.lock().unwrap();
+        *route_chat_handler = Some(Box::new(|stream, sink| {
+            // Start the call, keep the stream and drop the sink.
+            let f = stream
+                .for_each(|_| Ok(()))
+                .join(future::result(Ok(())).map(move |_| {
+                    drop(sink);
+                }))
+                .then(|_| Ok(()));
+            Box::new(f)
+        }));
+    }
+    let (_tx, rx) = client.route_chat().unwrap();
+    check_cancel(rx);
+}

--- a/tests/cases/cancel.rs
+++ b/tests/cases/cancel.rs
@@ -91,7 +91,7 @@ where
     }
 }
 
-fn run_suite() -> (CancelService, RouteGuideClient, Server) {
+fn prepare_suite() -> (CancelService, RouteGuideClient, Server) {
     let env = Arc::new(EnvBuilder::new().build());
     let service = CancelService::new();
     let mut server = ServerBuilder::new(env.clone())
@@ -108,7 +108,7 @@ fn run_suite() -> (CancelService, RouteGuideClient, Server) {
 
 #[test]
 fn test_client_cancel_on_dropping() {
-    let (service, client, _server) = run_suite();
+    let (service, client, _server) = prepare_suite();
 
     // Client streaming.
     *service.record_route_handler.lock().unwrap() = Some(Box::new(|stream, sink| {
@@ -147,7 +147,7 @@ fn test_client_cancel_on_dropping() {
 
 #[test]
 fn test_server_cancel_on_dropping() {
-    let (service, client, _server) = run_suite();
+    let (service, client, _server) = prepare_suite();
 
     // Unary
     let rx = client.get_feature_async(&Default::default()).unwrap();

--- a/tests/cases/mod.rs
+++ b/tests/cases/mod.rs
@@ -14,3 +14,4 @@
 mod alarm;
 mod health_check;
 mod metadata;
+mod cancel;


### PR DESCRIPTION
So we will not accidentally leak gRPC calls.

Cc https://github.com/pingcap/grpc-rs/issues/150