### PR TITLE
Specify maximum supported protobuf version

### DIFF
--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -11,7 +11,7 @@ description = "gRPC compiler for grpcio"
 categories = ["network-programming"]
 
 [dependencies]
-protobuf = "1.2"
+protobuf = ">=1.2, <1.6"
 
 [[bin]]
 name = "grpc_rust_plugin"


### PR DESCRIPTION
protobuf crate v1.6 breaks the build of grpcio-compiler.