### PR TITLE
Use protobuf 1.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 grpcio-sys = { path = "grpc-sys", version = "0.2.1" }
 libc = "0.2"
 futures = "^0.1.15"
-protobuf = { version = "1.2", optional = true }
+protobuf = { version = "1.6", optional = true }
 log = "0.3"
 
 [workspace]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -11,7 +11,8 @@ description = "gRPC compiler for grpcio"
 categories = ["network-programming"]
 
 [dependencies]
-protobuf = "1.2"
+protobuf = "1.6"
+protobuf-codegen = "1.6"
 
 [[bin]]
 name = "grpc_rust_plugin"

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -36,7 +36,7 @@ use std::collections::HashMap;
 
 use protobuf;
 use protobuf::compiler_plugin;
-use protobuf::code_writer::CodeWriter;
+use protobuf_codegen::code_writer::CodeWriter;
 use protobuf::descriptor::*;
 use protobuf::descriptorx::*;
 

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -12,6 +12,7 @@
 // limitations under the License.
 
 extern crate protobuf;
+extern crate protobuf_codegen;
 
 pub mod codegen;
 mod util;

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -12,10 +12,11 @@ categories = ["network-programming"]
 build = "build.rs"
 
 [dependencies]
-protobuf = "1.2"
+protobuf = "1.6"
 futures = "0.1"
 grpcio = { path = "..", version = "0.2.2", features = ["secure"] }
 
 [build-dependencies]
-protobuf = "1.2"
+protobuf = "1.6"
+protobuf-codegen = "1.6"
 grpcio-compiler = { path = "../compiler", version = "0.2.0" }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -13,6 +13,7 @@
 
 extern crate grpcio_compiler;
 extern crate protobuf;
+extern crate protobuf_codegen;
 
 use std::fs::{self, File};
 use std::env;
@@ -20,8 +21,9 @@ use std::io::Write;
 use std::path::Path;
 
 use grpcio_compiler::codegen as grpc_gen;
-use protobuf::codegen as pb_gen;
+use protobuf_codegen as pb_gen;
 use protobuf::compiler_plugin::GenResult;
+use pb_gen::Customize;
 use protobuf::descriptor::{FileDescriptorProto, FileDescriptorSet};
 
 /// Descriptor file to module file.
@@ -68,7 +70,15 @@ fn compile<P: AsRef<Path>>(desc_path: P, module: &str) {
 
     let mod_rs = module_path.join("mod.rs");
     let mut module = File::create(mod_rs).unwrap();
-    desc_to_module(desc_path.as_ref(), &module_path, pb_gen::gen, &mut module);
+    desc_to_module(
+        desc_path.as_ref(),
+        &module_path,
+        |a, b| {
+            let c = Customize::default();
+            pb_gen::gen(a, b, &c)
+        },
+        &mut module,
+    );
     desc_to_module(desc_path.as_ref(), &module_path, grpc_gen::gen, &mut module);
 }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -33,7 +33,7 @@ pub struct Marshaller<T> {
 
 #[cfg(feature = "protobuf-codec")]
 pub mod pb_codec {
-    use protobuf::{self, Message, MessageStatic};
+    use protobuf::{self, Message};
 
     use error::Result;
 
@@ -43,7 +43,7 @@ pub mod pb_codec {
     }
 
     #[inline]
-    pub fn de<T: MessageStatic>(buf: &[u8]) -> Result<T> {
+    pub fn de<T: Message>(buf: &[u8]) -> Result<T> {
         protobuf::parse_from_bytes(buf).map_err(From::from)
     }
 }

--- a/src/error.rs
+++ b/src/error.rs
@@ -16,6 +16,7 @@ use std::fmt::{self, Display, Formatter};
 
 use grpc_sys::GrpcCallStatus;
 #[cfg(feature = "protobuf-codec")]
+#[cfg(feature = "protobuf-codec")]
 use protobuf::ProtobufError;
 
 use call::RpcStatus;


### PR DESCRIPTION
When I was building a project which uses this `grpc-rs` crate as a dependency, it used the latest `protobuf`, version `1.6`, despite the Cargo.toml files all explicitly setting the version as `1.2`.

`protobuf 1.6` had some breaking changes. So instead of figuring out why Cargo didn't appear to be doing the right thing, I upgraded this crate to compile with `protobuf 1.6`.

