### PR TITLE
channel: fix overflow

### DIFF
--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -367,7 +367,7 @@ impl Client {
                         builder =
                             builder.raw_cfg_string(key, CString::new(arg.get_str_value()).unwrap());
                     } else if arg.has_int_value() {
-                        builder = builder.raw_cfg_int(key, arg.get_int_value() as usize);
+                        builder = builder.raw_cfg_int(key, arg.get_int_value() as i32);
                     }
                 }
                 if cfg.has_security_params() {

--- a/benchmark/src/server.rs
+++ b/benchmark/src/server.rs
@@ -64,7 +64,7 @@ impl Server {
                     ch_builder =
                         ch_builder.raw_cfg_string(key, CString::new(arg.get_str_value()).unwrap());
                 } else if arg.has_int_value() {
-                    ch_builder = ch_builder.raw_cfg_int(key, arg.get_int_value() as usize);
+                    ch_builder = ch_builder.raw_cfg_int(key, arg.get_int_value() as i32);
                 }
             }
             builder = builder.channel_args(ch_builder.build_args());

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -159,7 +159,10 @@ impl RequestContext {
             // RequestContext always holds a reference of the call.
             let call = grpc_sys::grpcwrap_request_call_context_get_call(self.ctx);
             let p = grpc_sys::grpc_call_get_peer(call);
-            let peer = CStr::from_ptr(p).to_str().expect("valid UTF-8 data").to_owned();
+            let peer = CStr::from_ptr(p)
+                .to_str()
+                .expect("valid UTF-8 data")
+                .to_owned();
             grpc_sys::gpr_free(p as _);
             peer
         }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -395,7 +395,7 @@ impl ChannelBuilder {
             let key = k.as_ptr() as *const c_char;
             match *v {
                 Options::Integer(val) => unsafe {
-                    // On most morden compiler and architect, c_int is the same as i32,
+                    // On most modern compiler and architect, c_int is the same as i32,
                     // panic directly to simplify signature.
                     assert!(
                         val <= i32::from(libc::INT_MAX) && val >= i32::from(libc::INT_MIN),


### PR DESCRIPTION
usize is too large for c int. This pr changes the type from usize to i32, which suits most modern compiler and architect. Also add an assert check that prevent overflow from happening at run time for the others.