### PR TITLE
Optionally build with openssl instead of boringssl

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,1 @@
+grpc-sys/grpc/.clang-format

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,3 +36,4 @@ script:
   - cargo build
   - cargo test --all
   - GRPCIO_SYS_USE_PKG_CONFIG=1 cargo test --all
+  - cargo test --features "secure openssl" --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -31,7 +31,7 @@ before_script:
   - export LIBRARY_PATH="$HOME/.cache/lib"
   - export PKG_CONFIG_PATH="$HOME/.cache/lib/pkgconfig"
 script:
-  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo install -f clippy && cargo clippy; fi
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then rustup component add clippy-preview --toolchain nightly && cargo clippy; fi
   - export RUSTFLAGS=-Dwarnings
   - cargo build --no-default-features
   - cargo build --no-default-features --features protobuf-codec

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,5 @@ script:
   - cargo build
   - cargo test --all
   - GRPCIO_SYS_USE_PKG_CONFIG=1 cargo test --all
-  - cargo test --features "secure openssl" --all
+  - apt-get update && apt-get -y install libssl-dev
+  - cargo test --features "openssl" --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,16 +19,28 @@ matrix:
   - os: osx
     rust: stable
 before_script:
+  - export GRPC_VERSION=1.14.2
   - export PATH="$PATH:$HOME/.cache/bin:$HOME/.cargo/bin"
   - GRPC_HEADER="$HOME/.cache/include/grpc/grpc.h"
-  - if [[ $TRAVIS_OS_NAME == "osx" ]] && [[ ! -f $GRPC_HEADER ]]; then export CC=clang; brew update && brew install autoconf libtool shtool; fi
-  - test -f "$GRPC_HEADER" || (git clone -b v1.7.2 https://github.com/grpc/grpc && cd grpc && git submodule update --init && env prefix=$HOME/.cache make install_c)
-  - export C_INCLUDE_PATH="$HOME/.cache/include"
+  - if [[ $TRAVIS_OS_NAME == "osx" ]] && [[ ! -f $GRPC_HEADER ]]; then
+      export CC=clang;
+      brew update && brew install autoconf libtool shtool;
+    fi
+  - if [[ ! -f "$GRPC_HEADER" ]] ; then
+      (
+        git clone -b v$GRPC_VERSION https://github.com/grpc/grpc &&
+        cd grpc &&
+        git submodule update --init &&
+        env prefix=$HOME/.cache make install_c
+      );
+    fi
+  - export CPLUS_INCLUDE_PATH="$HOME/.cache/include"
   - export LD_LIBRARY_PATH="$HOME/.cache/lib"
   - export DYLD_LIBRARY_PATH="$HOME/.cache/lib"
   - export LIBRARY_PATH="$HOME/.cache/lib"
   - export PKG_CONFIG_PATH="$HOME/.cache/lib/pkgconfig"
 script:
+  - export RUST_BACKTRACE=1
   - export RUSTFLAGS=-Dwarnings
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then rustup component add clippy-preview --toolchain nightly && cargo clippy --all; fi
   - cargo build --no-default-features

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,6 @@ rust:
   - beta
   - nightly
 matrix:
-  allow_failures:
-    - rust: nightly
   include:
   - os: osx
     rust: stable
@@ -31,8 +29,8 @@ before_script:
   - export LIBRARY_PATH="$HOME/.cache/lib"
   - export PKG_CONFIG_PATH="$HOME/.cache/lib/pkgconfig"
 script:
-  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then rustup component add clippy-preview --toolchain nightly && cargo clippy; fi
   - export RUSTFLAGS=-Dwarnings
+  - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then rustup component add clippy-preview --toolchain nightly && cargo clippy --all; fi
   - cargo build --no-default-features
   - cargo build --no-default-features --features protobuf-codec
   - cargo build

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: bionic
+dist: trusty
 sudo: true
 language: rust
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: trusty
+dist: bionic
 sudo: true
 language: rust
 cache:
@@ -37,5 +37,5 @@ script:
   - cargo test --all
   - GRPCIO_SYS_USE_PKG_CONFIG=1 cargo test --all
   - sudo apt-get -qq update
-  - sudo apt-get -y install libssl-dev
+  - sudo apt-get -y install libssl1.0-dev
   - cargo test --features "openssl" --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 dist: trusty
-sudo: false
+sudo: true
 language: rust
 cache:
   directories:
@@ -36,5 +36,6 @@ script:
   - cargo build
   - cargo test --all
   - GRPCIO_SYS_USE_PKG_CONFIG=1 cargo test --all
-  - apt-get update && apt-get -y install libssl-dev
+  - sudo apt-get -qq update
+  - sudo apt-get -y install libssl-dev
   - cargo test --features "openssl" --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,8 @@ before_script:
 script:
   - if [[ $TRAVIS_RUST_VERSION == "nightly" ]]; then cargo install -f clippy && cargo clippy; fi
   - export RUSTFLAGS=-Dwarnings
+  - cargo build --no-default-features
+  - cargo build --no-default-features --features protobuf-codec
   - cargo build
   - cargo test --all
   - GRPCIO_SYS_USE_PKG_CONFIG=1 cargo test --all

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.3.1 - 2018-08-27
+
+- Support configuring load balancing policy
+- Fix compilation failure when go is missing
+- Fix compilation issue under musl
+- Fix soundness of service handler
+
 # 0.3.0 - 2018-06-01
 
 - keep compatible with protobuf 2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+# 0.3.0 - 2018-06-01
+
+- keep compatible with protobuf 2.0
+- enable secure feature by default
+- fix potential overflow in channel args
+
 # 0.2.3 - 2018-04-27
 
 - support querying client address

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+# 0.4.0 - 2018-09-15
+
+- Update gRPC from 1.7.2 to 1.14.2
+- Services accept mut reference
+- Cancel RPC when senders and receivers were dropped
+- Notify completion queue via call
+
 # 0.3.1 - 2018-08-27
 
 - Support configuring load balancing policy

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,46 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to making participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, gender identity and expression, level of experience, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces when an individual is representing the project or its community. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event. Representation of a project may be further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at coc@pingcap.com. The project team will review and investigate all complaints, and will respond in a way that it deems appropriate to the circumstances. The project team is obligated to maintain confidentiality with regard to the reporter of an incident. Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4, available at [http://contributor-covenant.org/version/1/4][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/4/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ homepage = "https://github.com/pingcap/grpc-rs"
 documentation = "https://docs.rs/grpcio"
 description = "The rust language implementation of gRPC, base on the gRPC c core library."
 categories = ["asynchronous", "network-programming"]
+autoexamples = false
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ grpcio-sys = { path = "grpc-sys", version = "0.2.1" }
 libc = "0.2"
 futures = "^0.1.15"
 protobuf = { version = "~2.0", optional = true }
-log = "0.3"
+log = "0.4"
 
 [workspace]
 members = ["proto", "benchmark", "compiler", "interop"]
@@ -51,7 +51,7 @@ serde_json = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
 grpcio-proto = { path = "proto", version = "0.3.0" }
-rand = "0.3"
+rand = "0.4"
 slog = "2.0"
 slog-async = "2.1"
 slog-stdlog = "3.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio"
-version = "0.3.0"
+version = "0.3.1"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["grpc", "protobuf", "rpc", "tls", "http2"]
@@ -16,7 +16,7 @@ autoexamples = false
 all-features = true
 
 [dependencies]
-grpcio-sys = { path = "grpc-sys", version = "0.2.1" }
+grpcio-sys = { path = "grpc-sys", version = "0.3.1" }
 libc = "0.2"
 futures = "^0.1.15"
 protobuf = { version = "~2.0", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio"
-version = "0.2.3"
+version = "0.3.0"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["grpc", "protobuf", "rpc", "tls", "http2"]
@@ -50,7 +50,7 @@ path = "examples/hello_world/server.rs"
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
-grpcio-proto = { path = "proto", version = "0.2.0" }
+grpcio-proto = { path = "proto", version = "0.3.0" }
 rand = "0.3"
 slog = "2.0"
 slog-async = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["grpc", "protobuf", "rpc", "tls", "http2"]
@@ -16,7 +16,7 @@ autoexamples = false
 all-features = true
 
 [dependencies]
-grpcio-sys = { path = "grpc-sys", version = "0.3.1" }
+grpcio-sys = { path = "grpc-sys", version = "0.4.0" }
 libc = "0.2"
 futures = "^0.1.15"
 protobuf = { version = "~2.0", optional = true }
@@ -51,7 +51,7 @@ path = "examples/hello_world/server.rs"
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
-grpcio-proto = { path = "proto", version = "0.3.0" }
+grpcio-proto = { path = "proto", version = "0.4.0" }
 rand = "0.4"
 slog = "2.0"
 slog-async = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ members = ["proto", "benchmark", "compiler", "interop"]
 default = ["protobuf-codec"]
 protobuf-codec = ["protobuf"]
 secure = ["grpcio-sys/secure"]
-openssl = ["grpcio-sys/openssl"]
+openssl = ["grpcio-sys/openssl", "secure"]
 
 [[example]]
 name = "route_guide_client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ members = ["proto", "benchmark", "compiler", "interop"]
 default = ["protobuf-codec"]
 protobuf-codec = ["protobuf"]
 secure = ["grpcio-sys/secure"]
+openssl = ["grpcio-sys/openssl"]
 
 [[example]]
 name = "route_guide_client"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ log = "0.3"
 members = ["proto", "benchmark", "compiler", "interop"]
 
 [features]
-default = ["protobuf-codec"]
+default = ["protobuf-codec", "secure"]
 protobuf-codec = ["protobuf"]
 secure = ["grpcio-sys/secure"]
 openssl = ["grpcio-sys/openssl", "secure"]

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ For Windows, you also need to install following software:
 ## Build
 
 ```
+$ git submodule update --init --recursive # if you just cloned the repository
 $ cargo build
 ```
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ To include this project as a dependency:
 
 ```
 [dependencies]
-grpcio = "0.2"
+grpcio = "0.3"
 ```
 
 ### Feature `secure`
@@ -90,7 +90,7 @@ mechanism. When you do not need it, for example when working in intranet,
 you can disable it by using the following configuration:
 ```
 [dependencies]
-grpcio = { version = "0.2", default-features = false, features = ["protobuf-codec"] }
+grpcio = { version = "0.3", default-features = false, features = ["protobuf-codec"] }
 ```
 
 ## Performance

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project is still under development. The following features with the check m
 
 - CMake >= 3.8.0
 - Rust >= 1.19.0
-- If you want to enable [secure feature](#feature-secure), Go (>=1.7) is required.
+- By default, the [secure feature](#feature-secure) is enabled, therefore Go (>=1.7) is required.
 
 For Linux and MacOS, you also need to install gcc (or clang) too.
 

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 [![Build Status](https://travis-ci.org/pingcap/grpc-rs.svg)](https://travis-ci.org/pingcap/grpc-rs)
 [![Build status](https://ci.appveyor.com/api/projects/status/1cofa3nih5fm2kb0/branch/master?svg=true)](https://ci.appveyor.com/project/busyjay/grpc-rs/branch/master)
 
-Status
-------
+## Status
+
 This project is still under development. The following features with the check marks are supported:
 
 - [x] Basic asynchronous unary/steaming call 
@@ -23,12 +23,11 @@ This project is still under development. The following features with the check m
 - [ ] Authentication
 - [ ] Load balance
 
-Prerequisites
--------------
+## Prerequisites
 
 - CMake >= 3.8.0
 - Rust >= 1.19.0
-- If you want to enable secure feature, Go (>=1.7) is required.
+- If you want to enable [secure feature](#feature-secure), Go (>=1.7) is required.
 
 For Linux and MacOS, you also need to install gcc (or clang) too.
 
@@ -38,25 +37,22 @@ For Windows, you also need to install following software:
 - yasm
 - Visual Studio 2015+
 
-Build
------
+## Build
 
 ```
 $ cargo build
 ```
 
-Usage
------
+## Usage
 
 To generate the sources from proto files:
 
-Option 1 - Manual Generation
-----------------------------
+### Option 1 - Manual Generation
 
 1. Install the protobuf compiler:
 
 ```
-$ cargo install protobuf
+$ cargo install protobuf-codegen
 ```
 
 2. Install the gRPC compiler:
@@ -71,6 +67,15 @@ $ cargo install grpcio-compiler
 $ protoc --rust_out=. --grpc_out=. --plugin=protoc-gen-grpc=`which grpc_rust_plugin` example.proto
 ```
 
+
+### Option 2 - Programmatic Generation
+
+Programmatic generation can be used to generate Rust modules from proto files
+via your `build.rs` by using [protoc-grpcio](https://crates.io/crates/protoc-grpcio).
+
+For more information and examples see
+[README](https://github.com/mtp401/protoc-grpcio/blob/master/README.md).
+
 To include this project as a dependency:
 
 ```
@@ -78,15 +83,16 @@ To include this project as a dependency:
 grpcio = "0.2"
 ```
 
-Option 2 - Programmatic Generation
-----------------------------------
+### Feature `secure`
 
-Programmatic generation can be used to generate Rust modules from proto files
-via your `build.rs` by using [protoc-grpcio](https://crates.io/crates/protoc-grpcio).
+`secure` feature enables support for TLS encryption and some authentication
+mechanism. When you do not need it, for example when working in intranet,
+you can disable it by using the following configuration:
+```
+[dependencies]
+grpcio = { version = "0.2", default-features = false, features = ["protobuf-codec"] }
+```
 
-For more information and examples see the
-[README](https://github.com/mtp401/protoc-grpcio/blob/master/README.md).
+## Performance
 
-Performance
------------
 See [benchmark](https://github.com/pingcap/grpc-rs/tree/master/benchmark) to find out how to run a benchmark by yourself.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@
 
 This project is still under development. The following features with the check marks are supported:
 
-- [x] Basic asynchronous unary/steaming call 
+- [x] Basic asynchronous unary/steaming call
 - [x] SSL
 - [x] Generic call
 - [x] Connection level compression
@@ -33,7 +33,7 @@ For Linux and MacOS, you also need to install gcc (or clang) too.
 
 For Windows, you also need to install following software:
 
-- Active State Perl 
+- Active State Perl
 - yasm
 - Visual Studio 2015+
 
@@ -81,7 +81,7 @@ To include this project as a dependency:
 
 ```
 [dependencies]
-grpcio = "0.3"
+grpcio = "0.4"
 ```
 
 ### Feature `secure`
@@ -91,7 +91,7 @@ mechanism. When you do not need it, for example when working in intranet,
 you can disable it by using the following configuration:
 ```
 [dependencies]
-grpcio = { version = "0.3", default-features = false, features = ["protobuf-codec"] }
+grpcio = { version = "0.4", default-features = false, features = ["protobuf-codec"] }
 ```
 
 ## Performance

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,4 +1,4 @@
-branches:  
+branches:
   only:
     - master
 
@@ -19,10 +19,11 @@ install:
   - choco install yasm
   - rustc -V
   - cargo -V
-    
+
 build: false
 
 test_script:
   - SET RUSTFLAGS=-Dwarnings
+  - SET RUST_BACKTRACE=1
   - cargo build --target %TARGET%
   - cargo test --all --target %TARGET%

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: Remove it once Rust's tool_lints is stabilized.
+#![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
+
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -39,14 +39,14 @@ pub struct Benchmark {
 }
 
 impl BenchmarkService for Benchmark {
-    fn unary_call(&self, ctx: RpcContext, req: SimpleRequest, sink: UnarySink<SimpleResponse>) {
+    fn unary_call(&mut self, ctx: RpcContext, req: SimpleRequest, sink: UnarySink<SimpleResponse>) {
         let f = sink.success(gen_resp(&req));
         let keep_running = self.keep_running.clone();
         spawn!(ctx, keep_running, "unary", f)
     }
 
     fn streaming_call(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<SimpleRequest>,
         sink: DuplexSink<SimpleResponse>,
@@ -57,7 +57,7 @@ impl BenchmarkService for Benchmark {
     }
 
     fn streaming_from_client(
-        &self,
+        &mut self,
         ctx: RpcContext,
         _: RequestStream<SimpleRequest>,
         sink: ClientStreamingSink<SimpleResponse>,
@@ -68,7 +68,7 @@ impl BenchmarkService for Benchmark {
     }
 
     fn streaming_from_server(
-        &self,
+        &mut self,
         ctx: RpcContext,
         _: SimpleRequest,
         sink: ServerStreamingSink<SimpleResponse>,
@@ -79,7 +79,7 @@ impl BenchmarkService for Benchmark {
     }
 
     fn streaming_both_ways(
-        &self,
+        &mut self,
         ctx: RpcContext,
         _: RequestStream<SimpleRequest>,
         sink: DuplexSink<SimpleResponse>,

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -11,17 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
-use grpc_proto::testing::services_grpc::BenchmarkService;
-use grpc_proto::testing::messages::{SimpleRequest, SimpleResponse};
-use grpc_proto::util;
-use grpc::{self, ClientStreamingSink, DuplexSink, Method, MethodType, RequestStream, RpcContext,
-           RpcStatus, RpcStatusCode, ServerStreamingSink, ServiceBuilder, UnarySink, WriteFlags};
 use futures::{Future, Sink, Stream};
+use grpc::{
+    self, ClientStreamingSink, DuplexSink, Method, MethodType, RequestStream, RpcContext,
+    RpcStatus, RpcStatusCode, ServerStreamingSink, ServiceBuilder, UnarySink, WriteFlags,
+};
+use grpc_proto::testing::messages::{SimpleRequest, SimpleResponse};
+use grpc_proto::testing::services_grpc::BenchmarkService;
+use grpc_proto::util;
 
-fn gen_resp(req: SimpleRequest) -> SimpleResponse {
+fn gen_resp(req: &SimpleRequest) -> SimpleResponse {
     let payload = util::new_payload(req.get_response_size() as usize);
     let mut resp = SimpleResponse::new();
     resp.set_payload(payload);
@@ -35,7 +37,7 @@ pub struct Benchmark {
 
 impl BenchmarkService for Benchmark {
     fn unary_call(&self, ctx: RpcContext, req: SimpleRequest, sink: UnarySink<SimpleResponse>) {
-        let f = sink.success(gen_resp(req));
+        let f = sink.success(gen_resp(&req));
         let keep_running = self.keep_running.clone();
         spawn!(ctx, keep_running, "unary", f)
     }
@@ -46,7 +48,7 @@ impl BenchmarkService for Benchmark {
         stream: RequestStream<SimpleRequest>,
         sink: DuplexSink<SimpleResponse>,
     ) {
-        let f = sink.send_all(stream.map(|req| (gen_resp(req), WriteFlags::default())));
+        let f = sink.send_all(stream.map(|req| (gen_resp(&req), WriteFlags::default())));
         let keep_running = self.keep_running.clone();
         spawn!(ctx, keep_running, "streaming", f)
     }
@@ -93,7 +95,7 @@ pub struct Generic {
 impl Generic {
     pub fn streaming_call(
         &self,
-        ctx: RpcContext,
+        ctx: &RpcContext,
         stream: RequestStream<Vec<u8>>,
         sink: DuplexSink<Vec<u8>>,
     ) {
@@ -104,6 +106,7 @@ impl Generic {
 }
 
 #[inline]
+#[cfg_attr(feature = "cargo-clippy", allow(ptr_arg))]
 pub fn bin_ser(t: &Vec<u8>, buf: &mut Vec<u8>) {
     buf.extend_from_slice(t)
 }
@@ -130,7 +133,7 @@ pub fn create_generic_service(s: Generic) -> ::grpc::Service {
     ServiceBuilder::new()
         .add_duplex_streaming_handler(
             &METHOD_BENCHMARK_SERVICE_GENERIC_CALL,
-            move |ctx, req, resp| s.streaming_call(ctx, req, resp),
+            move |ctx, req, resp| s.streaming_call(&ctx, req, resp),
         )
         .build()
 }

--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -367,7 +367,7 @@ impl Client {
                         builder =
                             builder.raw_cfg_string(key, CString::new(arg.get_str_value()).unwrap());
                     } else if arg.has_int_value() {
-                        builder = builder.raw_cfg_int(key, arg.get_int_value() as usize);
+                        builder = builder.raw_cfg_int(key, arg.get_int_value() as i32);
                     }
                 }
                 if cfg.has_security_params() {

--- a/benchmark/src/lib.rs
+++ b/benchmark/src/lib.rs
@@ -27,7 +27,7 @@ extern crate tokio_timer;
 
 // Since impl trait is not stable yet, implement this as a function is impossible without box.
 macro_rules! spawn {
-    ($exec:ident, $keep_running:expr, $tag: expr, $f:expr) => {
+    ($exec:ident, $keep_running:expr, $tag:expr, $f:expr) => {
         $exec.spawn($f.map(|_| ()).map_err(move |e| {
             if $keep_running.load(Ordering::SeqCst) {
                 error!("failed to execute {}: {:?}", $tag, e);
@@ -40,8 +40,8 @@ mod bench;
 mod client;
 mod error;
 mod server;
-mod worker;
 mod util;
+mod worker;
 
-pub use worker::Worker;
 pub use util::log_util::init_log;
+pub use worker::Worker;

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -26,12 +26,12 @@ use std::sync::Arc;
 use benchmark::{init_log, Worker};
 use clap::{App, Arg};
 use futures::sync::oneshot;
+use futures::Future;
 use grpc::{Environment, ServerBuilder};
 use grpc_proto::testing::services_grpc;
-use futures::Future;
 use rand::Rng;
 
-const LOG_FILE: &'static str = "GRPCIO_BENCHMARK_LOG_FILE";
+const LOG_FILE: &str = "GRPCIO_BENCHMARK_LOG_FILE";
 
 fn main() {
     let matches = App::new("Benchmark QpsWorker")

--- a/benchmark/src/server.rs
+++ b/benchmark/src/server.rs
@@ -12,14 +12,14 @@
 // limitations under the License.
 
 use std::ffi::CString;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use error::Result;
 use grpc::{ChannelBuilder, EnvBuilder, Server as GrpcServer, ServerBuilder, ShutdownFuture};
 use grpc_proto::testing::control::{ServerConfig, ServerStatus, ServerType};
-use grpc_proto::testing::stats::ServerStats;
 use grpc_proto::testing::services_grpc;
+use grpc_proto::testing::stats::ServerStats;
 use grpc_proto::util as proto_util;
 
 use bench::{self, Benchmark, Generic};
@@ -107,7 +107,7 @@ impl Server {
 
     pub fn get_status(&self) -> ServerStatus {
         let mut status = ServerStatus::new();
-        status.set_port(self.server.bind_addrs()[0].1 as i32);
+        status.set_port(i32::from(self.server.bind_addrs()[0].1));
         status.set_cores(util::cpu_num_cores() as i32);
         status
     }

--- a/benchmark/src/server.rs
+++ b/benchmark/src/server.rs
@@ -64,7 +64,7 @@ impl Server {
                     ch_builder =
                         ch_builder.raw_cfg_string(key, CString::new(arg.get_str_value()).unwrap());
                 } else if arg.has_int_value() {
-                    ch_builder = ch_builder.raw_cfg_int(key, arg.get_int_value() as usize);
+                    ch_builder = ch_builder.raw_cfg_int(key, arg.get_int_value() as i32);
                 }
             }
             builder = builder.channel_args(ch_builder.build_args());

--- a/benchmark/src/worker.rs
+++ b/benchmark/src/worker.rs
@@ -41,7 +41,7 @@ impl Worker {
 
 impl WorkerService for Worker {
     fn run_server(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<ServerArgs>,
         sink: DuplexSink<ServerStatus>,
@@ -78,7 +78,7 @@ impl WorkerService for Worker {
     }
 
     fn run_client(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<ClientArgs>,
         sink: DuplexSink<ClientStatus>,
@@ -114,7 +114,7 @@ impl WorkerService for Worker {
         ctx.spawn(f)
     }
 
-    fn core_count(&self, ctx: RpcContext, _: CoreRequest, sink: UnarySink<CoreResponse>) {
+    fn core_count(&mut self, ctx: RpcContext, _: CoreRequest, sink: UnarySink<CoreResponse>) {
         let cpu_count = util::cpu_num_cores();
         let mut resp = CoreResponse::new();
         resp.set_cores(cpu_count as i32);
@@ -124,7 +124,7 @@ impl WorkerService for Worker {
         )
     }
 
-    fn quit_worker(&self, ctx: RpcContext, _: Void, sink: ::grpc::UnarySink<Void>) {
+    fn quit_worker(&mut self, ctx: RpcContext, _: Void, sink: ::grpc::UnarySink<Void>) {
         let notifier = self.shutdown_notifier.lock().unwrap().take();
         if let Some(notifier) = notifier {
             let _ = notifier.send(());

--- a/benchmark/src/worker.rs
+++ b/benchmark/src/worker.rs
@@ -13,17 +13,18 @@
 
 use std::sync::{Arc, Mutex};
 
-use grpc_proto::testing::services_grpc::WorkerService;
-use grpc_proto::testing::control::{ClientArgs, ClientStatus, CoreRequest, CoreResponse,
-                                   ServerArgs, ServerStatus, Void};
-use grpc::{DuplexSink, RequestStream, RpcContext, UnarySink, WriteFlags};
 use error::Error;
-use futures::{future, Future, Sink, Stream};
 use futures::sync::oneshot::Sender;
+use futures::{future, Future, Sink, Stream};
+use grpc::{DuplexSink, RequestStream, RpcContext, UnarySink, WriteFlags};
+use grpc_proto::testing::control::{
+    ClientArgs, ClientStatus, CoreRequest, CoreResponse, ServerArgs, ServerStatus, Void,
+};
+use grpc_proto::testing::services_grpc::WorkerService;
 
 use client::Client;
-use util;
 use server::Server;
+use util;
 
 #[derive(Clone)]
 pub struct Worker {
@@ -53,7 +54,8 @@ impl WorkerService for Worker {
                 info!("receive server setup: {:?}", cfg);
                 let server = Server::new(cfg)?;
                 let status = server.get_status();
-                Ok(sink.send((status, WriteFlags::default()))
+                Ok(sink
+                    .send((status, WriteFlags::default()))
                     .and_then(|sink| {
                         stream.fold((sink, server), |(sink, mut server), arg| {
                             let mark = arg.get_mark();

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-compiler"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["compiler", "grpc", "protobuf"]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-compiler"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["compiler", "grpc", "protobuf"]

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -368,7 +368,7 @@ impl<'a> MethodGen<'a> {
             MethodType::Duplex => ("stream", req_stream_type, "DuplexSink"),
         };
         let sig = format!(
-            "{}(&self, ctx: {}, {}: {}, sink: {}<{}>)",
+            "{}(&mut self, ctx: {}, {}: {}, sink: {}<{}>)",
             self.name(),
             fq_grpc("RpcContext"),
             req,
@@ -487,7 +487,7 @@ impl<'a> ServiceGen<'a> {
         w.pub_fn(&s, |w| {
             w.write_line("let mut builder = ::grpcio::ServiceBuilder::new();");
             for method in &self.methods {
-                w.write_line("let instance = s.clone();");
+                w.write_line("let mut instance = s.clone();");
                 method.write_bind(w);
             }
             w.write_line("builder.build()");

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -36,9 +36,9 @@ use std::collections::HashMap;
 
 use protobuf;
 use protobuf::compiler_plugin;
-use protobuf_codegen::code_writer::CodeWriter;
 use protobuf::descriptor::*;
 use protobuf::descriptorx::*;
+use protobuf_codegen::code_writer::CodeWriter;
 
 use super::util::{self, fq_grpc, to_snake_case, MethodType};
 
@@ -57,10 +57,10 @@ impl<'a> MethodGen<'a> {
         root_scope: &'a RootScope<'a>,
     ) -> MethodGen<'a> {
         MethodGen {
-            proto: proto,
-            service_name: service_name,
-            service_path: service_path,
-            root_scope: root_scope,
+            proto,
+            service_name,
+            service_path,
+            root_scope,
         }
     }
 
@@ -429,10 +429,7 @@ impl<'a> ServiceGen<'a> {
             })
             .collect();
 
-        ServiceGen {
-            proto: proto,
-            methods: methods,
-        }
+        ServiceGen { proto, methods }
     }
 
     fn service_name(&self) -> String {
@@ -550,9 +547,7 @@ pub fn gen(
     let files_map: HashMap<&str, &FileDescriptorProto> =
         file_descriptors.iter().map(|f| (f.get_name(), f)).collect();
 
-    let root_scope = RootScope {
-        file_descriptors: file_descriptors,
-    };
+    let root_scope = RootScope { file_descriptors };
 
     let mut results = Vec::new();
 

--- a/examples/hello_world/server.rs
+++ b/examples/hello_world/server.rs
@@ -27,8 +27,8 @@ use std::io::Read;
 use std::sync::Arc;
 use std::{io, thread};
 
-use futures::Future;
 use futures::sync::oneshot;
+use futures::Future;
 use grpcio::{Environment, RpcContext, ServerBuilder, UnarySink};
 
 use grpcio_proto::example::helloworld::{HelloReply, HelloRequest};
@@ -42,7 +42,8 @@ impl Greeter for GreeterService {
         let msg = format!("Hello {}", req.get_name());
         let mut resp = HelloReply::new();
         resp.set_message(msg);
-        let f = sink.success(resp)
+        let f = sink
+            .success(resp)
             .map_err(move |e| error!("failed to reply {:?}: {:?}", req, e));
         ctx.spawn(f)
     }

--- a/examples/hello_world/server.rs
+++ b/examples/hello_world/server.rs
@@ -35,7 +35,7 @@ use grpcio_proto::example::helloworld_grpc::{self, Greeter};
 struct GreeterService;
 
 impl Greeter for GreeterService {
-    fn say_hello(&self, ctx: RpcContext, req: HelloRequest, sink: UnarySink<HelloReply>) {
+    fn say_hello(&mut self, ctx: RpcContext, req: HelloRequest, sink: UnarySink<HelloReply>) {
         let msg = format!("Hello {}", req.get_name());
         let mut resp = HelloReply::new();
         resp.set_message(msg);

--- a/examples/hello_world/server.rs
+++ b/examples/hello_world/server.rs
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(unknown_lints)]
-#![allow(unreadable_literal)]
-
 extern crate futures;
 extern crate grpcio;
 extern crate grpcio_proto;
@@ -55,7 +52,7 @@ fn main() {
     let service = helloworld_grpc::create_greeter(GreeterService);
     let mut server = ServerBuilder::new(env)
         .register_service(service)
-        .bind("127.0.0.1", 50051)
+        .bind("127.0.0.1", 50_051)
         .build()
         .unwrap();
     server.start();

--- a/examples/route_guide/client.rs
+++ b/examples/route_guide/client.rs
@@ -21,13 +21,13 @@ extern crate rand;
 extern crate serde_derive;
 extern crate serde_json;
 
-mod util;
 #[path = "../log_util.rs"]
 mod log_util;
+mod util;
 
 use std::sync::Arc;
-use std::time::Duration;
 use std::thread;
+use std::time::Duration;
 
 use futures::{future, Future, Sink, Stream};
 use grpcio::*;
@@ -109,7 +109,8 @@ fn record_route(client: &RouteGuideClient) {
         let f = rng.choose(&features).unwrap();
         let point = f.get_location();
         info!("Visiting {}", util::format_point(point));
-        sink = sink.send((point.to_owned(), WriteFlags::default()))
+        sink = sink
+            .send((point.to_owned(), WriteFlags::default()))
             .wait()
             .unwrap();
         thread::sleep(Duration::from_millis(rng.gen_range(500, 1500)));

--- a/examples/route_guide/server.rs
+++ b/examples/route_guide/server.rs
@@ -23,22 +23,22 @@ extern crate log;
 extern crate serde_derive;
 extern crate serde_json;
 
-mod util;
 #[path = "../log_util.rs"]
 mod log_util;
+mod util;
 
-use std::sync::Arc;
 use std::io::Read;
+use std::sync::Arc;
 use std::time::Instant;
 use std::{io, thread};
 
-use grpcio::*;
-use futures::*;
 use futures::sync::oneshot;
+use futures::*;
+use grpcio::*;
 
-use util::*;
 use grpcio_proto::example::route_guide::*;
 use grpcio_proto::example::route_guide_grpc::{self, RouteGuide};
+use util::*;
 
 #[derive(Clone)]
 struct RouteGuideService {
@@ -48,17 +48,20 @@ struct RouteGuideService {
 impl RouteGuide for RouteGuideService {
     fn get_feature(&self, ctx: RpcContext, point: Point, sink: UnarySink<Feature>) {
         let data = self.data.clone();
-        let resp = data.iter()
+        let resp = data
+            .iter()
             .find(|f| same_point(f.get_location(), &point))
             .map_or_else(Feature::new, ToOwned::to_owned);
-        let f = sink.success(resp)
+        let f = sink
+            .success(resp)
             .map_err(|e| error!("failed to handle getfeature request: {:?}", e));
         ctx.spawn(f)
     }
 
     fn list_features(&self, ctx: RpcContext, rect: Rectangle, resp: ServerStreamingSink<Feature>) {
         let data = self.data.clone();
-        let features: Vec<_> = data.iter()
+        let features: Vec<_> = data
+            .iter()
             .filter_map(move |f| {
                 if fit_in(f.get_location(), &rect) {
                     Some((f.to_owned(), WriteFlags::default()))
@@ -67,7 +70,8 @@ impl RouteGuide for RouteGuideService {
                 }
             })
             .collect();
-        let f = resp.send_all(stream::iter_ok::<_, Error>(features))
+        let f = resp
+            .send_all(stream::iter_ok::<_, Error>(features))
             .map(|_| {})
             .map_err(|e| error!("failed to handle listfeatures request: {:?}", e));
         ctx.spawn(f)
@@ -87,7 +91,8 @@ impl RouteGuide for RouteGuideService {
                 move |(last, mut dis, mut summary), point| {
                     let total_count = summary.get_point_count();
                     summary.set_point_count(total_count + 1);
-                    let valid_point = data.iter()
+                    let valid_point = data
+                        .iter()
                         .any(|f| !f.get_name().is_empty() && same_point(f.get_location(), &point));
                     if valid_point {
                         let feature_count = summary.get_feature_count();
@@ -132,7 +137,8 @@ impl RouteGuide for RouteGuideService {
                 stream::iter_ok::<_, Error>(to_prints)
             })
             .flatten();
-        let f = resp.send_all(to_send)
+        let f = resp
+            .send_all(to_send)
             .map(|_| {})
             .map_err(|e| error!("failed to route chat: {:?}", e));
         ctx.spawn(f)

--- a/examples/route_guide/server.rs
+++ b/examples/route_guide/server.rs
@@ -11,9 +11,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#![allow(unknown_lints)]
-#![allow(unreadable_literal)]
-
 extern crate futures;
 extern crate grpcio;
 extern crate grpcio_proto;
@@ -154,7 +151,7 @@ fn main() {
     let service = route_guide_grpc::create_route_guide(instance);
     let mut server = ServerBuilder::new(env)
         .register_service(service)
-        .bind("127.0.0.1", 50051)
+        .bind("127.0.0.1", 50_051)
         .build()
         .unwrap();
     server.start();

--- a/examples/route_guide/server.rs
+++ b/examples/route_guide/server.rs
@@ -43,7 +43,7 @@ struct RouteGuideService {
 }
 
 impl RouteGuide for RouteGuideService {
-    fn get_feature(&self, ctx: RpcContext, point: Point, sink: UnarySink<Feature>) {
+    fn get_feature(&mut self, ctx: RpcContext, point: Point, sink: UnarySink<Feature>) {
         let data = self.data.clone();
         let resp = data
             .iter()
@@ -55,7 +55,12 @@ impl RouteGuide for RouteGuideService {
         ctx.spawn(f)
     }
 
-    fn list_features(&self, ctx: RpcContext, rect: Rectangle, resp: ServerStreamingSink<Feature>) {
+    fn list_features(
+        &mut self,
+        ctx: RpcContext,
+        rect: Rectangle,
+        resp: ServerStreamingSink<Feature>,
+    ) {
         let data = self.data.clone();
         let features: Vec<_> = data
             .iter()
@@ -75,7 +80,7 @@ impl RouteGuide for RouteGuideService {
     }
 
     fn record_route(
-        &self,
+        &mut self,
         ctx: RpcContext,
         points: RequestStream<Point>,
         resp: ClientStreamingSink<RouteSummary>,
@@ -112,7 +117,7 @@ impl RouteGuide for RouteGuideService {
     }
 
     fn route_chat(
-        &self,
+        &mut self,
         ctx: RpcContext,
         notes: RequestStream<RouteNote>,
         resp: DuplexSink<RouteNote>,

--- a/examples/route_guide/util.rs
+++ b/examples/route_guide/util.rs
@@ -58,8 +58,10 @@ pub fn same_point(lhs: &Point, rhs: &Point) -> bool {
 pub fn fit_in(lhs: &Point, rhs: &Rectangle) -> bool {
     let hi = rhs.get_hi();
     let lo = rhs.get_lo();
-    lhs.get_longitude() <= hi.get_longitude() && lhs.get_longitude() >= lo.get_longitude()
-        && lhs.get_latitude() <= hi.get_latitude() && lhs.get_latitude() >= lo.get_latitude()
+    lhs.get_longitude() <= hi.get_longitude()
+        && lhs.get_longitude() >= lo.get_longitude()
+        && lhs.get_latitude() <= hi.get_latitude()
+        && lhs.get_latitude() >= lo.get_latitude()
 }
 
 const COORD_FACTOR: f64 = 10000000.0;

--- a/examples/route_guide/util.rs
+++ b/examples/route_guide/util.rs
@@ -12,7 +12,6 @@
 // limitations under the License.
 
 #![allow(unknown_lints)]
-
 // client and server share different parts of utils.
 #![allow(dead_code)]
 #![allow(cast_lossless)]

--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-sys"
-version = "0.2.3"
+version = "0.3.1"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["grpc", "bindings"]

--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -16,6 +16,9 @@ exclude = [
     "grpc/examples/*",
     "grpc/Makefile",
     "grpc/templates/*",
+    "grpc/src/android/*",
+    "grpc/src/csharp/*",
+    "grpc/src/boringssl/crypto_test_data.cc",
     "grpc/src/node/*",
     "grpc/src/objective-c/*",
     "grpc/src/php/*",
@@ -27,7 +30,9 @@ exclude = [
     "grpc/third_party/benchmark/*",
     "grpc/third_party/bloaty/*",
     "grpc/third_party/boringssl/fuzz/*",
-    "grpc/third_party/boringssl/crypto/cipher/test/*",
+    "grpc/third_party/boringssl/crypto/cipher_extra/test/*",
+    "grpc/third_party/boringssl/third_party/android-cmake/*",
+    "grpc/third_party/boringssl/util/*",
     "grpc/third_party/boringssl-with-bazel/*",
     "grpc/third_party/gflags/*",
     "grpc/third_party/googletest/*",
@@ -37,6 +42,7 @@ exclude = [
     "grpc/third_party/protobuf/*",
     "grpc/third_party/rake-compiler-dock/*",
     "grpc/third_party/toolchan/*",
+    "grpc/tools/run_tests/generated/*",
 ]
 
 [dependencies]

--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -36,6 +36,7 @@ exclude = [
 
 [dependencies]
 libc = "0.2"
+openssl = { version = "0.10", optional = true }
 
 [features]
 default = []

--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-sys"
-version = "0.3.1"
+version = "0.4.0"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["grpc", "bindings"]
@@ -23,15 +23,20 @@ exclude = [
     "grpc/src/ruby/*",
     "grpc/vsprojects/*",
     "grpc/test/core/end2end/*",
+    "grpc/third_party/abseil-cpp/*",
     "grpc/third_party/benchmark/*",
+    "grpc/third_party/bloaty/*",
     "grpc/third_party/boringssl/fuzz/*",
     "grpc/third_party/boringssl/crypto/cipher/test/*",
     "grpc/third_party/boringssl-with-bazel/*",
     "grpc/third_party/gflags/*",
     "grpc/third_party/googletest/*",
+    "grpc/third_party/libcxx/*",
+    "grpc/third_party/libcxxabi/*",
     "grpc/third_party/objective_c/*",
     "grpc/third_party/protobuf/*",
     "grpc/third_party/rake-compiler-dock/*",
+    "grpc/third_party/toolchan/*",
 ]
 
 [dependencies]

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -75,6 +75,9 @@ fn build_grpc(cc: &mut Build, library: &str) {
         if cfg!(feature = "openssl") {
             config.define("gRPC_SSL_PROVIDER", "package");
         }
+        if env::var("CARGO_CFG_TARGET_ENV").unwrap_or("".to_owned()) == "musl" {
+            config.define("CMAKE_CXX_COMPILER", "g++");
+        }
         config.build_target(library).uses_cxx11().build()
     };
 

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -84,8 +84,12 @@ fn build_grpc(cc: &mut Build, library: &str) {
         if env::var("CARGO_CFG_TARGET_ENV").unwrap_or("".to_owned()) == "musl" {
             config.define("CMAKE_CXX_COMPILER", "g++");
         }
-        // We dont need generate install targets.
+        // We don't need to generate install targets.
         config.define("gRPC_INSTALL", "false");
+        // We don't need to build csharp target.
+        config.define("gRPC_BUILD_CSHARP_EXT", "false");
+        // We don't need to build codegen target.
+        config.define("gRPC_BUILD_CODEGEN", "false");
         config.build_target(library).uses_cxx11().build()
     };
 

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -69,6 +69,12 @@ fn build_grpc(cc: &mut Build, library: &str) {
 
     let dst = {
         let mut config = Config::new("grpc");
+        if !cfg!(feature = "secure") {
+            // boringssl's configuration is still included, but targets
+            // will never be built, hence specify a fake go to get rid of
+            // the unnecessary dependency.
+            config.define("GO_EXECUTABLE", "fake-go-nonexist");
+        }
         if cfg!(target_os = "macos") {
             config.cxxflag("-stdlib=libc++");
         }

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -90,6 +90,9 @@ fn build_grpc(cc: &mut Build, library: &str) {
         config.define("gRPC_BUILD_CSHARP_EXT", "false");
         // We don't need to build codegen target.
         config.define("gRPC_BUILD_CODEGEN", "false");
+        if cfg!(feature = "openssl") {
+            config.define("gRPC_SSL_PROVIDER", "package");
+        }
         config.build_target(library).uses_cxx11().build()
     };
 

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -15,12 +15,12 @@ extern crate cc;
 extern crate cmake;
 extern crate pkg_config;
 
+use std::env::VarError;
 use std::path::Path;
 use std::{env, fs, io};
-use std::env::VarError;
 
-use cmake::Config;
 use cc::Build;
+use cmake::Config;
 use pkg_config::Config as PkgConfig;
 
 const GRPC_VERSION: &'static str = "1.6.1";

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -72,6 +72,9 @@ fn build_grpc(cc: &mut Build, library: &str) {
         if cfg!(target_os = "macos") {
             config.cxxflag("-stdlib=libc++");
         }
+        if cfg!(feature = "openssl") {
+            config.define("gRPC_SSL_PROVIDER", "package");
+        }
         config.build_target(library).uses_cxx11().build()
     };
 
@@ -116,7 +119,7 @@ fn build_grpc(cc: &mut Build, library: &str) {
     println!("cargo:rustc-link-lib=static=gpr");
     println!("cargo:rustc-link-lib=static={}", library);
 
-    if cfg!(feature = "secure") {
+    if cfg!(feature = "secure") && !cfg!(feature = "openssl") {
         println!("cargo:rustc-link-lib=static=ssl");
         println!("cargo:rustc-link-lib=static=crypto");
     }

--- a/grpc-sys/grpc_wrap.c
+++ b/grpc-sys/grpc_wrap.c
@@ -762,6 +762,16 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_initial_metadata(
                                NULL);
 }
 
+/** Kick call's completion queue, it should be called after there is an event
+    ready to poll.
+    THREAD SAFETY: grpcwrap_call_kick_completion_queue is thread-safe
+    because it does not change the call's state. */
+GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_kick_completion_queue(
+    grpc_call* call, void* tag) {
+  // Empty batch grpc_op kicks call's completion queue immediately.
+  return grpc_call_start_batch(call, NULL, 0, tag, NULL);
+}
+
 /* Server */
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE

--- a/grpc-sys/grpc_wrap.c
+++ b/grpc-sys/grpc_wrap.c
@@ -76,9 +76,9 @@
 #define GPR_CALLTYPE
 #endif
 
-grpc_byte_buffer *string_to_byte_buffer(const char *buffer, size_t len) {
+grpc_byte_buffer* string_to_byte_buffer(const char* buffer, size_t len) {
   grpc_slice slice = grpc_slice_from_copied_buffer(buffer, len);
-  grpc_byte_buffer *bb = grpc_raw_byte_buffer_create(&slice, 1);
+  grpc_byte_buffer* bb = grpc_raw_byte_buffer_create(&slice, 1);
   grpc_slice_unref(slice);
   return bb;
 }
@@ -88,12 +88,12 @@ grpc_byte_buffer *string_to_byte_buffer(const char *buffer, size_t len) {
  */
 typedef struct grpcwrap_batch_context {
   grpc_metadata_array send_initial_metadata;
-  grpc_byte_buffer *send_message;
+  grpc_byte_buffer* send_message;
   struct {
     grpc_metadata_array trailing_metadata;
   } send_status_from_server;
   grpc_metadata_array recv_initial_metadata;
-  grpc_byte_buffer *recv_message;
+  grpc_byte_buffer* recv_message;
   struct {
     grpc_metadata_array trailing_metadata;
     grpc_status_code status;
@@ -102,22 +102,22 @@ typedef struct grpcwrap_batch_context {
   int recv_close_on_server_cancelled;
 } grpcwrap_batch_context;
 
-GPR_EXPORT grpcwrap_batch_context *GPR_CALLTYPE
+GPR_EXPORT grpcwrap_batch_context* GPR_CALLTYPE
 grpcwrap_batch_context_create() {
-  grpcwrap_batch_context *ctx = gpr_malloc(sizeof(grpcwrap_batch_context));
+  grpcwrap_batch_context* ctx = gpr_malloc(sizeof(grpcwrap_batch_context));
   memset(ctx, 0, sizeof(grpcwrap_batch_context));
   return ctx;
 }
 
 typedef struct {
-  grpc_call *call;
+  grpc_call* call;
   grpc_call_details call_details;
   grpc_metadata_array request_metadata;
 } grpcwrap_request_call_context;
 
-GPR_EXPORT grpcwrap_request_call_context *GPR_CALLTYPE
+GPR_EXPORT grpcwrap_request_call_context* GPR_CALLTYPE
 grpcwrap_request_call_context_create() {
-  grpcwrap_request_call_context *ctx =
+  grpcwrap_request_call_context* ctx =
       gpr_malloc(sizeof(grpcwrap_request_call_context));
   memset(ctx, 0, sizeof(grpcwrap_request_call_context));
   return ctx;
@@ -127,7 +127,7 @@ grpcwrap_request_call_context_create() {
  * Destroys array->metadata.
  * The array pointer itself is not freed.
  */
-void grpcwrap_metadata_array_destroy_metadata_only(grpc_metadata_array *array) {
+void grpcwrap_metadata_array_destroy_metadata_only(grpc_metadata_array* array) {
   gpr_free(array->metadata);
 }
 
@@ -136,7 +136,7 @@ void grpcwrap_metadata_array_destroy_metadata_only(grpc_metadata_array *array) {
  * The array pointer itself is not freed.
  */
 void grpcwrap_metadata_array_destroy_metadata_including_entries(
-    grpc_metadata_array *array) {
+    grpc_metadata_array* array) {
   size_t i;
   if (array->metadata) {
     for (i = 0; i < array->count; i++) {
@@ -151,7 +151,7 @@ void grpcwrap_metadata_array_destroy_metadata_including_entries(
  * Fully destroys the metadata array.
  */
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_metadata_array_destroy_full(grpc_metadata_array *array) {
+grpcwrap_metadata_array_destroy_full(grpc_metadata_array* array) {
   if (!array) {
     return;
   }
@@ -163,7 +163,7 @@ grpcwrap_metadata_array_destroy_full(grpc_metadata_array *array) {
  * Allocate metadata array with given capacity.
  */
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_metadata_array_init(grpc_metadata_array *array, size_t capacity) {
+grpcwrap_metadata_array_init(grpc_metadata_array* array, size_t capacity) {
   array->count = 0;
   array->capacity = capacity;
   if (!capacity) {
@@ -171,15 +171,15 @@ grpcwrap_metadata_array_init(grpc_metadata_array *array, size_t capacity) {
     return;
   }
 
-  grpc_metadata *arr =
-      (grpc_metadata *)gpr_malloc(sizeof(grpc_metadata) * capacity);
+  grpc_metadata* arr =
+      (grpc_metadata*)gpr_malloc(sizeof(grpc_metadata) * capacity);
   memset(arr, 0, sizeof(grpc_metadata) * capacity);
   array->metadata = arr;
 }
 
 GPR_EXPORT void GPR_CALLTYPE grpcwrap_metadata_array_add(
-    grpc_metadata_array *array, const char *key, size_t key_length,
-    const char *value, size_t value_length) {
+    grpc_metadata_array* array, const char* key, size_t key_length,
+    const char* value, size_t value_length) {
   GPR_ASSERT(array->count <= array->capacity);
   size_t i = array->count;
   if (i == array->capacity) {
@@ -194,27 +194,27 @@ GPR_EXPORT void GPR_CALLTYPE grpcwrap_metadata_array_add(
   array->count++;
 }
 
-GPR_EXPORT const char *GPR_CALLTYPE grpcwrap_metadata_array_get_key(
-    const grpc_metadata_array *array, size_t index, size_t *key_length) {
+GPR_EXPORT const char* GPR_CALLTYPE grpcwrap_metadata_array_get_key(
+    const grpc_metadata_array* array, size_t index, size_t* key_length) {
   GPR_ASSERT(index < array->count);
   *key_length = GRPC_SLICE_LENGTH(array->metadata[index].key);
-  return (char *)GRPC_SLICE_START_PTR(array->metadata[index].key);
+  return (char*)GRPC_SLICE_START_PTR(array->metadata[index].key);
 }
 
-GPR_EXPORT const char *GPR_CALLTYPE grpcwrap_metadata_array_get_value(
-    const grpc_metadata_array *array, size_t index, size_t *value_length) {
+GPR_EXPORT const char* GPR_CALLTYPE grpcwrap_metadata_array_get_value(
+    const grpc_metadata_array* array, size_t index, size_t* value_length) {
   GPR_ASSERT(index < array->count);
   *value_length = GRPC_SLICE_LENGTH(array->metadata[index].value);
-  return (char *)GRPC_SLICE_START_PTR(array->metadata[index].value);
+  return (char*)GRPC_SLICE_START_PTR(array->metadata[index].value);
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_metadata_array_cleanup(grpc_metadata_array *array) {
+grpcwrap_metadata_array_cleanup(grpc_metadata_array* array) {
   grpcwrap_metadata_array_destroy_metadata_including_entries(array);
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_metadata_array_shrink_to_fit(grpc_metadata_array *array) {
+grpcwrap_metadata_array_shrink_to_fit(grpc_metadata_array* array) {
   GPR_ASSERT(array->count <= array->capacity);
   if (array->count == array->capacity) {
     return;
@@ -231,8 +231,8 @@ grpcwrap_metadata_array_shrink_to_fit(grpc_metadata_array *array) {
 }
 
 /* Move contents of metadata array */
-void grpcwrap_metadata_array_move(grpc_metadata_array *dest,
-                                  grpc_metadata_array *src) {
+void grpcwrap_metadata_array_move(grpc_metadata_array* dest,
+                                  grpc_metadata_array* src) {
   if (!src) {
     dest->capacity = 0;
     dest->count = 0;
@@ -250,7 +250,7 @@ void grpcwrap_metadata_array_move(grpc_metadata_array *dest,
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_batch_context_destroy(grpcwrap_batch_context *ctx) {
+grpcwrap_batch_context_destroy(grpcwrap_batch_context* ctx) {
   if (!ctx) {
     return;
   }
@@ -274,7 +274,7 @@ grpcwrap_batch_context_destroy(grpcwrap_batch_context *ctx) {
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_request_call_context_destroy(grpcwrap_request_call_context *ctx) {
+grpcwrap_request_call_context_destroy(grpcwrap_request_call_context* ctx) {
   if (!ctx) {
     return;
   }
@@ -289,14 +289,14 @@ grpcwrap_request_call_context_destroy(grpcwrap_request_call_context *ctx) {
   gpr_free(ctx);
 }
 
-GPR_EXPORT const grpc_metadata_array *GPR_CALLTYPE
+GPR_EXPORT const grpc_metadata_array* GPR_CALLTYPE
 grpcwrap_batch_context_recv_initial_metadata(
-    const grpcwrap_batch_context *ctx) {
+    const grpcwrap_batch_context* ctx) {
   return &(ctx->recv_initial_metadata);
 }
 
 GPR_EXPORT size_t GPR_CALLTYPE
-grpcwrap_batch_context_recv_message_length(const grpcwrap_batch_context *ctx) {
+grpcwrap_batch_context_recv_message_length(const grpcwrap_batch_context* ctx) {
   grpc_byte_buffer_reader reader;
   if (!ctx->recv_message) {
     return (size_t)-1;
@@ -314,7 +314,7 @@ grpcwrap_batch_context_recv_message_length(const grpcwrap_batch_context *ctx) {
  * buffer is too small.
  */
 GPR_EXPORT void GPR_CALLTYPE grpcwrap_batch_context_recv_message_to_buffer(
-    const grpcwrap_batch_context *ctx, char *buffer, size_t buffer_len) {
+    const grpcwrap_batch_context* ctx, char* buffer, size_t buffer_len) {
   grpc_byte_buffer_reader reader;
   grpc_slice slice;
   size_t offset = 0;
@@ -335,74 +335,73 @@ GPR_EXPORT void GPR_CALLTYPE grpcwrap_batch_context_recv_message_to_buffer(
 
 GPR_EXPORT grpc_status_code GPR_CALLTYPE
 grpcwrap_batch_context_recv_status_on_client_status(
-    const grpcwrap_batch_context *ctx) {
+    const grpcwrap_batch_context* ctx) {
   return ctx->recv_status_on_client.status;
 }
 
-GPR_EXPORT const char *GPR_CALLTYPE
+GPR_EXPORT const char* GPR_CALLTYPE
 grpcwrap_batch_context_recv_status_on_client_details(
-    const grpcwrap_batch_context *ctx, size_t *details_length) {
+    const grpcwrap_batch_context* ctx, size_t* details_length) {
   *details_length =
       GRPC_SLICE_LENGTH(ctx->recv_status_on_client.status_details);
-  return (char *)GRPC_SLICE_START_PTR(
-      ctx->recv_status_on_client.status_details);
+  return (char*)GRPC_SLICE_START_PTR(ctx->recv_status_on_client.status_details);
 }
 
-GPR_EXPORT const grpc_metadata_array *GPR_CALLTYPE
+GPR_EXPORT const grpc_metadata_array* GPR_CALLTYPE
 grpcwrap_batch_context_recv_status_on_client_trailing_metadata(
-    const grpcwrap_batch_context *ctx) {
+    const grpcwrap_batch_context* ctx) {
   return &(ctx->recv_status_on_client.trailing_metadata);
 }
 
-GPR_EXPORT grpc_call *GPR_CALLTYPE
-grpcwrap_request_call_context_ref_call(grpcwrap_request_call_context *ctx) {
-  grpc_call *call = ctx->call;
+GPR_EXPORT grpc_call* GPR_CALLTYPE
+grpcwrap_request_call_context_ref_call(grpcwrap_request_call_context* ctx) {
+  grpc_call* call = ctx->call;
   grpc_call_ref(call);
   return call;
 }
 
-GPR_EXPORT grpc_call *GPR_CALLTYPE
-grpcwrap_request_call_context_get_call(grpcwrap_request_call_context *ctx) {
+GPR_EXPORT grpc_call* GPR_CALLTYPE
+grpcwrap_request_call_context_get_call(grpcwrap_request_call_context* ctx) {
   return ctx->call;
 }
 
-GPR_EXPORT const char *GPR_CALLTYPE grpcwrap_request_call_context_method(
-    const grpcwrap_request_call_context *ctx, size_t *method_length) {
+GPR_EXPORT const char* GPR_CALLTYPE grpcwrap_request_call_context_method(
+    const grpcwrap_request_call_context* ctx, size_t* method_length) {
   *method_length = GRPC_SLICE_LENGTH(ctx->call_details.method);
-  return (char *)GRPC_SLICE_START_PTR(ctx->call_details.method);
+  return (char*)GRPC_SLICE_START_PTR(ctx->call_details.method);
 }
 
-GPR_EXPORT const char *GPR_CALLTYPE grpcwrap_request_call_context_host(
-    const grpcwrap_request_call_context *ctx, size_t *host_length) {
+GPR_EXPORT const char* GPR_CALLTYPE grpcwrap_request_call_context_host(
+    const grpcwrap_request_call_context* ctx, size_t* host_length) {
   *host_length = GRPC_SLICE_LENGTH(ctx->call_details.host);
-  return (char *)GRPC_SLICE_START_PTR(ctx->call_details.host);
+  return (char*)GRPC_SLICE_START_PTR(ctx->call_details.host);
 }
 
 GPR_EXPORT gpr_timespec GPR_CALLTYPE grpcwrap_request_call_context_deadline(
-    const grpcwrap_request_call_context *ctx) {
+    const grpcwrap_request_call_context* ctx) {
   return ctx->call_details.deadline;
 }
 
-GPR_EXPORT const grpc_metadata_array *GPR_CALLTYPE
+GPR_EXPORT const grpc_metadata_array* GPR_CALLTYPE
 grpcwrap_request_call_context_metadata_array(
-    const grpcwrap_request_call_context *ctx) {
+    const grpcwrap_request_call_context* ctx) {
   return &(ctx->request_metadata);
 }
 
 GPR_EXPORT int32_t GPR_CALLTYPE
 grpcwrap_batch_context_recv_close_on_server_cancelled(
-    const grpcwrap_batch_context *ctx) {
+    const grpcwrap_batch_context* ctx) {
   return (int32_t)ctx->recv_close_on_server_cancelled;
 }
 
 /* Channel */
 
-GPR_EXPORT grpc_call *GPR_CALLTYPE grpcwrap_channel_create_call(
-    grpc_channel *channel, grpc_call *parent_call, uint32_t propagation_mask,
-    grpc_completion_queue *cq, const char *method, size_t method_len,
-    const char *host, size_t host_len, gpr_timespec deadline) {
+GPR_EXPORT grpc_call* GPR_CALLTYPE grpcwrap_channel_create_call(
+    grpc_channel* channel, grpc_call* parent_call, uint32_t propagation_mask,
+    grpc_completion_queue* cq, const char* method, size_t method_len,
+    const char* host, size_t host_len, gpr_timespec deadline) {
   grpc_slice method_slice = grpc_slice_from_copied_buffer(method, method_len);
-  grpc_slice *host_slice_ptr = NULL;
+  grpc_slice* host_slice_ptr = NULL;
   grpc_slice host_slice;
   if (host != NULL) {
     host_slice = grpc_slice_from_copied_buffer(host, host_len);
@@ -411,7 +410,7 @@ GPR_EXPORT grpc_call *GPR_CALLTYPE grpcwrap_channel_create_call(
     // to silent msvc false warning
     host_slice = grpc_empty_slice();
   }
-  grpc_call *ret =
+  grpc_call* ret =
       grpc_channel_create_call(channel, parent_call, propagation_mask, cq,
                                method_slice, host_slice_ptr, deadline, NULL);
   grpc_slice_unref(method_slice);
@@ -423,20 +422,20 @@ GPR_EXPORT grpc_call *GPR_CALLTYPE grpcwrap_channel_create_call(
 
 /* Channel args */
 
-GPR_EXPORT grpc_channel_args *GPR_CALLTYPE
+GPR_EXPORT grpc_channel_args* GPR_CALLTYPE
 grpcwrap_channel_args_create(size_t num_args) {
-  grpc_channel_args *args =
-      (grpc_channel_args *)gpr_malloc(sizeof(grpc_channel_args));
+  grpc_channel_args* args =
+      (grpc_channel_args*)gpr_malloc(sizeof(grpc_channel_args));
   memset(args, 0, sizeof(grpc_channel_args));
 
   args->num_args = num_args;
-  args->args = (grpc_arg *)gpr_malloc(sizeof(grpc_arg) * num_args);
+  args->args = (grpc_arg*)gpr_malloc(sizeof(grpc_arg) * num_args);
   memset(args->args, 0, sizeof(grpc_arg) * num_args);
   return args;
 }
 
 GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_string(
-    grpc_channel_args *args, size_t index, const char *key, const char *value) {
+    grpc_channel_args* args, size_t index, const char* key, const char* value) {
   GPR_ASSERT(args);
   GPR_ASSERT(index < args->num_args);
   args->args[index].type = GRPC_ARG_STRING;
@@ -445,7 +444,7 @@ GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_string(
 }
 
 GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_integer(
-    grpc_channel_args *args, size_t index, const char *key, int value) {
+    grpc_channel_args* args, size_t index, const char* key, int value) {
   GPR_ASSERT(args);
   GPR_ASSERT(index < args->num_args);
   args->args[index].type = GRPC_ARG_INTEGER;
@@ -454,7 +453,7 @@ GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_integer(
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_channel_args_destroy(grpc_channel_args *args) {
+grpcwrap_channel_args_destroy(grpc_channel_args* args) {
   size_t i;
   if (args) {
     for (i = 0; i < args->num_args; i++) {
@@ -471,10 +470,10 @@ grpcwrap_channel_args_destroy(grpc_channel_args *args) {
 /* Call */
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_unary(
-    grpc_call *call, grpcwrap_batch_context *ctx, const char *send_buffer,
+    grpc_call* call, grpcwrap_batch_context* ctx, const char* send_buffer,
     size_t send_buffer_len, uint32_t write_flags,
-    grpc_metadata_array *initial_metadata, uint32_t initial_metadata_flags,
-    void *tag) {
+    grpc_metadata_array* initial_metadata, uint32_t initial_metadata_flags,
+    void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[6];
   memset(ops, 0, sizeof(ops));
@@ -522,9 +521,9 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_unary(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_client_streaming(
-    grpc_call *call, grpcwrap_batch_context *ctx,
-    grpc_metadata_array *initial_metadata, uint32_t initial_metadata_flags,
-    void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx,
+    grpc_metadata_array* initial_metadata, uint32_t initial_metadata_flags,
+    void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[4];
   memset(ops, 0, sizeof(ops));
@@ -562,10 +561,10 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_client_streaming(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_server_streaming(
-    grpc_call *call, grpcwrap_batch_context *ctx, const char *send_buffer,
+    grpc_call* call, grpcwrap_batch_context* ctx, const char* send_buffer,
     size_t send_buffer_len, uint32_t write_flags,
-    grpc_metadata_array *initial_metadata, uint32_t initial_metadata_flags,
-    void *tag) {
+    grpc_metadata_array* initial_metadata, uint32_t initial_metadata_flags,
+    void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[4];
   memset(ops, 0, sizeof(ops));
@@ -602,9 +601,9 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_server_streaming(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_duplex_streaming(
-    grpc_call *call, grpcwrap_batch_context *ctx,
-    grpc_metadata_array *initial_metadata, uint32_t initial_metadata_flags,
-    void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx,
+    grpc_metadata_array* initial_metadata, uint32_t initial_metadata_flags,
+    void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[2];
   memset(ops, 0, sizeof(ops));
@@ -631,7 +630,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_duplex_streaming(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_recv_initial_metadata(
-    grpc_call *call, grpcwrap_batch_context *ctx, void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[1];
   ops[0].op = GRPC_OP_RECV_INITIAL_METADATA;
@@ -645,9 +644,9 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_recv_initial_metadata(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_message(
-    grpc_call *call, grpcwrap_batch_context *ctx, const char *send_buffer,
+    grpc_call* call, grpcwrap_batch_context* ctx, const char* send_buffer,
     size_t send_buffer_len, uint32_t write_flags,
-    int32_t send_empty_initial_metadata, void *tag) {
+    int32_t send_empty_initial_metadata, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[2];
   memset(ops, 0, sizeof(ops));
@@ -665,7 +664,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_message(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE
-grpcwrap_call_send_close_from_client(grpc_call *call, void *tag) {
+grpcwrap_call_send_close_from_client(grpc_call* call, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[1];
   ops[0].op = GRPC_OP_SEND_CLOSE_FROM_CLIENT;
@@ -677,11 +676,11 @@ grpcwrap_call_send_close_from_client(grpc_call *call, void *tag) {
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_status_from_server(
-    grpc_call *call, grpcwrap_batch_context *ctx, grpc_status_code status_code,
-    const char *status_details, size_t status_details_len,
-    grpc_metadata_array *trailing_metadata, int32_t send_empty_initial_metadata,
-    const char *optional_send_buffer, size_t optional_send_buffer_len,
-    uint32_t write_flags, void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx, grpc_status_code status_code,
+    const char* status_details, size_t status_details_len,
+    grpc_metadata_array* trailing_metadata, int32_t send_empty_initial_metadata,
+    const char* optional_send_buffer, size_t optional_send_buffer_len,
+    uint32_t write_flags, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[3];
   memset(ops, 0, sizeof(ops));
@@ -720,7 +719,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_status_from_server(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_recv_message(
-    grpc_call *call, grpcwrap_batch_context *ctx, void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[1];
   ops[0].op = GRPC_OP_RECV_MESSAGE;
@@ -732,7 +731,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_recv_message(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_serverside(
-    grpc_call *call, grpcwrap_batch_context *ctx, void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[1];
   ops[0].op = GRPC_OP_RECV_CLOSE_ON_SERVER;
@@ -746,8 +745,8 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_serverside(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_initial_metadata(
-    grpc_call *call, grpcwrap_batch_context *ctx,
-    grpc_metadata_array *initial_metadata, void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx,
+    grpc_metadata_array* initial_metadata, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[1];
   memset(ops, 0, sizeof(ops));
@@ -766,8 +765,8 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_initial_metadata(
 /* Server */
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE
-grpcwrap_server_request_call(grpc_server *server, grpc_completion_queue *cq,
-                             grpcwrap_request_call_context *ctx, void *tag) {
+grpcwrap_server_request_call(grpc_server* server, grpc_completion_queue* cq,
+                             grpcwrap_request_call_context* ctx, void* tag) {
   return grpc_server_request_call(server, &(ctx->call), &(ctx->call_details),
                                   &(ctx->request_metadata), cq, cq, tag);
 }
@@ -776,10 +775,10 @@ grpcwrap_server_request_call(grpc_server *server, grpc_completion_queue *cq,
 
 /* Security */
 
-static char *default_pem_root_certs = NULL;
+static char* default_pem_root_certs = NULL;
 
 static grpc_ssl_roots_override_result override_ssl_roots_handler(
-    char **pem_root_certs) {
+    char** pem_root_certs) {
   if (!default_pem_root_certs) {
     *pem_root_certs = NULL;
     return GRPC_SSL_ROOTS_OVERRIDE_FAIL_PERMANENTLY;
@@ -789,7 +788,7 @@ static grpc_ssl_roots_override_result override_ssl_roots_handler(
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_override_default_ssl_roots(const char *pem_root_certs) {
+grpcwrap_override_default_ssl_roots(const char* pem_root_certs) {
   /*
    * This currently wastes ~300kB of memory by keeping a copy of roots
    * in a static variable, but for desktop/server use, the overhead
@@ -800,10 +799,10 @@ grpcwrap_override_default_ssl_roots(const char *pem_root_certs) {
   grpc_set_ssl_roots_override_callback(override_ssl_roots_handler);
 }
 
-GPR_EXPORT grpc_channel_credentials *GPR_CALLTYPE
-grpcwrap_ssl_credentials_create(const char *pem_root_certs,
-                                const char *key_cert_pair_cert_chain,
-                                const char *key_cert_pair_private_key) {
+GPR_EXPORT grpc_channel_credentials* GPR_CALLTYPE
+grpcwrap_ssl_credentials_create(const char* pem_root_certs,
+                                const char* key_cert_pair_cert_chain,
+                                const char* key_cert_pair_private_key) {
   grpc_ssl_pem_key_cert_pair key_cert_pair;
   if (key_cert_pair_cert_chain || key_cert_pair_private_key) {
     key_cert_pair.cert_chain = key_cert_pair_cert_chain;
@@ -816,14 +815,14 @@ grpcwrap_ssl_credentials_create(const char *pem_root_certs,
   }
 }
 
-GPR_EXPORT grpc_server_credentials *GPR_CALLTYPE
+GPR_EXPORT grpc_server_credentials* GPR_CALLTYPE
 grpcwrap_ssl_server_credentials_create(
-    const char *pem_root_certs, const char **key_cert_pair_cert_chain_array,
-    const char **key_cert_pair_private_key_array, size_t num_key_cert_pairs,
+    const char* pem_root_certs, const char** key_cert_pair_cert_chain_array,
+    const char** key_cert_pair_private_key_array, size_t num_key_cert_pairs,
     int force_client_auth) {
   size_t i;
-  grpc_server_credentials *creds;
-  grpc_ssl_pem_key_cert_pair *key_cert_pairs =
+  grpc_server_credentials* creds;
+  grpc_ssl_pem_key_cert_pair* key_cert_pairs =
       gpr_malloc(sizeof(grpc_ssl_pem_key_cert_pair) * num_key_cert_pairs);
   memset(key_cert_pairs, 0,
          sizeof(grpc_ssl_pem_key_cert_pair) * num_key_cert_pairs);

--- a/grpc-sys/grpc_wrap.cc
+++ b/grpc-sys/grpc_wrap.cc
@@ -55,7 +55,7 @@
 #include <grpc/support/log.h>
 #include <grpc/support/port_platform.h>
 #include <grpc/support/string_util.h>
-#include <grpc/support/thd.h>
+#include <grpc/support/thd_id.h>
 
 #ifdef GRPC_SYS_SECURE
 #include <grpc/grpc_security.h>
@@ -64,12 +64,12 @@
 #include <string.h>
 
 #ifdef GPR_WINDOWS
-#define GPR_EXPORT __declspec(dllexport)
+#define GPR_EXPORT extern "C" __declspec(dllexport)
 #define GPR_CALLTYPE __cdecl
 #endif
 
 #ifndef GPR_EXPORT
-#define GPR_EXPORT
+#define GPR_EXPORT extern "C"
 #endif
 
 #ifndef GPR_CALLTYPE
@@ -104,7 +104,8 @@ typedef struct grpcwrap_batch_context {
 
 GPR_EXPORT grpcwrap_batch_context* GPR_CALLTYPE
 grpcwrap_batch_context_create() {
-  grpcwrap_batch_context* ctx = gpr_malloc(sizeof(grpcwrap_batch_context));
+  grpcwrap_batch_context* ctx =
+      (grpcwrap_batch_context*)gpr_malloc(sizeof(grpcwrap_batch_context));
   memset(ctx, 0, sizeof(grpcwrap_batch_context));
   return ctx;
 }
@@ -118,7 +119,8 @@ typedef struct {
 GPR_EXPORT grpcwrap_request_call_context* GPR_CALLTYPE
 grpcwrap_request_call_context_create() {
   grpcwrap_request_call_context* ctx =
-      gpr_malloc(sizeof(grpcwrap_request_call_context));
+      (grpcwrap_request_call_context*)gpr_malloc(
+          sizeof(grpcwrap_request_call_context));
   memset(ctx, 0, sizeof(grpcwrap_request_call_context));
   return ctx;
 }
@@ -184,8 +186,8 @@ GPR_EXPORT void GPR_CALLTYPE grpcwrap_metadata_array_add(
   size_t i = array->count;
   if (i == array->capacity) {
     array->capacity = array->capacity ? array->capacity * 2 : 4;
-    array->metadata =
-        gpr_realloc(array->metadata, array->capacity * sizeof(grpc_metadata));
+    array->metadata = (grpc_metadata*)gpr_realloc(
+        array->metadata, array->capacity * sizeof(grpc_metadata));
     memset(array->metadata + i, 0,
            sizeof(grpc_metadata) * (array->capacity - i));
   }
@@ -220,8 +222,8 @@ grpcwrap_metadata_array_shrink_to_fit(grpc_metadata_array* array) {
     return;
   }
   if (array->count) {
-    array->metadata =
-        gpr_realloc(array->metadata, array->count * sizeof(grpc_metadata));
+    array->metadata = (grpc_metadata*)gpr_realloc(
+        array->metadata, array->count * sizeof(grpc_metadata));
     array->capacity = array->count;
   } else {
     grpcwrap_metadata_array_cleanup(array);
@@ -817,11 +819,11 @@ grpcwrap_ssl_credentials_create(const char* pem_root_certs,
   if (key_cert_pair_cert_chain || key_cert_pair_private_key) {
     key_cert_pair.cert_chain = key_cert_pair_cert_chain;
     key_cert_pair.private_key = key_cert_pair_private_key;
-    return grpc_ssl_credentials_create(pem_root_certs, &key_cert_pair, NULL);
+    return grpc_ssl_credentials_create(pem_root_certs, &key_cert_pair, NULL, NULL);
   } else {
     GPR_ASSERT(!key_cert_pair_cert_chain);
     GPR_ASSERT(!key_cert_pair_private_key);
-    return grpc_ssl_credentials_create(pem_root_certs, NULL, NULL);
+    return grpc_ssl_credentials_create(pem_root_certs, NULL, NULL, NULL);
   }
 }
 
@@ -833,7 +835,8 @@ grpcwrap_ssl_server_credentials_create(
   size_t i;
   grpc_server_credentials* creds;
   grpc_ssl_pem_key_cert_pair* key_cert_pairs =
-      gpr_malloc(sizeof(grpc_ssl_pem_key_cert_pair) * num_key_cert_pairs);
+      (grpc_ssl_pem_key_cert_pair*)gpr_malloc(
+          sizeof(grpc_ssl_pem_key_cert_pair) * num_key_cert_pairs);
   memset(key_cert_pairs, 0,
          sizeof(grpc_ssl_pem_key_cert_pair) * num_key_cert_pairs);
 

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -348,17 +348,12 @@ pub struct GrpcMetadataArray {
     pub metadata: *mut GrpcMetadata,
 }
 
-#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
-pub const GRPC_INITIAL_METADATA_IDEMPOTENT_REQUEST: uint32_t = 0x00000010;
-#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
-pub const GRPC_INITIAL_METADATA_WAIT_FOR_READY: uint32_t = 0x00000020;
-#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
-pub const GRPC_INITIAL_METADATA_CACHEABLE_REQUEST: uint32_t = 0x00000040;
+pub const GRPC_INITIAL_METADATA_IDEMPOTENT_REQUEST: uint32_t = 0x0000_0010;
+pub const GRPC_INITIAL_METADATA_WAIT_FOR_READY: uint32_t = 0x0000_0020;
+pub const GRPC_INITIAL_METADATA_CACHEABLE_REQUEST: uint32_t = 0x0000_0040;
 
-#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
-pub const GRPC_WRITE_BUFFER_HINT: uint32_t = 0x00000001;
-#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
-pub const GRPC_WRITE_NO_COMPRESS: uint32_t = 0x00000002;
+pub const GRPC_WRITE_BUFFER_HINT: uint32_t = 0x0000_0001;
+pub const GRPC_WRITE_NO_COMPRESS: uint32_t = 0x0000_0002;
 
 pub enum GrpcMetadata {}
 pub enum GrpcSlice {}

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -15,10 +15,7 @@
 
 extern crate libc;
 
-#[cfg(feature = "openssl")]
-extern crate openssl;
-
-use libc::{c_char, c_int, c_uint, c_void, size_t, int32_t, int64_t, uint32_t};
+use libc::{c_char, c_int, c_uint, c_void, int32_t, int64_t, size_t, uint32_t};
 use std::time::Duration;
 
 /// The clocks gRPC supports.
@@ -351,11 +348,16 @@ pub struct GrpcMetadataArray {
     pub metadata: *mut GrpcMetadata,
 }
 
+#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 pub const GRPC_INITIAL_METADATA_IDEMPOTENT_REQUEST: uint32_t = 0x00000010;
+#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 pub const GRPC_INITIAL_METADATA_WAIT_FOR_READY: uint32_t = 0x00000020;
+#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 pub const GRPC_INITIAL_METADATA_CACHEABLE_REQUEST: uint32_t = 0x00000040;
 
+#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 pub const GRPC_WRITE_BUFFER_HINT: uint32_t = 0x00000001;
+#[cfg_attr(feature = "cargo-clippy", allow(unreadable_literal))]
 pub const GRPC_WRITE_NO_COMPRESS: uint32_t = 0x00000002;
 
 pub enum GrpcMetadata {}

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -15,6 +15,9 @@
 
 extern crate libc;
 
+#[cfg(feature = "openssl")]
+extern crate openssl;
+
 use libc::{c_char, c_int, c_uint, c_void, size_t, int32_t, int64_t, uint32_t};
 use std::time::Duration;
 

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -365,7 +365,6 @@ pub enum GrpcByteBuffer {}
 pub enum GrpcBatchContext {}
 pub enum GrpcServer {}
 pub enum GrpcRequestCallContext {}
-pub enum GrpcAlarm {}
 
 pub const GRPC_MAX_COMPLETION_QUEUE_PLUCKERS: usize = 6;
 
@@ -624,17 +623,6 @@ extern "C" {
         ctx: *mut GrpcRequestCallContext,
         tag: *mut c_void,
     ) -> GrpcCallStatus;
-
-    pub fn grpc_alarm_create(reserved: *mut c_void) -> *mut GrpcAlarm;
-    pub fn grpc_alarm_set(
-        alarm: *mut GrpcAlarm,
-        cq: *mut GrpcCompletionQueue,
-        deadline: GprTimespec,
-        tag: *mut c_void,
-        reserved: *mut c_void,
-    ) -> *mut GrpcAlarm;
-    pub fn grpc_alarm_cancel(alarm: *mut GrpcAlarm);
-    pub fn grpc_alarm_destroy(alarm: *mut GrpcAlarm);
 
     pub fn grpcwrap_metadata_array_init(array: *mut GrpcMetadataArray, capacity: size_t);
     pub fn grpcwrap_metadata_array_add(

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -469,6 +469,11 @@ extern "C" {
         ctx: *mut GrpcBatchContext,
     ) -> int32_t;
 
+    pub fn grpcwrap_call_kick_completion_queue(
+        call: *mut GrpcCall,
+        tag: *mut c_void,
+    ) -> GrpcCallStatus;
+
     pub fn grpcwrap_call_start_unary(
         call: *mut GrpcCall,
         ctx: *mut GrpcBatchContext,
@@ -559,6 +564,7 @@ extern "C" {
         description: *const c_char,
         reserved: *mut c_void,
     );
+    pub fn grpc_call_ref(call: *mut GrpcCall);
     pub fn grpc_call_unref(call: *mut GrpcCall);
 
     pub fn grpc_server_register_method(

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -11,6 +11,7 @@ protobuf = "~2.0"
 futures = "0.1"
 log = "0.3"
 clap = "2.23"
+futures-timer = "0.1"
 
 [[bin]]
 name = "interop_client"

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -22,11 +22,11 @@ extern crate log;
 use std::sync::Arc;
 
 use clap::{App, Arg};
+use futures::{future, Future};
 use grpc::{Environment, ServerBuilder};
-use interop::InteropTestService;
 use grpc_proto::testing::test_grpc;
 use grpc_proto::util;
-use futures::{future, Future};
+use interop::InteropTestService;
 
 fn main() {
     let matches = App::new("Interoperability Test Server")

--- a/interop/src/client.rs
+++ b/interop/src/client.rs
@@ -167,7 +167,7 @@ impl Client {
 
     pub fn timeout_on_sleeping_server(&self) {
         print!("testing timeout_of_sleeping_server ... ");
-        let opt = CallOption::default().timeout(Duration::new(0, 10_000));
+        let opt = CallOption::default().timeout(Duration::from_millis(1));
         let (sender, receiver) = self.client.full_duplex_call_opt(opt).unwrap();
         let mut req = StreamingOutputCallRequest::new();
         req.set_payload(util::new_payload(27182));

--- a/interop/src/client.rs
+++ b/interop/src/client.rs
@@ -14,13 +14,14 @@
 use std::thread;
 use std::time::Duration;
 
-use grpc::{self, CallOption, Channel, RpcStatusCode, WriteFlags};
 use futures::{future, stream, Future, Sink, Stream};
+use grpc::{self, CallOption, Channel, RpcStatusCode, WriteFlags};
 
-use grpc_proto::testing::test_grpc::{TestServiceClient, UnimplementedServiceClient};
 use grpc_proto::testing::empty::Empty;
-use grpc_proto::testing::messages::{EchoStatus, SimpleRequest, StreamingInputCallRequest,
-                                    StreamingOutputCallRequest};
+use grpc_proto::testing::messages::{
+    EchoStatus, SimpleRequest, StreamingInputCallRequest, StreamingOutputCallRequest,
+};
+use grpc_proto::testing::test_grpc::{TestServiceClient, UnimplementedServiceClient};
 use grpc_proto::util;
 
 pub struct Client {
@@ -47,10 +48,10 @@ impl Client {
     pub fn large_unary(&self) {
         print!("testing large unary ... ");
         let mut req = SimpleRequest::new();
-        req.set_response_size(314159);
-        req.set_payload(util::new_payload(271828));
+        req.set_response_size(314_159);
+        req.set_payload(util::new_payload(271_828));
         let resp = self.client.unary_call(&req).unwrap();
-        assert_eq!(314159, resp.get_payload().get_body().len());
+        assert_eq!(314_159, resp.get_payload().get_body().len());
         println!("pass");
     }
 
@@ -80,7 +81,8 @@ impl Client {
                 .push(util::new_parameters(*size));
         }
         let resp = self.client.streaming_output_call(&req).unwrap();
-        let resp_sizes = resp.map(|r| r.get_payload().get_body().len() as i32)
+        let resp_sizes = resp
+            .map(|r| r.get_payload().get_body().len() as i32)
             .collect()
             .wait()
             .unwrap();

--- a/interop/src/lib.rs
+++ b/interop/src/lib.rs
@@ -19,6 +19,7 @@ extern crate grpcio as grpc;
 extern crate grpcio_proto as grpc_proto;
 #[macro_use]
 extern crate log;
+extern crate futures_timer;
 
 mod client;
 mod server;

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -42,7 +42,7 @@ impl From<grpc::Error> for Error {
 pub struct InteropTestService;
 
 impl TestService for InteropTestService {
-    fn empty_call(&self, ctx: RpcContext, _: Empty, resp: UnarySink<Empty>) {
+    fn empty_call(&mut self, ctx: RpcContext, _: Empty, resp: UnarySink<Empty>) {
         let res = Empty::new();
         let f = resp
             .success(res)
@@ -50,7 +50,12 @@ impl TestService for InteropTestService {
         ctx.spawn(f)
     }
 
-    fn unary_call(&self, ctx: RpcContext, mut req: SimpleRequest, sink: UnarySink<SimpleResponse>) {
+    fn unary_call(
+        &mut self,
+        ctx: RpcContext,
+        mut req: SimpleRequest,
+        sink: UnarySink<SimpleResponse>,
+    ) {
         if req.has_response_status() {
             let code = req.get_response_status().get_code();
             let msg = Some(req.take_response_status().take_message());
@@ -70,12 +75,17 @@ impl TestService for InteropTestService {
         ctx.spawn(f)
     }
 
-    fn cacheable_unary_call(&self, _: RpcContext, _: SimpleRequest, _: UnarySink<SimpleResponse>) {
+    fn cacheable_unary_call(
+        &mut self,
+        _: RpcContext,
+        _: SimpleRequest,
+        _: UnarySink<SimpleResponse>,
+    ) {
         unimplemented!()
     }
 
     fn streaming_output_call(
-        &self,
+        &mut self,
         ctx: RpcContext,
         mut req: StreamingOutputCallRequest,
         sink: ServerStreamingSink<StreamingOutputCallResponse>,
@@ -93,7 +103,7 @@ impl TestService for InteropTestService {
     }
 
     fn streaming_input_call(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<StreamingInputCallRequest>,
         sink: ClientStreamingSink<StreamingInputCallResponse>,
@@ -115,7 +125,7 @@ impl TestService for InteropTestService {
     }
 
     fn full_duplex_call(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<StreamingOutputCallRequest>,
         sink: DuplexSink<StreamingOutputCallResponse>,
@@ -170,7 +180,7 @@ impl TestService for InteropTestService {
     }
 
     fn half_duplex_call(
-        &self,
+        &mut self,
         _: RpcContext,
         _: RequestStream<StreamingOutputCallRequest>,
         _: DuplexSink<StreamingOutputCallResponse>,
@@ -178,7 +188,7 @@ impl TestService for InteropTestService {
         unimplemented!()
     }
 
-    fn unimplemented_call(&self, ctx: RpcContext, _: Empty, sink: UnarySink<Empty>) {
+    fn unimplemented_call(&mut self, ctx: RpcContext, _: Empty, sink: UnarySink<Empty>) {
         let f = sink
             .fail(RpcStatus::new(RpcStatusCode::Unimplemented, None))
             .map_err(|e| error!("failed to report unimplemented method: {:?}", e));

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -11,15 +11,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use grpc::{self, ClientStreamingSink, DuplexSink, RequestStream, RpcContext, RpcStatus,
-           RpcStatusCode, ServerStreamingSink, UnarySink, WriteFlags};
 use futures::{future, stream, Async, Future, Poll, Sink, Stream};
+use grpc::{
+    self, ClientStreamingSink, DuplexSink, RequestStream, RpcContext, RpcStatus, RpcStatusCode,
+    ServerStreamingSink, UnarySink, WriteFlags,
+};
 
-use grpc_proto::testing::test_grpc::TestService;
 use grpc_proto::testing::empty::Empty;
-use grpc_proto::testing::messages::{SimpleRequest, SimpleResponse, StreamingInputCallRequest,
-                                    StreamingInputCallResponse, StreamingOutputCallRequest,
-                                    StreamingOutputCallResponse};
+use grpc_proto::testing::messages::{
+    SimpleRequest, SimpleResponse, StreamingInputCallRequest, StreamingInputCallResponse,
+    StreamingOutputCallRequest, StreamingOutputCallResponse,
+};
+use grpc_proto::testing::test_grpc::TestService;
 use grpc_proto::util;
 
 enum Error {
@@ -39,7 +42,8 @@ pub struct InteropTestService;
 impl TestService for InteropTestService {
     fn empty_call(&self, ctx: RpcContext, _: Empty, resp: UnarySink<Empty>) {
         let res = Empty::new();
-        let f = resp.success(res)
+        let f = resp
+            .success(res)
             .map_err(|e| panic!("failed to send response: {:?}", e));
         ctx.spawn(f)
     }
@@ -49,7 +53,8 @@ impl TestService for InteropTestService {
             let code = req.get_response_status().get_code();
             let msg = Some(req.take_response_status().take_message());
             let status = RpcStatus::new(code.into(), msg);
-            let f = sink.fail(status)
+            let f = sink
+                .fail(status)
                 .map_err(|e| panic!("failed to send response: {:?}", e));
             ctx.spawn(f);
             return;
@@ -57,7 +62,8 @@ impl TestService for InteropTestService {
         let resp_size = req.get_response_size();
         let mut resp = SimpleResponse::new();
         resp.set_payload(util::new_payload(resp_size as usize));
-        let f = sink.success(resp)
+        let f = sink
+            .success(resp)
             .map_err(|e| panic!("failed to send response: {:?}", e));
         ctx.spawn(f)
     }
@@ -77,7 +83,8 @@ impl TestService for InteropTestService {
             resp.set_payload(util::new_payload(param.get_size() as usize));
             (resp, WriteFlags::default())
         });
-        let f = sink.send_all(stream::iter_ok::<_, grpc::Error>(resps))
+        let f = sink
+            .send_all(stream::iter_ok::<_, grpc::Error>(resps))
             .map(|_| {})
             .map_err(|e| panic!("failed to send response: {:?}", e));
         ctx.spawn(f)
@@ -158,7 +165,8 @@ impl TestService for InteropTestService {
     }
 
     fn unimplemented_call(&self, ctx: RpcContext, _: Empty, sink: UnarySink<Empty>) {
-        let f = sink.fail(RpcStatus::new(RpcStatusCode::Unimplemented, None))
+        let f = sink
+            .fail(RpcStatus::new(RpcStatusCode::Unimplemented, None))
             .map_err(|e| error!("failed to report unimplemented method: {:?}", e));
         ctx.spawn(f)
     }

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -11,6 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::{thread::sleep, time::Duration};
+
 use futures::{future, stream, Async, Future, Poll, Sink, Stream};
 use grpc::{
     self, ClientStreamingSink, DuplexSink, RequestStream, RpcContext, RpcStatus, RpcStatusCode,
@@ -132,6 +134,18 @@ impl TestService for InteropTestService {
                     let mut resp = StreamingOutputCallResponse::new();
                     if let Some(param) = req.get_response_parameters().get(0) {
                         resp.set_payload(util::new_payload(param.get_size() as usize));
+                    }
+                    // A workaround for timeout_on_sleeping_server test.
+                    // The request only has 27182 bytes of zeros in payload.
+                    //
+                    // Client timeout 1ms is too short for grpcio. The server
+                    // can response in 1ms. To make the test stable, the server
+                    // sleeps 10ms explicitly.
+                    if req.get_payload().get_body().len() == 27182
+                        && req.get_response_parameters().is_empty()
+                        && !req.has_response_status()
+                    {
+                        sleep(Duration::from_millis(10));
                     }
                     send = Some(sink.send((resp, WriteFlags::default())));
                 }

--- a/interop/tests/tests.rs
+++ b/interop/tests/tests.rs
@@ -16,7 +16,7 @@ extern crate grpcio_proto as grpc_proto;
 extern crate interop;
 
 macro_rules! mk_test {
-    ($case_name:ident, $func:ident, $use_tls:expr) => (
+    ($case_name:ident, $func:ident, $use_tls:expr) => {
         #[test]
         fn $case_name() {
             let env = Arc::new(Environment::new(2));
@@ -34,8 +34,8 @@ macro_rules! mk_test {
             let mut server = builder.build().unwrap();
             server.start();
 
-            let builder = ChannelBuilder::new(env.clone())
-                              .override_ssl_target("foo.test.google.fr");
+            let builder =
+                ChannelBuilder::new(env.clone()).override_ssl_target("foo.test.google.fr");
             let channel = {
                 let (ref host, port) = server.bind_addrs()[0];
                 if $use_tls {
@@ -50,15 +50,15 @@ macro_rules! mk_test {
 
             client.$func();
         }
-    );
+    };
     ($func:ident) => {
         mod $func {
             use std::sync::Arc;
 
-            use grpc::{Environment, ServerBuilder, ChannelBuilder};
-            use interop::{InteropTestService, Client};
+            use grpc::{ChannelBuilder, Environment, ServerBuilder};
             use grpc_proto::testing::test_grpc;
             use grpc_proto::util;
+            use interop::{Client, InteropTestService};
 
             mk_test!(test_insecure, $func, false);
             mk_test!(test_secure, $func, true);

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -14,7 +14,7 @@ build = "build.rs"
 [dependencies]
 protobuf = "~2.0"
 futures = "0.1"
-grpcio = { path = "..", version = "0.2.2", features = ["secure"] }
+grpcio = { path = "..", version = "0.2.2" }
 
 [build-dependencies]
 protobuf = "~2.0"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-proto"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["grpc", "proto"]
@@ -14,9 +14,9 @@ build = "build.rs"
 [dependencies]
 protobuf = "~2.0"
 futures = "0.1"
-grpcio = { path = "..", version = "0.2.2" }
+grpcio = { path = "..", version = "0.3.0" }
 
 [build-dependencies]
 protobuf = "~2.0"
 protobuf-codegen = "~2.0"
-grpcio-compiler = { path = "../compiler", version = "0.2.0" }
+grpcio-compiler = { path = "../compiler", version = "0.3.0" }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "grpcio-proto"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["The TiKV Project Developers"]
 license = "Apache-2.0"
 keywords = ["grpc", "proto"]
@@ -14,9 +14,9 @@ build = "build.rs"
 [dependencies]
 protobuf = "~2.0"
 futures = "0.1"
-grpcio = { path = "..", version = "0.3.0" }
+grpcio = { path = "..", version = "0.4.0" }
 
 [build-dependencies]
 protobuf = "~2.0"
 protobuf-codegen = "~2.0"
-grpcio-compiler = { path = "../compiler", version = "0.3.0" }
+grpcio-compiler = { path = "../compiler", version = "0.4.0" }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -15,16 +15,16 @@ extern crate grpcio_compiler;
 extern crate protobuf;
 extern crate protobuf_codegen;
 
-use std::fs::{self, File};
 use std::env;
+use std::fs::{self, File};
 use std::io::Write;
 use std::path::Path;
 
 use grpcio_compiler::codegen as grpc_gen;
-use protobuf_codegen as pb_gen;
-use protobuf::compiler_plugin::GenResult;
 use pb_gen::Customize;
+use protobuf::compiler_plugin::GenResult;
 use protobuf::descriptor::{FileDescriptorProto, FileDescriptorSet};
+use protobuf_codegen as pb_gen;
 
 /// Descriptor file to module file.
 fn desc_to_module<G, W>(descriptor: &Path, output_dir: &Path, mut gen: G, mut module: W)

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -11,6 +11,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+// TODO: Remove it once Rust's tool_lints is stabilized.
+// There are some clippy lints in the generated protobuf files.
+#![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
+
 extern crate futures;
 extern crate grpcio;
 extern crate protobuf;

--- a/proto/src/util.rs
+++ b/proto/src/util.rs
@@ -11,8 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use grpcio::{ChannelCredentials, ChannelCredentialsBuilder, ServerCredentials,
-             ServerCredentialsBuilder};
+use grpcio::{
+    ChannelCredentials, ChannelCredentialsBuilder, ServerCredentials, ServerCredentialsBuilder,
+};
 
 use testing::messages::{Payload, ResponseParameters};
 

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,3 +1,0 @@
-reorder_imports = false
-reorder_imported_names = true
-use_try_shorthand = true

--- a/scripts/format-grpc-sys
+++ b/scripts/format-grpc-sys
@@ -1,2 +1,2 @@
 #!/usr/bin/env bash
-clang-format-5.0 -i grpc-sys/grpc_wrap.c
+clang-format-5.0 -i grpc-sys/grpc_wrap.cc

--- a/scripts/format-grpc-sys
+++ b/scripts/format-grpc-sys
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+clang-format-5.0 -i grpc-sys/grpc_wrap.c

--- a/src/async/callback.rs
+++ b/src/async/callback.rs
@@ -13,8 +13,8 @@
 
 use std::sync::Arc;
 
-use call::{BatchContext, Call};
 use call::server::{RequestContext, UnaryRequestContext};
+use call::{BatchContext, Call};
 use cq::CompletionQueue;
 use server::{self, Inner as ServerInner};
 

--- a/src/async/callback.rs
+++ b/src/async/callback.rs
@@ -25,7 +25,7 @@ pub struct Request {
 impl Request {
     pub fn new(inner: Arc<ServerInner>) -> Request {
         let ctx = RequestContext::new(inner);
-        Request { ctx: ctx }
+        Request { ctx }
     }
 
     pub fn context(&self) -> &RequestContext {
@@ -53,7 +53,7 @@ pub struct UnaryRequest {
 impl UnaryRequest {
     pub fn new(ctx: RequestContext, inner: Arc<ServerInner>) -> UnaryRequest {
         let ctx = UnaryRequestContext::new(ctx, inner);
-        UnaryRequest { ctx: ctx }
+        UnaryRequest { ctx }
     }
 
     pub fn batch_ctx(&self) -> &BatchContext {

--- a/src/async/callback.rs
+++ b/src/async/callback.rs
@@ -31,13 +31,13 @@ impl Request {
     }
 
     pub fn resolve(mut self, cq: &CompletionQueue, success: bool) {
-        let rc = self.ctx.take_request_call_context().unwrap();
+        let mut rc = self.ctx.take_request_call_context().unwrap();
         if !success {
             server::request_call(rc, cq);
             return;
         }
 
-        match self.ctx.handle_stream_req(cq, &rc) {
+        match self.ctx.handle_stream_req(cq, &mut rc) {
             Ok(_) => server::request_call(rc, cq),
             Err(ctx) => ctx.handle_unary_req(rc, cq),
         }
@@ -63,7 +63,7 @@ impl UnaryRequest {
     }
 
     pub fn resolve(mut self, cq: &CompletionQueue, success: bool) {
-        let rc = self.ctx.take_request_call_context().unwrap();
+        let mut rc = self.ctx.take_request_call_context().unwrap();
         if !success {
             server::request_call(rc, cq);
             return;
@@ -71,7 +71,7 @@ impl UnaryRequest {
 
         let data = self.ctx.batch_ctx().recv_message();
         self.ctx
-            .handle(&rc, cq, data.as_ref().map(|v| v.as_slice()));
+            .handle(&mut rc, cq, data.as_ref().map(|v| v.as_slice()));
         server::request_call(rc, cq);
     }
 }

--- a/src/async/callback.rs
+++ b/src/async/callback.rs
@@ -11,20 +11,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
-
 use call::server::{RequestContext, UnaryRequestContext};
 use call::{BatchContext, Call};
 use cq::CompletionQueue;
-use server::{self, Inner as ServerInner};
+use server::{self, RequestCallContext};
 
 pub struct Request {
     ctx: RequestContext,
 }
 
 impl Request {
-    pub fn new(inner: Arc<ServerInner>) -> Request {
-        let ctx = RequestContext::new(inner);
+    pub fn new(rc: RequestCallContext) -> Request {
+        let ctx = RequestContext::new(rc);
         Request { ctx }
     }
 
@@ -33,15 +31,15 @@ impl Request {
     }
 
     pub fn resolve(mut self, cq: &CompletionQueue, success: bool) {
-        let inner = self.ctx.take_inner().unwrap();
+        let rc = self.ctx.take_request_call_context().unwrap();
         if !success {
-            server::request_call(inner, cq);
+            server::request_call(rc, cq);
             return;
         }
 
-        match self.ctx.handle_stream_req(cq, &inner) {
-            Ok(_) => server::request_call(inner, cq),
-            Err(ctx) => ctx.handle_unary_req(inner, cq),
+        match self.ctx.handle_stream_req(cq, &rc) {
+            Ok(_) => server::request_call(rc, cq),
+            Err(ctx) => ctx.handle_unary_req(rc, cq),
         }
     }
 }
@@ -51,8 +49,8 @@ pub struct UnaryRequest {
 }
 
 impl UnaryRequest {
-    pub fn new(ctx: RequestContext, inner: Arc<ServerInner>) -> UnaryRequest {
-        let ctx = UnaryRequestContext::new(ctx, inner);
+    pub fn new(ctx: RequestContext, rc: RequestCallContext) -> UnaryRequest {
+        let ctx = UnaryRequestContext::new(ctx, rc);
         UnaryRequest { ctx }
     }
 
@@ -65,16 +63,16 @@ impl UnaryRequest {
     }
 
     pub fn resolve(mut self, cq: &CompletionQueue, success: bool) {
-        let inner = self.ctx.take_inner().unwrap();
+        let rc = self.ctx.take_request_call_context().unwrap();
         if !success {
-            server::request_call(inner, cq);
+            server::request_call(rc, cq);
             return;
         }
 
         let data = self.ctx.batch_ctx().recv_message();
         self.ctx
-            .handle(&inner, cq, data.as_ref().map(|v| v.as_slice()));
-        server::request_call(inner, cq);
+            .handle(&rc, cq, data.as_ref().map(|v| v.as_slice()));
+        server::request_call(rc, cq);
     }
 }
 

--- a/src/async/executor.rs
+++ b/src/async/executor.rs
@@ -11,81 +11,83 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::ptr;
 use std::sync::Arc;
 use std::thread::{self, ThreadId};
 
 use futures::executor::{self, Notify, Spawn};
 use futures::{Async, Future};
-use grpc_sys::{self, GprTimespec, GrpcAlarm};
 
 use super::lock::SpinLock;
 use super::CallTag;
+use call::Call;
 use cq::CompletionQueue;
 use error::{Error, Result};
+use grpc_sys::{self, GrpcCallStatus};
 
 type BoxFuture<T, E> = Box<Future<Item = T, Error = E> + Send>;
-
-struct Alarm {
-    alarm: *mut GrpcAlarm,
-}
-
-impl Alarm {
-    fn new(cq: &CompletionQueue, tag: Box<CallTag>) -> Result<Alarm> {
-        let alarm = unsafe {
-            let ptr = Box::into_raw(tag);
-            let timeout = GprTimespec::inf_future();
-            let cq_ref = cq.borrow()?;
-            let alarm = grpc_sys::grpc_alarm_create(ptr::null_mut());
-            grpc_sys::grpc_alarm_set(alarm, cq_ref.as_ptr(), timeout, ptr as _, ptr::null_mut());
-            alarm
-        };
-        Ok(Alarm { alarm })
-    }
-
-    fn alarm(&mut self) {
-        // hack: because grpc's alarm feels more like a timer,
-        // but what we need here is a notification hook. Hence
-        // use cancel to implement the alarm behaviour.
-        unsafe { grpc_sys::grpc_alarm_cancel(self.alarm) }
-    }
-}
-
-impl Drop for Alarm {
-    fn drop(&mut self) {
-        unsafe { grpc_sys::grpc_alarm_destroy(self.alarm) }
-    }
-}
 
 /// A handle to a `Spawn`.
 /// Inner future is expected to be polled in the same thread as cq.
 type SpawnHandle = Option<Spawn<BoxFuture<(), ()>>>;
 
+pub(crate) struct Kicker {
+    call: Call,
+}
+
+impl Kicker {
+    pub fn from_call(call: Call) -> Kicker {
+        Kicker { call }
+    }
+
+    /// Kick its completion queue.
+    pub fn kick(&self, tag: Box<CallTag>) -> Result<()> {
+        let _ref = self.call.cq.borrow()?;
+        unsafe {
+            let ptr = Box::into_raw(tag);
+            let status = grpc_sys::grpcwrap_call_kick_completion_queue(self.call.call, ptr as _);
+            if status == GrpcCallStatus::Ok {
+                Ok(())
+            } else {
+                Err(Error::CallFailure(status))
+            }
+        }
+    }
+}
+
+unsafe impl Sync for Kicker {}
+
+impl Clone for Kicker {
+    fn clone(&self) -> Kicker {
+        // Bump call's reference count.
+        let call = unsafe {
+            grpc_sys::grpc_call_ref(self.call.call);
+            self.call.call
+        };
+        let cq = self.call.cq.clone();
+        Kicker {
+            call: Call { call, cq },
+        }
+    }
+}
+
 struct NotifyContext {
-    cq: CompletionQueue,
-    alarmed: bool,
-    alarm: Option<Alarm>,
+    kicked: bool,
+    kicker: Kicker,
 }
 
 impl NotifyContext {
-    /// Notify the alarm.
+    /// Notify the completion queue.
     ///
     /// It only makes sence to call this function from the thread
     /// that cq is not run on.
     fn notify(&mut self, tag: Box<CallTag>) {
-        self.alarm.take();
-        let mut alarm = match Alarm::new(&self.cq, tag) {
-            Ok(a) => a,
-            Err(Error::QueueShutdown) => {
-                // If the queue is shutdown, then the tag will be notified
-                // eventually. So just skip here.
-                return;
-            }
-            Err(e) => panic!("failed to create alarm: {:?}", e),
-        };
-        alarm.alarm();
-        // We need to keep the alarm until tag is resolved.
-        self.alarm = Some(alarm);
+        match self.kicker.kick(tag) {
+            // If the queue is shutdown, then the tag will be notified
+            // eventually. So just skip here.
+            Err(Error::QueueShutdown) => return,
+            Err(e) => panic!("unexpected error when canceling call: {:?}", e),
+            _ => (),
+        }
     }
 }
 
@@ -101,27 +103,23 @@ pub struct SpawnNotify {
 }
 
 impl SpawnNotify {
-    fn new(s: Spawn<BoxFuture<(), ()>>, cq: CompletionQueue) -> SpawnNotify {
+    fn new(s: Spawn<BoxFuture<(), ()>>, kicker: Kicker, worker_id: ThreadId) -> SpawnNotify {
         SpawnNotify {
-            worker_id: cq.worker_id(),
+            worker_id,
             handle: Arc::new(SpinLock::new(Some(s))),
             ctx: Arc::new(SpinLock::new(NotifyContext {
-                cq,
-                alarmed: false,
-                alarm: None,
+                kicked: false,
+                kicker,
             })),
         }
     }
 
     pub fn resolve(self, success: bool) {
         // it should always be canceled for now.
-        assert!(!success);
+        assert!(success);
         poll(&Arc::new(self.clone()), true);
     }
 }
-
-unsafe impl Send for SpawnNotify {}
-unsafe impl Sync for SpawnNotify {}
 
 impl Notify for SpawnNotify {
     fn notify(&self, _: usize) {
@@ -129,22 +127,22 @@ impl Notify for SpawnNotify {
             poll(&Arc::new(self.clone()), false)
         } else {
             let mut ctx = self.ctx.lock();
-            if ctx.alarmed {
+            if ctx.kicked {
                 return;
             }
             ctx.notify(Box::new(CallTag::Spawn(self.clone())));
-            ctx.alarmed = true;
+            ctx.kicked = true;
         }
     }
 }
 
 /// Poll the future.
 ///
-/// `woken` indicates that if the alarm is woken by a cancel action.
+/// `woken` indicates that if the cq is kicked by itself.
 fn poll(notify: &Arc<SpawnNotify>, woken: bool) {
     let mut handle = notify.handle.lock();
     if woken {
-        notify.ctx.lock().alarmed = false;
+        notify.ctx.lock().kicked = false;
     }
     if handle.is_none() {
         // it's resolved, no need to poll again.
@@ -163,7 +161,7 @@ fn poll(notify: &Arc<SpawnNotify>, woken: bool) {
 
 /// An executor that drives a future in the gRPC poll thread, which
 /// can reduce thread context switching.
-pub struct Executor<'a> {
+pub(crate) struct Executor<'a> {
     cq: &'a CompletionQueue,
 }
 
@@ -172,7 +170,7 @@ impl<'a> Executor<'a> {
         Executor { cq }
     }
 
-    pub(crate) fn cq(&self) -> &CompletionQueue {
+    pub fn cq(&self) -> &CompletionQueue {
         self.cq
     }
 
@@ -180,12 +178,12 @@ impl<'a> Executor<'a> {
     ///
     /// If you want to trace the future, you may need to create a sender/receiver
     /// pair by yourself.
-    pub fn spawn<F>(&self, f: F)
+    pub fn spawn<F>(&self, f: F, kicker: Kicker)
     where
         F: Future<Item = (), Error = ()> + Send + 'static,
     {
         let s = executor::spawn(Box::new(f) as BoxFuture<_, _>);
-        let notify = Arc::new(SpawnNotify::new(s, self.cq.clone()));
+        let notify = Arc::new(SpawnNotify::new(s, kicker, self.cq.worker_id()));
         poll(&notify, false)
     }
 }

--- a/src/async/executor.rs
+++ b/src/async/executor.rs
@@ -161,7 +161,7 @@ fn poll(notify: Arc<SpawnNotify>, woken: bool) {
     }
 }
 
-/// An executor that drives a future in the grpc poll thread, which
+/// An executor that drives a future in the gRPC poll thread, which
 /// can reduce thread context switching.
 pub struct Executor<'a> {
     cq: &'a CompletionQueue,

--- a/src/async/executor.rs
+++ b/src/async/executor.rs
@@ -40,7 +40,7 @@ impl Alarm {
             grpc_sys::grpc_alarm_set(alarm, cq_ref.as_ptr(), timeout, ptr as _, ptr::null_mut());
             alarm
         };
-        Ok(Alarm { alarm: alarm })
+        Ok(Alarm { alarm })
     }
 
     fn alarm(&mut self) {
@@ -106,7 +106,7 @@ impl SpawnNotify {
             worker_id: cq.worker_id(),
             handle: Arc::new(SpinLock::new(Some(s))),
             ctx: Arc::new(SpinLock::new(NotifyContext {
-                cq: cq,
+                cq,
                 alarmed: false,
                 alarm: None,
             })),
@@ -169,7 +169,7 @@ pub struct Executor<'a> {
 
 impl<'a> Executor<'a> {
     pub fn new(cq: &CompletionQueue) -> Executor {
-        Executor { cq: cq }
+        Executor { cq }
     }
 
     pub(crate) fn cq(&self) -> &CompletionQueue {

--- a/src/async/lock.rs
+++ b/src/async/lock.rs
@@ -74,11 +74,11 @@ impl<'a, T> Drop for LockGuard<'a, T> {
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+    use std::sync::mpsc::*;
+    use std::sync::*;
     use std::thread;
     use std::time::Duration;
-    use std::sync::*;
-    use std::sync::mpsc::*;
-    use super::*;
 
     #[test]
     fn test_lock() {

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -31,7 +31,7 @@ use cq::CompletionQueue;
 use error::{Error, Result};
 use server::RequestCallContext;
 
-pub use self::executor::Executor;
+pub(crate) use self::executor::{Executor, Kicker};
 pub use self::lock::SpinLock;
 pub use self::promise::BatchType;
 

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -11,29 +11,29 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod executor;
-mod promise;
 mod callback;
+mod executor;
 mod lock;
+mod promise;
 
 use std::fmt::{self, Debug, Formatter};
 use std::sync::Arc;
 
-use futures::{Async, Future, Poll};
 use futures::task::{self, Task};
+use futures::{Async, Future, Poll};
 
-use call::{BatchContext, Call};
+use self::callback::{Abort, Request as RequestCallback, UnaryRequest as UnaryRequestCallback};
+use self::executor::SpawnNotify;
+use self::promise::{Batch as BatchPromise, Shutdown as ShutdownPromise};
 use call::server::RequestContext;
+use call::{BatchContext, Call};
 use cq::CompletionQueue;
 use error::{Error, Result};
-use self::executor::SpawnNotify;
-use self::callback::{Abort, Request as RequestCallback, UnaryRequest as UnaryRequestCallback};
-use self::promise::{Batch as BatchPromise, Shutdown as ShutdownPromise};
 use server::Inner as ServerInner;
 
 pub use self::executor::Executor;
-pub use self::promise::BatchType;
 pub use self::lock::SpinLock;
+pub use self::promise::BatchType;
 
 /// A handle that is used to notify future that the task finishes.
 pub struct NotifyHandle<T> {
@@ -209,9 +209,9 @@ impl Debug for CallTag {
 
 #[cfg(test)]
 mod tests {
-    use std::thread;
-    use std::sync::*;
     use std::sync::mpsc::*;
+    use std::sync::*;
+    use std::thread;
 
     use super::*;
     use env::Environment;

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -29,7 +29,7 @@ use call::server::RequestContext;
 use call::{BatchContext, Call};
 use cq::CompletionQueue;
 use error::{Error, Result};
-use server::Inner as ServerInner;
+use server::RequestCallContext;
 
 pub use self::executor::Executor;
 pub use self::lock::SpinLock;
@@ -140,8 +140,8 @@ impl CallTag {
 
     /// Generate a CallTag for request job. We don't have an eventloop
     /// to pull the future, so just the tag is enough.
-    pub fn request(inner: Arc<ServerInner>) -> CallTag {
-        CallTag::Request(RequestCallback::new(inner))
+    pub fn request(ctx: RequestCallContext) -> CallTag {
+        CallTag::Request(RequestCallback::new(ctx))
     }
 
     /// Generate a Future/CallTag pair for shutdown call.
@@ -157,8 +157,8 @@ impl CallTag {
     }
 
     /// Generate a CallTag for unary request job.
-    pub fn unary_request(ctx: RequestContext, inner: Arc<ServerInner>) -> CallTag {
-        let cb = UnaryRequestCallback::new(ctx, inner);
+    pub fn unary_request(ctx: RequestContext, rc: RequestCallContext) -> CallTag {
+        let cb = UnaryRequestCallback::new(ctx, rc);
         CallTag::UnaryRequest(cb)
     }
 

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -87,7 +87,7 @@ pub struct CqFuture<T> {
 
 impl<T> CqFuture<T> {
     fn new(inner: Arc<Inner<T>>) -> CqFuture<T> {
-        CqFuture { inner: inner }
+        CqFuture { inner }
     }
 }
 

--- a/src/async/promise.rs
+++ b/src/async/promise.rs
@@ -11,12 +11,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
 use std::fmt::{self, Debug, Formatter};
+use std::sync::Arc;
 
+use super::{BatchMessage, Inner};
 use call::{BatchContext, RpcStatusCode};
 use error::Error;
-use super::{BatchMessage, Inner};
 
 /// Batch job type.
 #[derive(PartialEq, Debug)]

--- a/src/async/promise.rs
+++ b/src/async/promise.rs
@@ -39,9 +39,9 @@ pub struct Batch {
 impl Batch {
     pub fn new(ty: BatchType, inner: Arc<Inner<BatchMessage>>) -> Batch {
         Batch {
-            ty: ty,
+            ty,
             ctx: BatchContext::new(),
-            inner: inner,
+            inner,
         }
     }
 
@@ -122,7 +122,7 @@ pub struct Shutdown {
 
 impl Shutdown {
     pub fn new(inner: Arc<Inner<()>>) -> Shutdown {
-        Shutdown { inner: inner }
+        Shutdown { inner }
     }
 
     pub fn resolve(self, success: bool) {

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -36,6 +36,7 @@ pub fn change_flag(res: &mut u32, flag: u32, set: bool) {
     }
 }
 
+/// Options for calls made by client.
 #[derive(Clone, Default)]
 pub struct CallOption {
     timeout: Option<Duration>,
@@ -45,7 +46,7 @@ pub struct CallOption {
 }
 
 impl CallOption {
-    /// Signal that the call is idempotent
+    /// Signal that the call is idempotent.
     pub fn idempotent(mut self, is_idempotent: bool) -> CallOption {
         change_flag(
             &mut self.call_flags,
@@ -55,7 +56,7 @@ impl CallOption {
         self
     }
 
-    /// Signal that the call should not return UNAVAILABLE before it has started
+    /// Signal that the call should not return UNAVAILABLE before it has started.
     pub fn wait_for_ready(mut self, wait_for_ready: bool) -> CallOption {
         change_flag(
             &mut self.call_flags,
@@ -65,7 +66,7 @@ impl CallOption {
         self
     }
 
-    /// Signal that the call is cacheable. GRPC is free to use GET verb
+    /// Signal that the call is cacheable. gRPC is free to use GET verb.
     pub fn cacheable(mut self, cacheable: bool) -> CallOption {
         change_flag(
             &mut self.call_flags,
@@ -75,6 +76,7 @@ impl CallOption {
         self
     }
 
+    /// Set write flags.
     pub fn write_flags(mut self, write_flags: WriteFlags) -> CallOption {
         self.write_flags = write_flags;
         self
@@ -97,19 +99,19 @@ impl CallOption {
         self
     }
 
-    /// Get the headers.
+    /// Get headers to be sent with the call.
     pub fn get_headers(&self) -> Option<&Metadata> {
         self.headers.as_ref()
     }
 }
 
 impl Call {
-    pub fn unary_async<P, Q>(
+    pub fn unary_async<Req, Resp>(
         channel: &Channel,
-        method: &Method<P, Q>,
-        req: &P,
+        method: &Method<Req, Resp>,
+        req: &Req,
         mut opt: CallOption,
-    ) -> Result<ClientUnaryReceiver<Q>> {
+    ) -> Result<ClientUnaryReceiver<Resp>> {
         let call = channel.create_call(method, &opt)?;
         let mut payload = vec![];
         (method.req_ser())(req, &mut payload);
@@ -130,11 +132,11 @@ impl Call {
         Ok(ClientUnaryReceiver::new(call, cq_f, method.resp_de()))
     }
 
-    pub fn client_streaming<P, Q>(
+    pub fn client_streaming<Req, Resp>(
         channel: &Channel,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         mut opt: CallOption,
-    ) -> Result<(ClientCStreamSender<P>, ClientCStreamReceiver<Q>)> {
+    ) -> Result<(ClientCStreamSender<Req>, ClientCStreamReceiver<Resp>)> {
         let call = channel.create_call(method, &opt)?;
         let cq_f = check_run(BatchType::CheckRead, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_client_streaming(
@@ -157,12 +159,12 @@ impl Call {
         Ok((sink, recv))
     }
 
-    pub fn server_streaming<P, Q>(
+    pub fn server_streaming<Req, Resp>(
         channel: &Channel,
-        method: &Method<P, Q>,
-        req: &P,
+        method: &Method<Req, Resp>,
+        req: &Req,
         mut opt: CallOption,
-    ) -> Result<ClientSStreamReceiver<Q>> {
+    ) -> Result<ClientSStreamReceiver<Resp>> {
         let call = channel.create_call(method, &opt)?;
         let mut payload = vec![];
         (method.req_ser())(req, &mut payload);
@@ -189,11 +191,11 @@ impl Call {
         Ok(ClientSStreamReceiver::new(call, cq_f, method.resp_de()))
     }
 
-    pub fn duplex_streaming<P, Q>(
+    pub fn duplex_streaming<Req, Resp>(
         channel: &Channel,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         mut opt: CallOption,
-    ) -> Result<(ClientDuplexSender<P>, ClientDuplexReceiver<Q>)> {
+    ) -> Result<(ClientDuplexSender<Req>, ClientDuplexReceiver<Resp>)> {
         let call = channel.create_call(method, &opt)?;
         let cq_f = check_run(BatchType::Finish, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_duplex_streaming(
@@ -287,15 +289,15 @@ impl<T> Future for ClientCStreamReceiver<T> {
 }
 
 /// A sink for client streaming call and duplex streaming call.
-pub struct StreamingCallSink<P> {
+pub struct StreamingCallSink<Req> {
     call: Arc<SpinLock<ShareCall>>,
     sink_base: SinkBase,
     close_f: Option<BatchFuture>,
-    req_ser: SerializeFn<P>,
+    req_ser: SerializeFn<Req>,
 }
 
-impl<P> StreamingCallSink<P> {
-    fn new(call: Arc<SpinLock<ShareCall>>, ser: SerializeFn<P>) -> StreamingCallSink<P> {
+impl<Req> StreamingCallSink<Req> {
+    fn new(call: Arc<SpinLock<ShareCall>>, ser: SerializeFn<Req>) -> StreamingCallSink<Req> {
         StreamingCallSink {
             call,
             sink_base: SinkBase::new(false),
@@ -310,8 +312,8 @@ impl<P> StreamingCallSink<P> {
     }
 }
 
-impl<P> Sink for StreamingCallSink<P> {
-    type SinkItem = (P, WriteFlags);
+impl<Req> Sink for StreamingCallSink<Req> {
+    type SinkItem = (Req, WriteFlags);
     type SinkError = Error;
 
     fn start_send(&mut self, (msg, flags): Self::SinkItem) -> StartSend<Self::SinkItem, Error> {
@@ -424,16 +426,16 @@ impl<H: ShareCallHolder, T> ResponseStreamImpl<H, T> {
 }
 
 /// A receiver for server streaming call.
-pub struct ClientSStreamReceiver<Q> {
-    imp: ResponseStreamImpl<ShareCall, Q>,
+pub struct ClientSStreamReceiver<Resp> {
+    imp: ResponseStreamImpl<ShareCall, Resp>,
 }
 
-impl<Q> ClientSStreamReceiver<Q> {
+impl<Resp> ClientSStreamReceiver<Resp> {
     fn new(
         call: Call,
         finish_f: CqFuture<BatchMessage>,
-        de: DeserializeFn<Q>,
-    ) -> ClientSStreamReceiver<Q> {
+        de: DeserializeFn<Resp>,
+    ) -> ClientSStreamReceiver<Resp> {
         let share_call = ShareCall::new(call, finish_f);
         ClientSStreamReceiver {
             imp: ResponseStreamImpl::new(share_call, de),
@@ -445,22 +447,22 @@ impl<Q> ClientSStreamReceiver<Q> {
     }
 }
 
-impl<Q> Stream for ClientSStreamReceiver<Q> {
-    type Item = Q;
+impl<Resp> Stream for ClientSStreamReceiver<Resp> {
+    type Item = Resp;
     type Error = Error;
 
-    fn poll(&mut self) -> Poll<Option<Q>, Error> {
+    fn poll(&mut self) -> Poll<Option<Resp>, Error> {
         self.imp.poll()
     }
 }
 
 /// A response receiver for duplex call.
-pub struct ClientDuplexReceiver<Q> {
-    imp: ResponseStreamImpl<Arc<SpinLock<ShareCall>>, Q>,
+pub struct ClientDuplexReceiver<Resp> {
+    imp: ResponseStreamImpl<Arc<SpinLock<ShareCall>>, Resp>,
 }
 
-impl<Q> ClientDuplexReceiver<Q> {
-    fn new(call: Arc<SpinLock<ShareCall>>, de: DeserializeFn<Q>) -> ClientDuplexReceiver<Q> {
+impl<Resp> ClientDuplexReceiver<Resp> {
+    fn new(call: Arc<SpinLock<ShareCall>>, de: DeserializeFn<Resp>) -> ClientDuplexReceiver<Resp> {
         ClientDuplexReceiver {
             imp: ResponseStreamImpl::new(call, de),
         }
@@ -471,11 +473,11 @@ impl<Q> ClientDuplexReceiver<Q> {
     }
 }
 
-impl<Q> Stream for ClientDuplexReceiver<Q> {
-    type Item = Q;
+impl<Resp> Stream for ClientDuplexReceiver<Resp> {
+    type Item = Resp;
     type Error = Error;
 
-    fn poll(&mut self) -> Poll<Option<Q>, Error> {
+    fn poll(&mut self) -> Poll<Option<Resp>, Error> {
         self.imp.poll()
     }
 }

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -18,13 +18,13 @@ use std::time::Duration;
 use futures::{Async, AsyncSink, Future, Poll, Sink, StartSend, Stream};
 use grpc_sys;
 
+use super::{ShareCall, ShareCallHolder, SinkBase, WriteFlags};
 use async::{BatchFuture, BatchMessage, BatchType, CqFuture, SpinLock};
 use call::{check_run, Call, Method};
 use channel::Channel;
 use codec::{DeserializeFn, SerializeFn};
 use error::{Error, Result};
 use metadata::Metadata;
-use super::{ShareCall, ShareCallHolder, SinkBase, WriteFlags};
 
 /// Update the flag bit in res.
 #[inline]

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -235,8 +235,8 @@ impl<T> ClientUnaryReceiver<T> {
         de: DeserializeFn<T>,
     ) -> ClientUnaryReceiver<T> {
         ClientUnaryReceiver {
-            call: call,
-            resp_f: resp_f,
+            call,
+            resp_f,
             resp_de: de,
         }
     }
@@ -297,7 +297,7 @@ pub struct StreamingCallSink<P> {
 impl<P> StreamingCallSink<P> {
     fn new(call: Arc<SpinLock<ShareCall>>, ser: SerializeFn<P>) -> StreamingCallSink<P> {
         StreamingCallSink {
-            call: call,
+            call,
             sink_base: SinkBase::new(false),
             close_f: None,
             req_ser: ser,
@@ -369,10 +369,10 @@ struct ResponseStreamImpl<H, T> {
 impl<H: ShareCallHolder, T> ResponseStreamImpl<H, T> {
     fn new(call: H, resp_de: DeserializeFn<T>) -> ResponseStreamImpl<H, T> {
         ResponseStreamImpl {
-            call: call,
+            call,
             msg_f: None,
             read_done: false,
-            resp_de: resp_de,
+            resp_de,
         }
     }
 

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -501,6 +501,14 @@ impl StreamingBase {
             Ok(Async::Ready(bytes))
         }
     }
+
+    // Cancel the call if we still have some messages or did not
+    // receive status code.
+    fn on_drop<C: ShareCallHolder>(&self, call: &mut C) {
+        if !self.read_done || self.close_f.is_some() {
+            call.call(|c| c.call.cancel());
+        }
+    }
 }
 
 /// Flags for write operations.

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -76,8 +76,8 @@ pub struct RpcStatus {
 impl RpcStatus {
     pub fn new(status: RpcStatusCode, details: Option<String>) -> RpcStatus {
         RpcStatus {
-            status: status,
-            details: details,
+            status,
+            details,
         }
     }
 
@@ -122,8 +122,8 @@ impl BatchContext {
         };
 
         RpcStatus {
-            status: status,
-            details: details,
+            status,
+            details,
         }
     }
 
@@ -361,8 +361,8 @@ struct ShareCall {
 impl ShareCall {
     fn new(call: Call, close_f: CqFuture<BatchMessage>) -> ShareCall {
         ShareCall {
-            call: call,
-            close_f: close_f,
+            call,
+            close_f,
             finished: false,
             status: None,
         }
@@ -428,7 +428,7 @@ struct StreamingBase {
 impl StreamingBase {
     fn new(close_f: Option<BatchFuture>) -> StreamingBase {
         StreamingBase {
-            close_f: close_f,
+            close_f,
             msg_f: None,
             read_done: false,
         }
@@ -534,7 +534,7 @@ impl SinkBase {
         SinkBase {
             batch_f: None,
             buf: Vec::new(),
-            send_metadata: send_metadata,
+            send_metadata,
         }
     }
 

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -204,8 +204,8 @@ where
 /// set until it is invoked. After invoke, the Call can have messages
 /// written to it and read from it.
 pub struct Call {
-    call: *mut GrpcCall,
-    cq: CompletionQueue,
+    pub call: *mut GrpcCall,
+    pub cq: CompletionQueue,
 }
 
 unsafe impl Send for Call {}

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -28,52 +28,77 @@ use error::{Error, Result};
 
 pub use grpc_sys::GrpcStatusCode as RpcStatusCode;
 
+/// Method types supported by gRPC.
 #[derive(Clone, Copy)]
 pub enum MethodType {
+    /// Single request sent from client, single response received from server.
     Unary,
+
+    /// Stream of requests sent from client, single response received from server.
     ClientStreaming,
+
+    /// Single request sent from client, stream of responses received from server.
     ServerStreaming,
+
+    /// Both server and client can stream arbitrary number of requests and responses simultaneously.
     Duplex,
 }
 
+
+/// A description of a remote method.
 // TODO: add serializer and deserializer.
-pub struct Method<P, Q> {
+pub struct Method<Req, Resp> {
+    /// Type of method.
     pub ty: MethodType,
+
+    /// Full qualified name of the method.
     pub name: &'static str,
-    pub req_mar: Marshaller<P>,
-    pub resp_mar: Marshaller<Q>,
+
+    /// The marshaller used for request messages.
+    pub req_mar: Marshaller<Req>,
+
+    /// The marshaller used for response messages.
+    pub resp_mar: Marshaller<Resp>,
 }
 
-impl<P, Q> Method<P, Q> {
+impl<Req, Resp> Method<Req, Resp> {
+    /// Get the request serializer.
     #[inline]
-    pub fn req_ser(&self) -> SerializeFn<P> {
+    pub fn req_ser(&self) -> SerializeFn<Req> {
         self.req_mar.ser
     }
 
+    /// Get the request deserializer.
     #[inline]
-    pub fn req_de(&self) -> DeserializeFn<P> {
+    pub fn req_de(&self) -> DeserializeFn<Req> {
         self.req_mar.de
     }
 
+    /// Get the response serializer.
     #[inline]
-    pub fn resp_ser(&self) -> SerializeFn<Q> {
+    pub fn resp_ser(&self) -> SerializeFn<Resp> {
         self.resp_mar.ser
     }
 
+    /// Get the response deserializer.
     #[inline]
-    pub fn resp_de(&self) -> DeserializeFn<Q> {
+    pub fn resp_de(&self) -> DeserializeFn<Resp> {
         self.resp_mar.de
     }
 }
 
-/// Status return from server.
+/// RPC result returned from the server.
 #[derive(Debug, Clone)]
 pub struct RpcStatus {
+    /// gRPC status code. `Ok` indicates success, all other values indicate an error.
     pub status: RpcStatusCode,
+
+    /// Optional detail string.
     pub details: Option<String>,
 }
 
 impl RpcStatus {
+    /// Create a new [`RpcStatus`].
     pub fn new(status: RpcStatusCode, details: Option<String>) -> RpcStatus {
         RpcStatus {
             status,
@@ -81,7 +106,7 @@ impl RpcStatus {
         }
     }
 
-    /// Generate an Ok status.
+    /// Create a new [`RpcStatus`] that status code is Ok.
     pub fn ok() -> RpcStatus {
         RpcStatus::new(RpcStatusCode::Ok, None)
     }
@@ -485,6 +510,7 @@ impl StreamingBase {
     }
 }
 
+/// Flags for write operations.
 #[derive(Default, Clone, Copy)]
 pub struct WriteFlags {
     flags: u32,
@@ -492,6 +518,9 @@ pub struct WriteFlags {
 
 impl WriteFlags {
     /// Hint that the write may be buffered and need not go out on the wire immediately.
+    ///
+    /// gRPC is free to buffer the message until the next non-buffered write, or until write stream
+    /// completion, but it need not buffer completely or at all.
     pub fn buffer_hint(mut self, need_buffered: bool) -> WriteFlags {
         client::change_flag(
             &mut self.flags,
@@ -511,12 +540,12 @@ impl WriteFlags {
         self
     }
 
-    /// Get if buffer hint is enabled.
+    /// Get whether buffer hint is enabled.
     pub fn get_buffer_hint(&self) -> bool {
         (self.flags & grpc_sys::GRPC_WRITE_BUFFER_HINT) != 0
     }
 
-    /// Get if compression is disabled.
+    /// Get whether compression is disabled.
     pub fn get_force_no_compress(&self) -> bool {
         (self.flags & grpc_sys::GRPC_WRITE_NO_COMPRESS) != 0
     }

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -14,8 +14,8 @@
 pub mod client;
 pub mod server;
 
-use std::{ptr, slice, usize};
 use std::sync::Arc;
+use std::{ptr, slice, usize};
 
 use cq::CompletionQueue;
 use futures::{Async, Future, Poll};
@@ -43,7 +43,6 @@ pub enum MethodType {
     /// Both server and client can stream arbitrary number of requests and responses simultaneously.
     Duplex,
 }
-
 
 /// A description of a remote method.
 // TODO: add serializer and deserializer.
@@ -100,10 +99,7 @@ pub struct RpcStatus {
 impl RpcStatus {
     /// Create a new [`RpcStatus`].
     pub fn new(status: RpcStatusCode, details: Option<String>) -> RpcStatus {
-        RpcStatus {
-            status,
-            details,
-        }
+        RpcStatus { status, details }
     }
 
     /// Create a new [`RpcStatus`] that status code is Ok.
@@ -146,10 +142,7 @@ impl BatchContext {
             }
         };
 
-        RpcStatus {
-            status,
-            details,
-        }
+        RpcStatus { status, details }
     }
 
     /// Fetch the response bytes of the rpc call.
@@ -280,7 +273,7 @@ impl Call {
         &mut self,
         status: &RpcStatus,
         send_empty_metadata: bool,
-        payload: Option<Vec<u8>>,
+        payload: &Option<Vec<u8>>,
         write_flags: u32,
     ) -> Result<BatchFuture> {
         let _cq_ref = self.cq.borrow()?;
@@ -312,7 +305,7 @@ impl Call {
     }
 
     /// Abort an rpc call before handler is called.
-    pub fn abort(self, status: RpcStatus) {
+    pub fn abort(self, status: &RpcStatus) {
         match self.cq.borrow() {
             // Queue is shutdown, ignore.
             Err(Error::QueueShutdown) => return,
@@ -541,12 +534,12 @@ impl WriteFlags {
     }
 
     /// Get whether buffer hint is enabled.
-    pub fn get_buffer_hint(&self) -> bool {
+    pub fn get_buffer_hint(self) -> bool {
         (self.flags & grpc_sys::GRPC_WRITE_BUFFER_HINT) != 0
     }
 
     /// Get whether compression is disabled.
-    pub fn get_force_no_compress(&self) -> bool {
+    pub fn get_force_no_compress(self) -> bool {
         (self.flags & grpc_sys::GRPC_WRITE_NO_COMPRESS) != 0
     }
 }

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -217,6 +217,11 @@ impl UnaryRequestContext {
     }
 }
 
+/// A stream for client a streaming call and a duplex streaming call.
+///
+/// The corresponding RPC will be canceled if the stream did not
+/// finish before dropping.
+#[must_use = "if unused the RequestStream may immediately cancel the RPC"]
 pub struct RequestStream<T> {
     call: Arc<SpinLock<ShareCall>>,
     base: StreamingBase,
@@ -254,12 +259,20 @@ impl<T> Stream for RequestStream<T> {
     }
 }
 
+impl<T> Drop for RequestStream<T> {
+    /// The corresponding RPC will be canceled if the stream did not
+    /// finish before dropping.
+    fn drop(&mut self) {
+        self.base.on_drop(&mut self.call);
+    }
+}
+
 /// A helper macro used to implement server side unary sink.
 /// Not using generic here because we don't need to expose
 /// `CallHolder` or `Call` to caller.
 // TODO: Use type alias to be friendly for documentation.
 macro_rules! impl_unary_sink {
-    ($t:ident, $rt:ident, $holder:ty) => {
+    ($(#[$attr:meta])* $t:ident, $rt:ident, $holder:ty) => {
         pub struct $rt {
             call: $holder,
             cq_f: Option<BatchFuture>,
@@ -284,8 +297,9 @@ macro_rules! impl_unary_sink {
             }
         }
 
+        $(#[$attr])*
         pub struct $t<T> {
-            call: $holder,
+            call: Option<$holder>,
             write_flags: u32,
             ser: SerializeFn<T>,
         }
@@ -293,7 +307,7 @@ macro_rules! impl_unary_sink {
         impl<T> $t<T> {
             fn new(call: $holder, ser: SerializeFn<T>) -> $t<T> {
                 $t {
-                    call: call,
+                    call: Some(call),
                     write_flags: 0,
                     ser: ser,
                 }
@@ -315,7 +329,7 @@ macro_rules! impl_unary_sink {
                 });
 
                 let write_flags = self.write_flags;
-                let res = self.call.call(|c| {
+                let res = self.call.as_mut().unwrap().call(|c| {
                     c.call
                         .start_send_status_from_server(&status, true, &data, write_flags)
                 });
@@ -326,17 +340,45 @@ macro_rules! impl_unary_sink {
                 };
 
                 $rt {
-                    call: self.call,
+                    call: self.call.take().unwrap(),
                     cq_f: cq_f,
                     err: err,
                 }
             }
         }
+
+        impl<T> Drop for $t<T> {
+            /// The corresponding RPC will be canceled if the sink did not
+            /// send a response before dropping.
+            fn drop(&mut self) {
+                self.call
+                    .as_mut()
+                    .map(|call| call.call(|c| c.call.cancel()));
+            }
+        }
     };
 }
 
-impl_unary_sink!(UnarySink, UnarySinkResult, ShareCall);
 impl_unary_sink!(
+    /// A sink for unary call.
+    ///
+    /// To close the sink properly, you should call [`success`] or [`fail`] before dropping.
+    ///
+    /// [`success`]: #method.success
+    /// [`fail`]: #method.fail
+    #[must_use = "if unused the sink may immediately cancel the RPC"]
+    UnarySink,
+    UnarySinkResult,
+    ShareCall
+);
+impl_unary_sink!(
+    /// A sink for client streaming call.
+    ///
+    /// To close the sink properly, you should call [`success`] or [`fail`] before dropping.
+    ///
+    /// [`success`]: #method.success
+    /// [`fail`]: #method.fail
+    #[must_use = "if unused the sink may immediately cancel the RPC"]
     ClientStreamingSink,
     ClientStreamingSinkResult,
     Arc<SpinLock<ShareCall>>
@@ -344,24 +386,27 @@ impl_unary_sink!(
 
 // A macro helper to implement server side streaming sink.
 macro_rules! impl_stream_sink {
-    ($t:ident, $ft:ident, $holder:ty) => {
+    ($(#[$attr:meta])* $t:ident, $ft:ident, $holder:ty) => {
+        $(#[$attr])*
         pub struct $t<T> {
-            call: $holder,
+            call: Option<$holder>,
             base: SinkBase,
             flush_f: Option<BatchFuture>,
             status: RpcStatus,
             flushed: bool,
+            closed: bool,
             ser: SerializeFn<T>,
         }
 
         impl<T> $t<T> {
             fn new(call: $holder, ser: SerializeFn<T>) -> $t<T> {
                 $t {
-                    call: call,
+                    call: Some(call),
                     base: SinkBase::new(true),
                     flush_f: None,
                     status: RpcStatus::ok(),
                     flushed: false,
+                    closed: false,
                     ser: ser,
                 }
             }
@@ -374,7 +419,7 @@ macro_rules! impl_stream_sink {
             pub fn fail(mut self, status: RpcStatus) -> $ft {
                 assert!(self.flush_f.is_none());
                 let send_metadata = self.base.send_metadata;
-                let res = self.call.call(|c| {
+                let res = self.call.as_mut().unwrap().call(|c| {
                     c.call
                         .start_send_status_from_server(&status, send_metadata, &None, 0)
                 });
@@ -385,9 +430,24 @@ macro_rules! impl_stream_sink {
                 };
 
                 $ft {
-                    call: self.call,
+                    call: self.call.take().unwrap(),
                     fail_f: fail_f,
                     err: err,
+                }
+            }
+        }
+
+        impl<T> Drop for $t<T> {
+            /// The corresponding RPC will be canceled if the sink did not call
+            /// [`close`] or [`fail`] before dropping.
+            ///
+            /// [`close`]: #method.close
+            /// [`fail`]: #method.fail
+            fn drop(&mut self) {
+                // We did not close it explicitly and it was not dropped in the `fail`.
+                if !self.closed && self.call.is_some() {
+                    let mut call = self.call.take().unwrap();
+                    call.call(|c| c.call.cancel());
                 }
             }
         }
@@ -397,11 +457,11 @@ macro_rules! impl_stream_sink {
             type SinkError = Error;
 
             fn start_send(&mut self, item: Self::SinkItem) -> StartSend<Self::SinkItem, Error> {
-                if let Async::Ready(_) = self.call.call(|c| c.poll_finish())? {
+                if let Async::Ready(_) = self.call.as_mut().unwrap().call(|c| c.poll_finish())? {
                     return Err(Error::RemoteStopped);
                 }
                 self.base
-                    .start_send(&mut self.call, &item.0, item.1, self.ser)
+                    .start_send(self.call.as_mut().unwrap(), &item.0, item.1, self.ser)
                     .map(|s| {
                         if s {
                             AsyncSink::Ready
@@ -421,7 +481,7 @@ macro_rules! impl_stream_sink {
 
                     let send_metadata = self.base.send_metadata;
                     let status = &self.status;
-                    let flush_f = self.call.call(|c| {
+                    let flush_f = self.call.as_mut().unwrap().call(|c| {
                         c.call
                             .start_send_status_from_server(status, send_metadata, &None, 0)
                     })?;
@@ -433,11 +493,13 @@ macro_rules! impl_stream_sink {
                     self.flushed = true;
                 }
 
-                try_ready!(self.call.call(|c| c.poll_finish()));
+                try_ready!(self.call.as_mut().unwrap().call(|c| c.poll_finish()));
+                self.closed = true;
                 Ok(Async::Ready(()))
             }
         }
 
+        #[must_use = "if unused the sink failure may immediately cancel the RPC"]
         pub struct $ft {
             call: $holder,
             fail_f: Option<BatchFuture>,
@@ -472,8 +534,30 @@ macro_rules! impl_stream_sink {
     };
 }
 
-impl_stream_sink!(ServerStreamingSink, ServerStreamingSinkFailure, ShareCall);
-impl_stream_sink!(DuplexSink, DuplexSinkFailure, Arc<SpinLock<ShareCall>>);
+impl_stream_sink!(
+    /// A sink for server streaming call.
+    ///
+    /// To close the sink properly, you should call [`close`] or [`fail`] before dropping.
+    ///
+    /// [`close`]: #method.close
+    /// [`fail`]: #method.fail
+    #[must_use = "if unused the sink may immediately cancel the RPC"]
+    ServerStreamingSink,
+    ServerStreamingSinkFailure,
+    ShareCall
+);
+impl_stream_sink!(
+    /// A sink for duplex streaming call.
+    ///
+    /// To close the sink properly, you should call [`close`] or [`fail`] before dropping.
+    ///
+    /// [`close`]: #method.close
+    /// [`fail`]: #method.fail
+    #[must_use = "if unused the sink may immediately cancel the RPC"]
+    DuplexSink,
+    DuplexSinkFailure,
+    Arc<SpinLock<ShareCall>>
+);
 
 /// A context for rpc handling.
 pub struct RpcContext<'a> {

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -159,7 +159,10 @@ impl RequestContext {
             // RequestContext always holds a reference of the call.
             let call = grpc_sys::grpcwrap_request_call_context_get_call(self.ctx);
             let p = grpc_sys::grpc_call_get_peer(call);
-            let peer = CStr::from_ptr(p).to_str().expect("valid UTF-8 data").to_owned();
+            let peer = CStr::from_ptr(p)
+                .to_str()
+                .expect("valid UTF-8 data")
+                .to_owned();
             grpc_sys::gpr_free(p as _);
             peer
         }

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -71,7 +71,7 @@ impl RequestContext {
     pub fn handle_stream_req(
         self,
         cq: &CompletionQueue,
-        rc: &RequestCallContext,
+        rc: &mut RequestCallContext,
     ) -> result::Result<(), Self> {
         let handler = unsafe { rc.get_handler(self.method()) };
         match handler {
@@ -206,7 +206,7 @@ impl UnaryRequestContext {
         self.request_call.take()
     }
 
-    pub fn handle(self, rc: &RequestCallContext, cq: &CompletionQueue, data: Option<&[u8]>) {
+    pub fn handle(self, rc: &mut RequestCallContext, cq: &CompletionQueue, data: Option<&[u8]>) {
         let handler = unsafe { rc.get_handler(self.request.method()).unwrap() };
         if let Some(data) = data {
             return execute(self.request, cq, data, handler);
@@ -551,9 +551,9 @@ pub fn execute_unary<P, Q, F>(
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
     payload: &[u8],
-    f: &F,
+    f: &mut F,
 ) where
-    F: Fn(RpcContext, P, UnarySink<Q>),
+    F: FnMut(RpcContext, P, UnarySink<Q>),
 {
     let mut call = ctx.call();
     let close_f = accept_call!(call);
@@ -577,9 +577,9 @@ pub fn execute_client_streaming<P, Q, F>(
     ctx: RpcContext,
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
-    f: &F,
+    f: &mut F,
 ) where
-    F: Fn(RpcContext, RequestStream<P>, ClientStreamingSink<Q>),
+    F: FnMut(RpcContext, RequestStream<P>, ClientStreamingSink<Q>),
 {
     let mut call = ctx.call();
     let close_f = accept_call!(call);
@@ -596,9 +596,9 @@ pub fn execute_server_streaming<P, Q, F>(
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
     payload: &[u8],
-    f: &F,
+    f: &mut F,
 ) where
-    F: Fn(RpcContext, P, ServerStreamingSink<Q>),
+    F: FnMut(RpcContext, P, ServerStreamingSink<Q>),
 {
     let mut call = ctx.call();
     let close_f = accept_call!(call);
@@ -624,9 +624,9 @@ pub fn execute_duplex_streaming<P, Q, F>(
     ctx: RpcContext,
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
-    f: &F,
+    f: &mut F,
 ) where
-    F: Fn(RpcContext, RequestStream<P>, DuplexSink<Q>),
+    F: FnMut(RpcContext, RequestStream<P>, DuplexSink<Q>),
 {
     let mut call = ctx.call();
     let close_f = accept_call!(call);
@@ -649,7 +649,7 @@ pub fn execute_unimplemented(ctx: RequestContext, cq: CompletionQueue) {
 // Helper function to call handler.
 //
 // Invoked after a request is ready to be handled.
-fn execute(ctx: RequestContext, cq: &CompletionQueue, payload: &[u8], f: &BoxHandler) {
+fn execute(ctx: RequestContext, cq: &CompletionQueue, payload: &[u8], f: &mut BoxHandler) {
     let rpc_ctx = RpcContext::new(ctx, cq);
     f.handle(rpc_ctx, payload)
 }

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -11,13 +11,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{result, slice};
-use std::sync::Arc;
 use std::ffi::CStr;
+use std::sync::Arc;
+use std::{result, slice};
 
 use futures::{Async, AsyncSink, Future, Poll, Sink, StartSend, Stream};
 use grpc_sys::{self, GprClockType, GprTimespec, GrpcCallStatus, GrpcRequestCallContext};
 
+use super::{RpcStatus, ShareCall, ShareCallHolder, WriteFlags};
 use async::{BatchFuture, CallTag, Executor, SpinLock};
 use call::{BatchContext, Call, MethodType, RpcStatusCode, SinkBase, StreamingBase};
 use codec::{DeserializeFn, SerializeFn};
@@ -25,7 +26,6 @@ use cq::CompletionQueue;
 use error::Error;
 use metadata::Metadata;
 use server::{CallBack, Inner};
-use super::{RpcStatus, ShareCall, ShareCallHolder, WriteFlags};
 
 pub struct Deadline {
     spec: GprTimespec,
@@ -210,7 +210,7 @@ impl UnaryRequestContext {
         }
 
         let status = RpcStatus::new(RpcStatusCode::Internal, Some("No payload".to_owned()));
-        self.request.call(cq.clone()).abort(status)
+        self.request.call(cq.clone()).abort(&status)
     }
 }
 
@@ -256,7 +256,7 @@ impl<T> Stream for RequestStream<T> {
 /// `CallHolder` or `Call` to caller.
 // TODO: Use type alias to be friendly for documentation.
 macro_rules! impl_unary_sink {
-    ($t:ident, $rt:ident, $holder:ty) => (
+    ($t:ident, $rt:ident, $holder:ty) => {
         pub struct $rt {
             call: $holder,
             cq_f: Option<BatchFuture>,
@@ -313,7 +313,8 @@ macro_rules! impl_unary_sink {
 
                 let write_flags = self.write_flags;
                 let res = self.call.call(|c| {
-                    c.call.start_send_status_from_server(&status, true, data, write_flags)
+                    c.call
+                        .start_send_status_from_server(&status, true, &data, write_flags)
                 });
 
                 let (cq_f, err) = match res {
@@ -328,7 +329,7 @@ macro_rules! impl_unary_sink {
                 }
             }
         }
-    );
+    };
 }
 
 impl_unary_sink!(UnarySink, UnarySinkResult, ShareCall);
@@ -340,7 +341,7 @@ impl_unary_sink!(
 
 // A macro helper to implement server side streaming sink.
 macro_rules! impl_stream_sink {
-    ($t:ident, $ft:ident, $holder:ty) => (
+    ($t:ident, $ft:ident, $holder:ty) => {
         pub struct $t<T> {
             call: $holder,
             base: SinkBase,
@@ -371,7 +372,8 @@ macro_rules! impl_stream_sink {
                 assert!(self.flush_f.is_none());
                 let send_metadata = self.base.send_metadata;
                 let res = self.call.call(|c| {
-                    c.call.start_send_status_from_server(&status, send_metadata, None, 0)
+                    c.call
+                        .start_send_status_from_server(&status, send_metadata, &None, 0)
                 });
 
                 let (fail_f, err) = match res {
@@ -397,11 +399,13 @@ macro_rules! impl_stream_sink {
                 }
                 self.base
                     .start_send(&mut self.call, &item.0, item.1, self.ser)
-                    .map(|s| if s {
+                    .map(|s| {
+                        if s {
                             AsyncSink::Ready
                         } else {
                             AsyncSink::NotReady(item)
-                        })
+                        }
+                    })
             }
 
             fn poll_complete(&mut self) -> Poll<(), Error> {
@@ -415,7 +419,8 @@ macro_rules! impl_stream_sink {
                     let send_metadata = self.base.send_metadata;
                     let status = &self.status;
                     let flush_f = self.call.call(|c| {
-                        c.call.start_send_status_from_server(status, send_metadata, None, 0)
+                        c.call
+                            .start_send_status_from_server(status, send_metadata, &None, 0)
                     })?;
                     self.flush_f = Some(flush_f);
                 }
@@ -461,7 +466,7 @@ macro_rules! impl_stream_sink {
                 Ok(readiness)
             }
         }
-    )
+    };
 }
 
 impl_stream_sink!(ServerStreamingSink, ServerStreamingSinkFailure, ShareCall);
@@ -529,7 +534,7 @@ macro_rules! accept_call {
             Err(e) => panic!("unexpected error when trying to accept request: {:?}", e),
             Ok(f) => f,
         }
-    }
+    };
 }
 
 // Helper function to call a unary handler.
@@ -551,7 +556,7 @@ pub fn execute_unary<P, Q, F>(
                 RpcStatusCode::Internal,
                 Some(format!("Failed to deserialize response message: {:?}", e)),
             );
-            call.abort(status);
+            call.abort(&status);
             return;
         }
     };
@@ -597,7 +602,7 @@ pub fn execute_server_streaming<P, Q, F>(
                 RpcStatusCode::Internal,
                 Some(format!("Failed to deserialize response message: {:?}", e)),
             );
-            call.abort(status);
+            call.abort(&status);
             return;
         }
     };
@@ -628,7 +633,7 @@ pub fn execute_duplex_streaming<P, Q, F>(
 pub fn execute_unimplemented(mut ctx: RequestContext, cq: CompletionQueue) {
     let mut call = ctx.call(cq);
     accept_call!(call);
-    call.abort(RpcStatus::new(RpcStatusCode::Unimplemented, None))
+    call.abort(&RpcStatus::new(RpcStatusCode::Unimplemented, None))
 }
 
 // Helper function to call handler.

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -25,7 +25,7 @@ use codec::{DeserializeFn, SerializeFn};
 use cq::CompletionQueue;
 use error::Error;
 use metadata::Metadata;
-use server::{CallBack, Inner};
+use server::{BoxHandler, RequestCallContext};
 
 pub struct Deadline {
     spec: GprTimespec,
@@ -52,16 +52,16 @@ impl Deadline {
 /// Context for accepting a request.
 pub struct RequestContext {
     ctx: *mut GrpcRequestCallContext,
-    inner: Option<Arc<Inner>>,
+    request_call: Option<RequestCallContext>,
 }
 
 impl RequestContext {
-    pub fn new(inner: Arc<Inner>) -> RequestContext {
+    pub fn new(rc: RequestCallContext) -> RequestContext {
         let ctx = unsafe { grpc_sys::grpcwrap_request_call_context_create() };
 
         RequestContext {
             ctx,
-            inner: Some(inner),
+            request_call: Some(rc),
         }
     }
 
@@ -71,13 +71,14 @@ impl RequestContext {
     pub fn handle_stream_req(
         self,
         cq: &CompletionQueue,
-        inner: &Inner,
+        rc: &RequestCallContext,
     ) -> result::Result<(), Self> {
-        match inner.get_handler(self.method()) {
+        let handler = unsafe { rc.get_handler(self.method()) };
+        match handler {
             Some(handler) => match handler.method_type() {
                 MethodType::Unary | MethodType::ServerStreaming => Err(self),
                 _ => {
-                    execute(self, cq, &[], handler.cb());
+                    execute(self, cq, &[], handler);
                     Ok(())
                 }
             },
@@ -93,9 +94,9 @@ impl RequestContext {
     /// This method should be called after `handle_stream_req`. When handling
     /// client side unary request, handler will only be called after the unary
     /// request is received.
-    pub fn handle_unary_req(self, inner: Arc<Inner>, _: &CompletionQueue) {
+    pub fn handle_unary_req(self, rc: RequestCallContext, _: &CompletionQueue) {
         // fetch message before calling callback.
-        let tag = Box::new(CallTag::unary_request(self, inner));
+        let tag = Box::new(CallTag::unary_request(self, rc));
         let batch_ctx = tag.batch_ctx().unwrap().as_ptr();
         let request_ctx = tag.request_ctx().unwrap().as_ptr();
         let tag_ptr = Box::into_raw(tag);
@@ -110,8 +111,8 @@ impl RequestContext {
         }
     }
 
-    pub fn take_inner(&mut self) -> Option<Arc<Inner>> {
-        self.inner.take()
+    pub fn take_request_call_context(&mut self) -> Option<RequestCallContext> {
+        self.request_call.take()
     }
 
     pub fn as_ptr(&self) -> *mut GrpcRequestCallContext {
@@ -178,15 +179,15 @@ impl Drop for RequestContext {
 /// A context for handling client side unary request.
 pub struct UnaryRequestContext {
     request: RequestContext,
-    inner: Option<Arc<Inner>>,
+    request_call: Option<RequestCallContext>,
     batch: BatchContext,
 }
 
 impl UnaryRequestContext {
-    pub fn new(ctx: RequestContext, inner: Arc<Inner>) -> UnaryRequestContext {
+    pub fn new(ctx: RequestContext, rc: RequestCallContext) -> UnaryRequestContext {
         UnaryRequestContext {
             request: ctx,
-            inner: Some(inner),
+            request_call: Some(rc),
             batch: BatchContext::new(),
         }
     }
@@ -199,14 +200,14 @@ impl UnaryRequestContext {
         &self.request
     }
 
-    pub fn take_inner(&mut self) -> Option<Arc<Inner>> {
-        self.inner.take()
+    pub fn take_request_call_context(&mut self) -> Option<RequestCallContext> {
+        self.request_call.take()
     }
 
-    pub fn handle(mut self, inner: &Arc<Inner>, cq: &CompletionQueue, data: Option<&[u8]>) {
-        let handler = inner.get_handler(self.request.method()).unwrap();
+    pub fn handle(mut self, rc: &RequestCallContext, cq: &CompletionQueue, data: Option<&[u8]>) {
+        let handler = unsafe { rc.get_handler(self.request.method()).unwrap() };
         if let Some(data) = data {
-            return execute(self.request, cq, data, handler.cb());
+            return execute(self.request, cq, data, handler);
         }
 
         let status = RpcStatus::new(RpcStatusCode::Internal, Some("No payload".to_owned()));
@@ -639,7 +640,7 @@ pub fn execute_unimplemented(mut ctx: RequestContext, cq: CompletionQueue) {
 // Helper function to call handler.
 //
 // Invoked after a request is ready to be handled.
-fn execute(ctx: RequestContext, cq: &CompletionQueue, payload: &[u8], f: &CallBack) {
+fn execute(ctx: RequestContext, cq: &CompletionQueue, payload: &[u8], f: &BoxHandler) {
     let rpc_ctx = RpcContext::new(ctx, cq);
-    f(rpc_ctx, payload)
+    f.handle(rpc_ctx, payload)
 }

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -19,7 +19,7 @@ use futures::{Async, AsyncSink, Future, Poll, Sink, StartSend, Stream};
 use grpc_sys::{self, GprClockType, GprTimespec, GrpcCallStatus, GrpcRequestCallContext};
 
 use super::{RpcStatus, ShareCall, ShareCallHolder, WriteFlags};
-use async::{BatchFuture, CallTag, Executor, SpinLock};
+use async::{BatchFuture, CallTag, Executor, Kicker, SpinLock};
 use call::{BatchContext, Call, MethodType, RpcStatusCode, SinkBase, StreamingBase};
 use codec::{DeserializeFn, SerializeFn};
 use cq::CompletionQueue;
@@ -119,8 +119,10 @@ impl RequestContext {
         self.ctx
     }
 
-    fn call(&mut self, cq: CompletionQueue) -> Call {
+    fn call(&self, cq: CompletionQueue) -> Call {
         unsafe {
+            // It is okay to use a mutable pointer on a immutable reference, `self`,
+            // because grpcwrap_request_call_context_ref_call is thread-safe.
             let call = grpc_sys::grpcwrap_request_call_context_ref_call(self.ctx);
             assert!(!call.is_null());
             Call::from_raw(call, cq)
@@ -204,7 +206,7 @@ impl UnaryRequestContext {
         self.request_call.take()
     }
 
-    pub fn handle(mut self, rc: &RequestCallContext, cq: &CompletionQueue, data: Option<&[u8]>) {
+    pub fn handle(self, rc: &RequestCallContext, cq: &CompletionQueue, data: Option<&[u8]>) {
         let handler = unsafe { rc.get_handler(self.request.method()).unwrap() };
         if let Some(data) = data {
             return execute(self.request, cq, data, handler);
@@ -489,7 +491,12 @@ impl<'a> RpcContext<'a> {
         }
     }
 
-    pub(crate) fn call(&mut self) -> Call {
+    fn kicker(&self) -> Kicker {
+        let call = self.call();
+        Kicker::from_call(call)
+    }
+
+    pub(crate) fn call(&self) -> Call {
         self.ctx.call(self.executor.cq().clone())
     }
 
@@ -522,7 +529,7 @@ impl<'a> RpcContext<'a> {
     where
         F: Future<Item = (), Error = ()> + Send + 'static,
     {
-        self.executor.spawn(f)
+        self.executor.spawn(f, self.kicker())
     }
 }
 
@@ -540,7 +547,7 @@ macro_rules! accept_call {
 
 // Helper function to call a unary handler.
 pub fn execute_unary<P, Q, F>(
-    mut ctx: RpcContext,
+    ctx: RpcContext,
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
     payload: &[u8],
@@ -567,7 +574,7 @@ pub fn execute_unary<P, Q, F>(
 
 // Helper function to call client streaming handler.
 pub fn execute_client_streaming<P, Q, F>(
-    mut ctx: RpcContext,
+    ctx: RpcContext,
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
     f: &F,
@@ -585,7 +592,7 @@ pub fn execute_client_streaming<P, Q, F>(
 
 // Helper function to call server streaming handler.
 pub fn execute_server_streaming<P, Q, F>(
-    mut ctx: RpcContext,
+    ctx: RpcContext,
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
     payload: &[u8],
@@ -614,7 +621,7 @@ pub fn execute_server_streaming<P, Q, F>(
 
 // Helper function to call duplex streaming handler.
 pub fn execute_duplex_streaming<P, Q, F>(
-    mut ctx: RpcContext,
+    ctx: RpcContext,
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
     f: &F,
@@ -631,7 +638,9 @@ pub fn execute_duplex_streaming<P, Q, F>(
 }
 
 // A helper function used to handle all undefined rpc calls.
-pub fn execute_unimplemented(mut ctx: RequestContext, cq: CompletionQueue) {
+pub fn execute_unimplemented(ctx: RequestContext, cq: CompletionQueue) {
+    // Suppress needless-pass-by-value.
+    let ctx = ctx;
     let mut call = ctx.call(cq);
     accept_call!(call);
     call.abort(&RpcStatus::new(RpcStatusCode::Unimplemented, None))

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -60,7 +60,7 @@ impl RequestContext {
         let ctx = unsafe { grpc_sys::grpcwrap_request_call_context_create() };
 
         RequestContext {
-            ctx: ctx,
+            ctx,
             inner: Some(inner),
         }
     }
@@ -223,9 +223,9 @@ pub struct RequestStream<T> {
 impl<T> RequestStream<T> {
     fn new(call: Arc<SpinLock<ShareCall>>, de: DeserializeFn<T>) -> RequestStream<T> {
         RequestStream {
-            call: call,
+            call,
             base: StreamingBase::new(None),
-            de: de,
+            de,
         }
     }
 }
@@ -477,7 +477,7 @@ impl<'a> RpcContext<'a> {
     fn new(ctx: RequestContext, cq: &CompletionQueue) -> RpcContext {
         RpcContext {
             deadline: ctx.deadline(),
-            ctx: ctx,
+            ctx,
             executor: Executor::new(cq),
         }
     }

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -251,9 +251,10 @@ impl<T> Stream for RequestStream<T> {
     }
 }
 
-// A helper macro used to implement server side unary sink.
-// Not using generic here because we don't need to expose
-// `CallHolder` or `Call` to caller.
+/// A helper macro used to implement server side unary sink.
+/// Not using generic here because we don't need to expose
+/// `CallHolder` or `Call` to caller.
+// TODO: Use type alias to be friendly for documentation.
 macro_rules! impl_unary_sink {
     ($t:ident, $rt:ident, $holder:ty) => (
         pub struct $rt {
@@ -507,7 +508,7 @@ impl<'a> RpcContext<'a> {
         self.ctx.peer()
     }
 
-    /// Spawn the future into current grpc poll thread.
+    /// Spawn the future into current gRPC poll thread.
     ///
     /// This can reduce a lot of context switching, but please make
     /// sure there is no heavy work in the future.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -12,24 +12,25 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::{cmp, ptr, i32};
-use std::collections::HashMap;
 use std::collections::hash_map::Entry;
+use std::collections::HashMap;
 use std::ffi::{CStr, CString};
 use std::sync::Arc;
 use std::time::Duration;
+use std::{cmp, i32, ptr};
 
-use libc::{self, c_char, c_int};
 use grpc_sys::{self, GprTimespec, GrpcChannel, GrpcChannelArgs};
+use libc::{self, c_char, c_int};
 
-use CallOption;
 use call::{Call, Method};
 use cq::CompletionQueue;
 use env::Environment;
 use error::Result;
+use CallOption;
 
-pub use grpc_sys::{GrpcCompressionAlgorithms as CompressionAlgorithms,
-                   GrpcCompressionLevel as CompressionLevel};
+pub use grpc_sys::{
+    GrpcCompressionAlgorithms as CompressionAlgorithms, GrpcCompressionLevel as CompressionLevel,
+};
 
 // hack: add a '\0' to be compatible with c string without extra allocation.
 const OPT_DEFAULT_AUTHORITY: &[u8] = b"grpc.default_authority\0";
@@ -85,6 +86,7 @@ enum Options {
 }
 
 /// The optimization target for a [`Channel`].
+#[derive(Clone, Copy)]
 pub enum OptTarget {
     /// Minimize latency at the cost of throughput.
     Latency,
@@ -94,6 +96,7 @@ pub enum OptTarget {
     Throughput,
 }
 
+#[derive(Clone, Copy)]
 pub enum LbPolicy {
     PickFirst,
     RoundRobin,
@@ -385,7 +388,7 @@ impl ChannelBuilder {
         };
         self.options.insert(
             Cow::Borrowed(OPT_GRPC_ARG_LB_POLICY_NAME),
-            Options::String(val.unwrap())
+            Options::String(val.unwrap()),
         );
         self
     }
@@ -414,6 +417,7 @@ impl ChannelBuilder {
     ///
     /// This method is only for bench usage, users should use the encapsulated API instead.
     #[doc(hidden)]
+    #[cfg_attr(feature = "cargo-clippy", allow(identity_conversion))]
     pub fn build_args(&self) -> ChannelArgs {
         let args = unsafe { grpc_sys::grpcwrap_channel_args_create(self.options.len()) };
         for (i, (k, v)) in self.options.iter().enumerate() {
@@ -459,9 +463,9 @@ impl ChannelBuilder {
 
 #[cfg(feature = "secure")]
 mod secure_channel {
-    use std::ptr;
-    use std::ffi::CString;
     use std::borrow::Cow;
+    use std::ffi::CString;
+    use std::ptr;
 
     use grpc_sys;
 
@@ -552,23 +556,25 @@ unsafe impl Sync for Channel {}
 impl Channel {
     fn new(cq: CompletionQueue, env: Arc<Environment>, channel: *mut GrpcChannel) -> Channel {
         Channel {
-            inner: Arc::new(ChannelInner {
-                _env: env,
-                channel,
-            }),
+            inner: Arc::new(ChannelInner { _env: env, channel }),
             cq,
         }
     }
 
     /// Create a call using the method and option.
-    pub(crate) fn create_call<Req, Resp>(&self, method: &Method<Req, Resp>, opt: &CallOption) -> Result<Call> {
+    pub(crate) fn create_call<Req, Resp>(
+        &self,
+        method: &Method<Req, Resp>,
+        opt: &CallOption,
+    ) -> Result<Call> {
         let cq_ref = self.cq.borrow()?;
         let raw_call = unsafe {
             let ch = self.inner.channel;
             let cq = cq_ref.as_ptr();
             let method_ptr = method.name.as_ptr();
             let method_len = method.name.len();
-            let timeout = opt.get_timeout()
+            let timeout = opt
+                .get_timeout()
                 .map_or_else(GprTimespec::inf_future, GprTimespec::from);
             grpc_sys::grpcwrap_channel_create_call(
                 ch,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -507,6 +507,8 @@ impl Drop for ChannelInner {
 }
 
 /// The Channel struct allows creation of Call objects.
+///
+/// Typically created by a [`ChannelBuilder`](struct.ChannelBuilder.html).
 #[derive(Clone)]
 pub struct Channel {
     inner: Arc<ChannelInner>,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -83,7 +83,7 @@ enum Options {
     String(CString),
 }
 
-/// Optimization target for a channel.
+/// The optimization target for a [`Channel`].
 pub enum OptTarget {
     /// Minimize latency at the cost of throughput.
     Latency,
@@ -93,13 +93,14 @@ pub enum OptTarget {
     Throughput,
 }
 
-/// Channel configuration object.
+/// [`Channel`] factory in order to configure the properties.
 pub struct ChannelBuilder {
     env: Arc<Environment>,
     options: HashMap<Cow<'static, [u8]>, Options>,
 }
 
 impl ChannelBuilder {
+    /// Initialize a new [`ChannelBuilder`].
     pub fn new(env: Arc<Environment>) -> ChannelBuilder {
         ChannelBuilder {
             env,
@@ -107,7 +108,7 @@ impl ChannelBuilder {
         }
     }
 
-    /// Default authority to pass if none specified on call construction.
+    /// Set default authority to pass if none specified on call construction.
     pub fn default_authority<S: Into<Vec<u8>>>(mut self, authority: S) -> ChannelBuilder {
         let authority = CString::new(authority).unwrap();
         self.options.insert(
@@ -117,7 +118,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Maximum number of concurrent incoming streams to allow on a http2 connection.
+    /// Set maximum number of concurrent incoming streams to allow on a HTTP/2 connection.
     pub fn max_concurrent_stream(mut self, num: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_MAX_CONCURRENT_STREAMS),
@@ -126,7 +127,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Maximum message length that the channel can receive. usize::MAX means unlimited.
+    /// Set maximum message length that the channel can receive. `usize::MAX` means unlimited.
     pub fn max_receive_message_len(mut self, len: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_MAX_RECEIVE_MESSAGE_LENGTH),
@@ -135,7 +136,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Maximum message length that the channel can send. -1 means unlimited.
+    /// Set maximum message length that the channel can send. `-1` means unlimited.
     pub fn max_send_message_len(mut self, len: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_MAX_SEND_MESSAGE_LENGTH),
@@ -144,7 +145,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// The maximum time between subsequent connection attempts.
+    /// Set maximum time between subsequent connection attempts.
     pub fn max_reconnect_backoff(mut self, backoff: Duration) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_MAX_RECONNECT_BACKOFF_MS),
@@ -153,7 +154,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// The time between the first and second connection attempts.
+    /// Set time between the first and second connection attempts.
     pub fn initial_reconnect_backoff(mut self, backoff: Duration) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_INITIAL_RECONNECT_BACKOFF_MS),
@@ -162,7 +163,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Initial sequence number for http2 transports.
+    /// Set initial sequence number for HTTP/2 transports.
     pub fn https_initial_seq_number(mut self, number: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_HTTP2_INITIAL_SEQUENCE_NUMBER),
@@ -171,8 +172,8 @@ impl ChannelBuilder {
         self
     }
 
-    /// Amount to read ahead on individual streams. Defaults to 64kb, larger
-    /// values can help throughput on high-latency connections.
+    /// Set amount to read ahead on individual streams. Defaults to 64KB. Larger
+    /// values help throughput on high-latency connections.
     pub fn stream_initial_window_size(mut self, window_size: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_STREAM_INITIAL_WINDOW_SIZE),
@@ -181,7 +182,8 @@ impl ChannelBuilder {
         self
     }
 
-    /// Primary user agent: goes at the start of the user-agent metadata sent on each request.
+    /// Set primary user agent, which goes at the start of the user-agent metadata sent on
+    /// each request.
     pub fn primary_user_agent(mut self, agent: &str) -> ChannelBuilder {
         let agent_string = format_user_agent_string(agent);
         self.options.insert(
@@ -191,7 +193,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// If enable, allow the use of SO_REUSEPORT if it's available (default true).
+    /// Set whether to allow the use of `SO_REUSEPORT` if available. Defaults to `true`.
     pub fn reuse_port(mut self, reuse: bool) -> ChannelBuilder {
         let opt = if reuse { 1 } else { 0 };
         self.options
@@ -199,7 +201,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// How large a slice to try and read from the wire each time.
+    /// Set the size of slice to try and read from the wire each time.
     pub fn tcp_read_chunk_size(mut self, bytes: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_TCP_READ_CHUNK_SIZE),
@@ -208,7 +210,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// How minimal large a slice to try and read from the wire each time.
+    /// Set the minimum size of slice to try and read from the wire each time.
     pub fn tcp_min_read_chunk_size(mut self, bytes: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_TCP_MIN_READ_CHUNK_SIZE),
@@ -217,7 +219,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// How maximal large a slice to try and read from the wire each time.
+    /// Set the maximum size of slice to try and read from the wire each time.
     pub fn tcp_max_read_chunk_size(mut self, bytes: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_TCP_MAX_READ_CHUNK_SIZE),
@@ -236,7 +238,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// How big a frame are we willing to receive via HTTP2.
+    /// How big a frame are we willing to receive via HTTP/2.
     /// Min 16384, max 16777215.
     /// Larger values give lower CPU usage for large messages, but more head of line
     /// blocking for small messages.
@@ -248,7 +250,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Set BDP probing.
+    /// Set whether to enable BDP probing.
     pub fn http2_bdp_probe(mut self, enable: bool) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_HTTP2_BDP_PROBE),
@@ -305,7 +307,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Default compression algorithm for the channel.
+    /// Set default compression algorithm for the channel.
     pub fn default_compression_algorithm(mut self, algo: CompressionAlgorithms) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_DEFALUT_COMPRESSION_ALGORITHM),
@@ -314,7 +316,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Default compression level for the channel.
+    /// Set default compression level for the channel.
     pub fn default_compression_level(mut self, level: CompressionLevel) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_DEFAULT_COMPRESSION_LEVEL),
@@ -352,9 +354,8 @@ impl ChannelBuilder {
         self
     }
 
-    /// Optimize a channel.
-    ///
-    /// Default is `OptTarget::Blend`.
+    /// Set optimization target for the channel. See [`OptTarget`] for all available
+    /// optimization targets. Defaults to `OptTarget::Blend`.
     pub fn optimize_for(mut self, target: OptTarget) -> ChannelBuilder {
         let val = match target {
             OptTarget::Latency => CString::new("latency"),
@@ -368,7 +369,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Set a raw int configuration.
+    /// Set a raw integer configuration.
     ///
     /// This method is only for bench usage, users should use the encapsulated API instead.
     #[doc(hidden)]
@@ -388,7 +389,10 @@ impl ChannelBuilder {
         self
     }
 
-    /// Build a channel args from the current configuration.
+    /// Build `ChannelArgs` from the current configuration.
+    ///
+    /// This method is only for bench usage, users should use the encapsulated API instead.
+    #[doc(hidden)]
     pub fn build_args(&self) -> ChannelArgs {
         let args = unsafe { grpc_sys::grpcwrap_channel_args_create(self.options.len()) };
         for (i, (k, v)) in self.options.iter().enumerate() {
@@ -420,7 +424,7 @@ impl ChannelBuilder {
         self.build_args()
     }
 
-    /// Build an insure connection to the address.
+    /// Build an insecure [`Channel`] that connects to a specific address.
     pub fn connect(mut self, addr: &str) -> Channel {
         let args = self.prepare_connect_args();
         let addr = CString::new(addr).unwrap();
@@ -448,8 +452,10 @@ mod secure_channel {
 
     impl ChannelBuilder {
         /// The caller of the secure_channel_create functions may override the target name used
-        /// for SSL host name checking using this channel argument. This *should* be used for
-        /// testing only.
+        /// for SSL host name checking using this channel argument.
+        ///
+        /// This *should* be used for testing only.
+        #[doc(hidden)]
         pub fn override_ssl_target<S: Into<Vec<u8>>>(mut self, target: S) -> ChannelBuilder {
             let target = CString::new(target).unwrap();
             self.options.insert(
@@ -459,6 +465,7 @@ mod secure_channel {
             self
         }
 
+        /// Build a secure [`Channel`] that connects to a specific address.
         pub fn secure_connect(mut self, addr: &str, mut creds: ChannelCredentials) -> Channel {
             let args = self.prepare_connect_args();
             let addr = CString::new(addr).unwrap();
@@ -506,9 +513,12 @@ impl Drop for ChannelInner {
     }
 }
 
-/// The Channel struct allows creation of Call objects.
+/// A gRPC channel.
 ///
-/// Typically created by a [`ChannelBuilder`](struct.ChannelBuilder.html).
+/// Channels are an abstraction of long-lived connections to remote servers. More client objects
+/// can reuse the same channel.
+///
+/// Use [`ChannelBuilder`] to build a [`Channel`].
 #[derive(Clone)]
 pub struct Channel {
     inner: Arc<ChannelInner>,
@@ -530,7 +540,7 @@ impl Channel {
     }
 
     /// Create a call using the method and option.
-    pub fn create_call<P, Q>(&self, method: &Method<P, Q>, opt: &CallOption) -> Result<Call> {
+    pub(crate) fn create_call<Req, Resp>(&self, method: &Method<Req, Resp>, opt: &CallOption) -> Result<Call> {
         let cq_ref = self.cq.borrow()?;
         let raw_call = unsafe {
             let ch = self.inner.channel;
@@ -556,7 +566,7 @@ impl Channel {
         unsafe { Ok(Call::from_raw(raw_call, self.cq.clone())) }
     }
 
-    pub fn cq(&self) -> &CompletionQueue {
+    pub(crate) fn cq(&self) -> &CompletionQueue {
         &self.cq
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -32,34 +32,34 @@ pub use grpc_sys::{GrpcCompressionAlgorithms as CompressionAlgorithms,
                    GrpcCompressionLevel as CompressionLevel};
 
 // hack: add a '\0' to be compatible with c string without extra allocation.
-const OPT_DEFAULT_AUTHORITY: &'static [u8] = b"grpc.default_authority\0";
-const OPT_MAX_CONCURRENT_STREAMS: &'static [u8] = b"grpc.max_concurrent_streams\0";
-const OPT_MAX_RECEIVE_MESSAGE_LENGTH: &'static [u8] = b"grpc.max_receive_message_length\0";
-const OPT_MAX_SEND_MESSAGE_LENGTH: &'static [u8] = b"grpc.max_send_message_length\0";
-const OPT_MAX_RECONNECT_BACKOFF_MS: &'static [u8] = b"grpc.max_reconnect_backoff_ms\0";
-const OPT_INITIAL_RECONNECT_BACKOFF_MS: &'static [u8] = b"grpc.initial_reconnect_backoff_ms\0";
-const OPT_HTTP2_INITIAL_SEQUENCE_NUMBER: &'static [u8] = b"grpc.http2.initial_sequence_number\0";
-const OPT_SO_REUSE_PORT: &'static [u8] = b"grpc.so_reuseport\0";
-const OPT_STREAM_INITIAL_WINDOW_SIZE: &'static [u8] = b"grpc.http2.lookahead_bytes\0";
-const OPT_TCP_READ_CHUNK_SIZE: &'static [u8] = b"grpc.experimental.tcp_read_chunk_size\0";
-const OPT_TCP_MIN_READ_CHUNK_SIZE: &'static [u8] = b"grpc.experimental.tcp_min_read_chunk_size\0";
-const OPT_TCP_MAX_READ_CHUNK_SIZE: &'static [u8] = b"grpc.experimental.tcp_max_read_chunk_size\0";
-const OPT_HTTP2_WRITE_BUFFER_SIZE: &'static [u8] = b"grpc.http2.write_buffer_size\0";
-const OPT_HTTP2_MAX_FRAME_SIZE: &'static [u8] = b"grpc.http2.max_frame_size\0";
-const OPT_HTTP2_BDP_PROBE: &'static [u8] = b"grpc.http2.bdp_probe\0";
-const OPT_HTTP2_MIN_SENT_PING_INTERVAL_WITHOUT_DATA_MS: &'static [u8] =
+const OPT_DEFAULT_AUTHORITY: &[u8] = b"grpc.default_authority\0";
+const OPT_MAX_CONCURRENT_STREAMS: &[u8] = b"grpc.max_concurrent_streams\0";
+const OPT_MAX_RECEIVE_MESSAGE_LENGTH: &[u8] = b"grpc.max_receive_message_length\0";
+const OPT_MAX_SEND_MESSAGE_LENGTH: &[u8] = b"grpc.max_send_message_length\0";
+const OPT_MAX_RECONNECT_BACKOFF_MS: &[u8] = b"grpc.max_reconnect_backoff_ms\0";
+const OPT_INITIAL_RECONNECT_BACKOFF_MS: &[u8] = b"grpc.initial_reconnect_backoff_ms\0";
+const OPT_HTTP2_INITIAL_SEQUENCE_NUMBER: &[u8] = b"grpc.http2.initial_sequence_number\0";
+const OPT_SO_REUSE_PORT: &[u8] = b"grpc.so_reuseport\0";
+const OPT_STREAM_INITIAL_WINDOW_SIZE: &[u8] = b"grpc.http2.lookahead_bytes\0";
+const OPT_TCP_READ_CHUNK_SIZE: &[u8] = b"grpc.experimental.tcp_read_chunk_size\0";
+const OPT_TCP_MIN_READ_CHUNK_SIZE: &[u8] = b"grpc.experimental.tcp_min_read_chunk_size\0";
+const OPT_TCP_MAX_READ_CHUNK_SIZE: &[u8] = b"grpc.experimental.tcp_max_read_chunk_size\0";
+const OPT_HTTP2_WRITE_BUFFER_SIZE: &[u8] = b"grpc.http2.write_buffer_size\0";
+const OPT_HTTP2_MAX_FRAME_SIZE: &[u8] = b"grpc.http2.max_frame_size\0";
+const OPT_HTTP2_BDP_PROBE: &[u8] = b"grpc.http2.bdp_probe\0";
+const OPT_HTTP2_MIN_SENT_PING_INTERVAL_WITHOUT_DATA_MS: &[u8] =
     b"grpc.http2.min_time_between_pings_ms\0";
-const OPT_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS: &'static [u8] =
+const OPT_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS: &[u8] =
     b"grpc.http2.min_ping_interval_without_data_ms\0";
-const OPT_HTTP2_MAX_PINGS_WITHOUT_DATA: &'static [u8] = b"grpc.http2.max_pings_without_data\0";
-const OPT_HTTP2_MAX_PING_STRIKES: &'static [u8] = b"grpc.http2.max_ping_strikes\0";
-const OPT_DEFALUT_COMPRESSION_ALGORITHM: &'static [u8] = b"grpc.default_compression_algorithm\0";
-const OPT_DEFAULT_COMPRESSION_LEVEL: &'static [u8] = b"grpc.default_compression_level\0";
-const OPT_KEEPALIVE_TIME_MS: &'static [u8] = b"grpc.keepalive_time_ms\0";
-const OPT_KEEPALIVE_TIMEOUT_MS: &'static [u8] = b"grpc.keepalive_timeout_ms\0";
-const OPT_KEEPALIVE_PERMIT_WITHOUT_CALLS: &'static [u8] = b"grpc.keepalive_permit_without_calls\0";
-const OPT_OPTIMIZATION_TARGET: &'static [u8] = b"grpc.optimization_target\0";
-const PRIMARY_USER_AGENT_STRING: &'static [u8] = b"grpc.primary_user_agent\0";
+const OPT_HTTP2_MAX_PINGS_WITHOUT_DATA: &[u8] = b"grpc.http2.max_pings_without_data\0";
+const OPT_HTTP2_MAX_PING_STRIKES: &[u8] = b"grpc.http2.max_ping_strikes\0";
+const OPT_DEFALUT_COMPRESSION_ALGORITHM: &[u8] = b"grpc.default_compression_algorithm\0";
+const OPT_DEFAULT_COMPRESSION_LEVEL: &[u8] = b"grpc.default_compression_level\0";
+const OPT_KEEPALIVE_TIME_MS: &[u8] = b"grpc.keepalive_time_ms\0";
+const OPT_KEEPALIVE_TIMEOUT_MS: &[u8] = b"grpc.keepalive_timeout_ms\0";
+const OPT_KEEPALIVE_PERMIT_WITHOUT_CALLS: &[u8] = b"grpc.keepalive_permit_without_calls\0";
+const OPT_OPTIMIZATION_TARGET: &[u8] = b"grpc.optimization_target\0";
+const PRIMARY_USER_AGENT_STRING: &[u8] = b"grpc.primary_user_agent\0";
 
 /// Ref: http://www.grpc.io/docs/guides/wire.html#user-agents
 fn format_user_agent_string(agent: &str) -> CString {
@@ -102,7 +102,7 @@ pub struct ChannelBuilder {
 impl ChannelBuilder {
     pub fn new(env: Arc<Environment>) -> ChannelBuilder {
         ChannelBuilder {
-            env: env,
+            env,
             options: HashMap::new(),
         }
     }
@@ -410,7 +410,7 @@ impl ChannelBuilder {
                 },
             }
         }
-        ChannelArgs { args: args }
+        ChannelArgs { args }
     }
 
     fn prepare_connect_args(&mut self) -> ChannelArgs {
@@ -444,7 +444,7 @@ mod secure_channel {
 
     use super::{Channel, ChannelBuilder, Options};
 
-    const OPT_SSL_TARGET_NAME_OVERRIDE: &'static [u8] = b"grpc.ssl_target_name_override\0";
+    const OPT_SSL_TARGET_NAME_OVERRIDE: &[u8] = b"grpc.ssl_target_name_override\0";
 
     impl ChannelBuilder {
         /// The caller of the secure_channel_create functions may override the target name used
@@ -523,9 +523,9 @@ impl Channel {
         Channel {
             inner: Arc::new(ChannelInner {
                 _env: env,
-                channel: channel,
+                channel,
             }),
-            cq: cq,
+            cq,
         }
     }
 

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -12,14 +12,14 @@
 // limitations under the License.
 
 use std::borrow::Cow;
-use std::{cmp, ptr, usize};
+use std::{cmp, ptr, i32};
 use std::collections::HashMap;
 use std::collections::hash_map::Entry;
-use std::ffi::CString;
+use std::ffi::{CStr, CString};
 use std::sync::Arc;
 use std::time::Duration;
 
-use libc::{c_char, c_int};
+use libc::{self, c_char, c_int};
 use grpc_sys::{self, GprTimespec, GrpcChannel, GrpcChannelArgs};
 
 use CallOption;
@@ -73,13 +73,13 @@ fn format_user_agent_string(agent: &str) -> CString {
     CString::new(val).unwrap()
 }
 
-fn dur_to_ms(dur: Duration) -> usize {
+fn dur_to_ms(dur: Duration) -> i32 {
     let millis = dur.as_secs() * 1000 + dur.subsec_nanos() as u64 / 1_000_000;
-    cmp::min(usize::MAX as u64, millis) as usize
+    cmp::min(i32::MAX as u64, millis) as i32
 }
 
 enum Options {
-    Integer(usize),
+    Integer(i32),
     String(CString),
 }
 
@@ -118,7 +118,7 @@ impl ChannelBuilder {
     }
 
     /// Maximum number of concurrent incoming streams to allow on a http2 connection.
-    pub fn max_concurrent_stream(mut self, num: usize) -> ChannelBuilder {
+    pub fn max_concurrent_stream(mut self, num: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_MAX_CONCURRENT_STREAMS),
             Options::Integer(num),
@@ -127,7 +127,7 @@ impl ChannelBuilder {
     }
 
     /// Maximum message length that the channel can receive. usize::MAX means unlimited.
-    pub fn max_receive_message_len(mut self, len: usize) -> ChannelBuilder {
+    pub fn max_receive_message_len(mut self, len: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_MAX_RECEIVE_MESSAGE_LENGTH),
             Options::Integer(len),
@@ -136,7 +136,7 @@ impl ChannelBuilder {
     }
 
     /// Maximum message length that the channel can send. -1 means unlimited.
-    pub fn max_send_message_len(mut self, len: usize) -> ChannelBuilder {
+    pub fn max_send_message_len(mut self, len: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_MAX_SEND_MESSAGE_LENGTH),
             Options::Integer(len),
@@ -163,7 +163,7 @@ impl ChannelBuilder {
     }
 
     /// Initial sequence number for http2 transports.
-    pub fn https_initial_seq_number(mut self, number: usize) -> ChannelBuilder {
+    pub fn https_initial_seq_number(mut self, number: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_HTTP2_INITIAL_SEQUENCE_NUMBER),
             Options::Integer(number),
@@ -173,7 +173,7 @@ impl ChannelBuilder {
 
     /// Amount to read ahead on individual streams. Defaults to 64kb, larger
     /// values can help throughput on high-latency connections.
-    pub fn stream_initial_window_size(mut self, window_size: usize) -> ChannelBuilder {
+    pub fn stream_initial_window_size(mut self, window_size: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_STREAM_INITIAL_WINDOW_SIZE),
             Options::Integer(window_size),
@@ -200,7 +200,7 @@ impl ChannelBuilder {
     }
 
     /// How large a slice to try and read from the wire each time.
-    pub fn tcp_read_chunk_size(mut self, bytes: usize) -> ChannelBuilder {
+    pub fn tcp_read_chunk_size(mut self, bytes: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_TCP_READ_CHUNK_SIZE),
             Options::Integer(bytes),
@@ -209,7 +209,7 @@ impl ChannelBuilder {
     }
 
     /// How minimal large a slice to try and read from the wire each time.
-    pub fn tcp_min_read_chunk_size(mut self, bytes: usize) -> ChannelBuilder {
+    pub fn tcp_min_read_chunk_size(mut self, bytes: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_TCP_MIN_READ_CHUNK_SIZE),
             Options::Integer(bytes),
@@ -218,7 +218,7 @@ impl ChannelBuilder {
     }
 
     /// How maximal large a slice to try and read from the wire each time.
-    pub fn tcp_max_read_chunk_size(mut self, bytes: usize) -> ChannelBuilder {
+    pub fn tcp_max_read_chunk_size(mut self, bytes: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_TCP_MAX_READ_CHUNK_SIZE),
             Options::Integer(bytes),
@@ -228,7 +228,7 @@ impl ChannelBuilder {
 
     /// How much data are we willing to queue up per stream if
     /// write_buffer_hint is set. This is an upper bound.
-    pub fn http2_write_buffer_size(mut self, size: usize) -> ChannelBuilder {
+    pub fn http2_write_buffer_size(mut self, size: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_HTTP2_WRITE_BUFFER_SIZE),
             Options::Integer(size),
@@ -240,7 +240,7 @@ impl ChannelBuilder {
     /// Min 16384, max 16777215.
     /// Larger values give lower CPU usage for large messages, but more head of line
     /// blocking for small messages.
-    pub fn http2_max_frame_size(mut self, size: usize) -> ChannelBuilder {
+    pub fn http2_max_frame_size(mut self, size: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_HTTP2_MAX_FRAME_SIZE),
             Options::Integer(size),
@@ -250,9 +250,10 @@ impl ChannelBuilder {
 
     /// Set BDP probing.
     pub fn http2_bdp_probe(mut self, enable: bool) -> ChannelBuilder {
-        let enable_int = Options::Integer(if enable { 1 } else { 0 });
-        self.options
-            .insert(Cow::Borrowed(OPT_HTTP2_BDP_PROBE), enable_int);
+        self.options.insert(
+            Cow::Borrowed(OPT_HTTP2_BDP_PROBE),
+            Options::Integer(enable as i32),
+        );
         self
     }
 
@@ -285,7 +286,7 @@ impl ChannelBuilder {
     /// How many pings can we send before needing to send a data frame or header
     /// frame? (0 indicates that an infinite number of pings can be sent without
     /// sending a data frame or header frame)
-    pub fn http2_max_pings_without_data(mut self, num: usize) -> ChannelBuilder {
+    pub fn http2_max_pings_without_data(mut self, num: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_HTTP2_MAX_PINGS_WITHOUT_DATA),
             Options::Integer(num),
@@ -296,7 +297,7 @@ impl ChannelBuilder {
     /// How many misbehaving pings the server can bear before sending goaway and
     /// closing the transport? (0 indicates that the server can bear an infinite
     /// number of misbehaving pings)
-    pub fn http2_max_ping_strikes(mut self, num: usize) -> ChannelBuilder {
+    pub fn http2_max_ping_strikes(mut self, num: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_HTTP2_MAX_PING_STRIKES),
             Options::Integer(num),
@@ -308,7 +309,7 @@ impl ChannelBuilder {
     pub fn default_compression_algorithm(mut self, algo: CompressionAlgorithms) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_DEFALUT_COMPRESSION_ALGORITHM),
-            Options::Integer(algo as usize),
+            Options::Integer(algo as i32),
         );
         self
     }
@@ -317,7 +318,7 @@ impl ChannelBuilder {
     pub fn default_compression_level(mut self, level: CompressionLevel) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_DEFAULT_COMPRESSION_LEVEL),
-            Options::Integer(level as usize),
+            Options::Integer(level as i32),
         );
         self
     }
@@ -325,10 +326,9 @@ impl ChannelBuilder {
     /// After a duration of this time the client/server pings its peer to see
     /// if the transport is still alive.
     pub fn keepalive_time(mut self, timeout: Duration) -> ChannelBuilder {
-        let timeout_ms = timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000;
         self.options.insert(
             Cow::Borrowed(OPT_KEEPALIVE_TIME_MS),
-            Options::Integer(timeout_ms as usize),
+            Options::Integer(dur_to_ms(timeout)),
         );
         self
     }
@@ -336,10 +336,9 @@ impl ChannelBuilder {
     /// After waiting for a duration of this time, if the keepalive ping sender does
     /// not receive the ping ack, it will close the transport.
     pub fn keepalive_timeout(mut self, timeout: Duration) -> ChannelBuilder {
-        let timeout_ms = timeout.as_secs() * 1000 + timeout.subsec_nanos() as u64 / 1_000_000;
         self.options.insert(
             Cow::Borrowed(OPT_KEEPALIVE_TIMEOUT_MS),
-            Options::Integer(timeout_ms as usize),
+            Options::Integer(dur_to_ms(timeout)),
         );
         self
     }
@@ -348,7 +347,7 @@ impl ChannelBuilder {
     pub fn keepalive_permit_without_calls(mut self, allow: bool) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_KEEPALIVE_PERMIT_WITHOUT_CALLS),
-            Options::Integer(allow as usize),
+            Options::Integer(allow as i32),
         );
         self
     }
@@ -373,9 +372,9 @@ impl ChannelBuilder {
     ///
     /// This method is only for bench usage, users should use the encapsulated API instead.
     #[doc(hidden)]
-    pub fn raw_cfg_int(mut self, key: CString, val: usize) -> ChannelBuilder {
+    pub fn raw_cfg_int(mut self, key: CString, val: i32) -> ChannelBuilder {
         self.options
-            .insert(Cow::Owned(key.into_bytes()), Options::Integer(val));
+            .insert(Cow::Owned(key.into_bytes_with_nul()), Options::Integer(val));
         self
     }
 
@@ -385,7 +384,7 @@ impl ChannelBuilder {
     #[doc(hidden)]
     pub fn raw_cfg_string(mut self, key: CString, val: CString) -> ChannelBuilder {
         self.options
-            .insert(Cow::Owned(key.into_bytes()), Options::String(val));
+            .insert(Cow::Owned(key.into_bytes_with_nul()), Options::String(val));
         self
     }
 
@@ -396,6 +395,14 @@ impl ChannelBuilder {
             let key = k.as_ptr() as *const c_char;
             match *v {
                 Options::Integer(val) => unsafe {
+                    // On most modern compiler and architect, c_int is the same as i32,
+                    // panic directly to simplify signature.
+                    assert!(
+                        val <= i32::from(libc::INT_MAX) && val >= i32::from(libc::INT_MIN),
+                        "{} is out of range for {:?}",
+                        val,
+                        CStr::from_bytes_with_nul(k).unwrap()
+                    );
                     grpc_sys::grpcwrap_channel_args_set_integer(args, i, key, val as c_int)
                 },
                 Options::String(ref val) => unsafe {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -60,6 +60,7 @@ const OPT_KEEPALIVE_TIMEOUT_MS: &[u8] = b"grpc.keepalive_timeout_ms\0";
 const OPT_KEEPALIVE_PERMIT_WITHOUT_CALLS: &[u8] = b"grpc.keepalive_permit_without_calls\0";
 const OPT_OPTIMIZATION_TARGET: &[u8] = b"grpc.optimization_target\0";
 const PRIMARY_USER_AGENT_STRING: &[u8] = b"grpc.primary_user_agent\0";
+const OPT_GRPC_ARG_LB_POLICY_NAME: &[u8] = b"grpc.lb_policy_name\0";
 
 /// Ref: http://www.grpc.io/docs/guides/wire.html#user-agents
 fn format_user_agent_string(agent: &str) -> CString {
@@ -91,6 +92,11 @@ pub enum OptTarget {
     Blend,
     /// Maximize throughput at the expense of latency.
     Throughput,
+}
+
+pub enum LbPolicy {
+    PickFirst,
+    RoundRobin,
 }
 
 /// [`Channel`] factory in order to configure the properties.
@@ -365,6 +371,21 @@ impl ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_OPTIMIZATION_TARGET),
             Options::String(val.unwrap()),
+        );
+        self
+    }
+
+    /// Set LbPolicy for channel
+    ///
+    /// This method allows one to set the load-balancing policy for a given channel.
+    pub fn load_balancing_policy(mut self, lb_policy: LbPolicy) -> ChannelBuilder {
+        let val = match lb_policy {
+            LbPolicy::PickFirst => CString::new("pick_first"),
+            LbPolicy::RoundRobin => CString::new("round_robin"),
+        };
+        self.options.insert(
+            Cow::Borrowed(OPT_GRPC_ARG_LB_POLICY_NAME),
+            Options::String(val.unwrap())
         );
         self
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,52 +21,53 @@ use channel::Channel;
 
 use error::Result;
 
-/// A generic client for making rpc calls.
+/// A generic client for making RPC calls.
 pub struct Client {
     channel: Channel,
 }
 
 impl Client {
+    /// Initialize a new [`Client`].
     pub fn new(channel: Channel) -> Client {
         Client { channel }
     }
 
-    /// Create a synchronized unary rpc call.
-    pub fn unary_call<P, Q>(&self, method: &Method<P, Q>, req: &P, opt: CallOption) -> Result<Q> {
+    /// Create a synchronized unary RPC call.
+    pub fn unary_call<Req, Resp>(&self, method: &Method<Req, Resp>, req: &Req, opt: CallOption) -> Result<Resp> {
         let f = self.unary_call_async(method, req, opt)?;
         f.wait()
     }
 
-    /// Create a asynchronized unary rpc call.
-    pub fn unary_call_async<P, Q>(
+    /// Create an asynchronized unary RPC call.
+    pub fn unary_call_async<Req, Resp>(
         &self,
-        method: &Method<P, Q>,
-        req: &P,
+        method: &Method<Req, Resp>,
+        req: &Req,
         opt: CallOption,
-    ) -> Result<ClientUnaryReceiver<Q>> {
+    ) -> Result<ClientUnaryReceiver<Resp>> {
         Call::unary_async(&self.channel, method, req, opt)
     }
 
-    /// Create a asynchronized client streaming call.
+    /// Create an asynchronized client streaming call.
     ///
     /// Client can send a stream of requests and server responds with a single response.
-    pub fn client_streaming<P, Q>(
+    pub fn client_streaming<Req, Resp>(
         &self,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         opt: CallOption,
-    ) -> Result<(ClientCStreamSender<P>, ClientCStreamReceiver<Q>)> {
+    ) -> Result<(ClientCStreamSender<Req>, ClientCStreamReceiver<Resp>)> {
         Call::client_streaming(&self.channel, method, opt)
     }
 
-    /// Create a asynchronized server streaming call.
+    /// Create an asynchronized server streaming call.
     ///
     /// Client sends on request and server responds with a stream of responses.
-    pub fn server_streaming<P, Q>(
+    pub fn server_streaming<Req, Resp>(
         &self,
-        method: &Method<P, Q>,
-        req: &P,
+        method: &Method<Req, Resp>,
+        req: &Req,
         opt: CallOption,
-    ) -> Result<ClientSStreamReceiver<Q>> {
+    ) -> Result<ClientSStreamReceiver<Resp>> {
         Call::server_streaming(&self.channel, method, req, opt)
     }
 
@@ -75,15 +76,15 @@ impl Client {
     /// Client sends a stream of requests and server responds with a stream of responses.
     /// The response stream is completely independent and both side can be sending messages
     /// at the same time.
-    pub fn duplex_streaming<P, Q>(
+    pub fn duplex_streaming<Req, Resp>(
         &self,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         opt: CallOption,
-    ) -> Result<(ClientDuplexSender<P>, ClientDuplexReceiver<Q>)> {
+    ) -> Result<(ClientDuplexSender<Req>, ClientDuplexReceiver<Resp>)> {
         Call::duplex_streaming(&self.channel, method, opt)
     }
 
-    /// Spawn the future into current grpc poll thread.
+    /// Spawn the future into current gRPC poll thread.
     ///
     /// This can reduce a lot of context switching, but please make
     /// sure there is no heavy work in the future.

--- a/src/client.rs
+++ b/src/client.rs
@@ -14,9 +14,11 @@
 use futures::Future;
 
 use async::Executor;
+use call::client::{
+    CallOption, ClientCStreamReceiver, ClientCStreamSender, ClientDuplexReceiver,
+    ClientDuplexSender, ClientSStreamReceiver, ClientUnaryReceiver,
+};
 use call::{Call, Method};
-use call::client::{CallOption, ClientCStreamReceiver, ClientCStreamSender, ClientDuplexReceiver,
-                   ClientDuplexSender, ClientSStreamReceiver, ClientUnaryReceiver};
 use channel::Channel;
 
 use error::Result;
@@ -33,7 +35,12 @@ impl Client {
     }
 
     /// Create a synchronized unary RPC call.
-    pub fn unary_call<Req, Resp>(&self, method: &Method<Req, Resp>, req: &Req, opt: CallOption) -> Result<Resp> {
+    pub fn unary_call<Req, Resp>(
+        &self,
+        method: &Method<Req, Resp>,
+        req: &Req,
+        opt: CallOption,
+    ) -> Result<Resp> {
         let f = self.unary_call_async(method, req, opt)?;
         f.wait()
     }

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ pub struct Client {
 
 impl Client {
     pub fn new(channel: Channel) -> Client {
-        Client { channel: channel }
+        Client { channel }
     }
 
     /// Create a synchronized unary rpc call.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -27,7 +27,6 @@ pub struct Marshaller<T> {
     //
     // const function is not stable yet (rust-lang/rust#24111), hence
     // make all fields public.
-
     /// The serialize function.
     pub ser: SerializeFn<T>,
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -16,18 +16,22 @@ use error::Result;
 pub type DeserializeFn<T> = fn(&[u8]) -> Result<T>;
 pub type SerializeFn<T> = fn(&T, &mut Vec<u8>);
 
-/// Marshaller defines how to serialize and deserialize between T and byte slice.
+/// Defines how to serialize and deserialize between the specialized type and byte slice.
 pub struct Marshaller<T> {
     // Use function pointer here to simplify the signature.
     // Compiler will probably inline the function so performance
     // impact can be omitted.
     //
-    // Use trait will require trait object or Generic which will
+    // Using trait will require a trait object or generic, which will
     // either have performance impact or make signature complicated.
     //
     // const function is not stable yet (rust-lang/rust#24111), hence
     // make all fields public.
+
+    /// The serialize function.
     pub ser: SerializeFn<T>,
+
+    /// The deserialize function.
     pub de: DeserializeFn<T>,
 }
 

--- a/src/cq.rs
+++ b/src/cq.rs
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 use std::ptr;
-use std::sync::Arc;
 use std::sync::atomic::{AtomicIsize, Ordering};
+use std::sync::Arc;
 use std::thread::ThreadId;
 
 use grpc_sys::{self, GprClockType, GrpcCompletionQueue};
@@ -52,9 +52,9 @@ impl CompletionQueueHandle {
                 return Err(Error::QueueShutdown);
             }
             let new_cnt = cnt + 1;
-            if cnt
-                == self.ref_cnt
-                    .compare_and_swap(cnt, new_cnt, Ordering::SeqCst)
+            if cnt == self
+                .ref_cnt
+                .compare_and_swap(cnt, new_cnt, Ordering::SeqCst)
             {
                 return Ok(());
             }
@@ -67,9 +67,9 @@ impl CompletionQueueHandle {
             // If `shutdown` is not called, `cnt` > 0, so minus 1 to unref.
             // If `shutdown` is called, `cnt` < 0, so plus 1 to unref.
             let new_cnt = cnt - cnt.signum();
-            if cnt
-                == self.ref_cnt
-                    .compare_and_swap(cnt, new_cnt, Ordering::SeqCst)
+            if cnt == self
+                .ref_cnt
+                .compare_and_swap(cnt, new_cnt, Ordering::SeqCst)
             {
                 break new_cnt == 0;
             }
@@ -92,9 +92,9 @@ impl CompletionQueueHandle {
             // Because `cnt` is initialised to 1, so minus 1 to make it reach
             // toward 0. That is `new_cnt = -(cnt - 1) = -cnt + 1`.
             let new_cnt = -cnt + 1;
-            if cnt
-                == self.ref_cnt
-                    .compare_and_swap(cnt, new_cnt, Ordering::SeqCst)
+            if cnt == self
+                .ref_cnt
+                .compare_and_swap(cnt, new_cnt, Ordering::SeqCst)
             {
                 break new_cnt == 0;
             }
@@ -137,10 +137,7 @@ pub struct CompletionQueue {
 
 impl CompletionQueue {
     pub fn new(handle: Arc<CompletionQueueHandle>, id: ThreadId) -> CompletionQueue {
-        CompletionQueue {
-            handle,
-            id,
-        }
+        CompletionQueue { handle, id }
     }
 
     /// Blocks until an event is available, the completion queue is being shut down.

--- a/src/cq.rs
+++ b/src/cq.rs
@@ -138,8 +138,8 @@ pub struct CompletionQueue {
 impl CompletionQueue {
     pub fn new(handle: Arc<CompletionQueueHandle>, id: ThreadId) -> CompletionQueue {
         CompletionQueue {
-            handle: handle,
-            id: id,
+            handle,
+            id,
         }
     }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -14,8 +14,8 @@
 use std::ffi::CString;
 use std::ptr;
 
-use grpc_sys::{self, GrpcChannelCredentials, GrpcServerCredentials};
 use error::{Error, Result};
+use grpc_sys::{self, GrpcChannelCredentials, GrpcServerCredentials};
 use libc::c_char;
 
 fn clear_key_securely(key: &mut [u8]) {
@@ -74,7 +74,8 @@ impl ServerCredentialsBuilder {
 
     /// Finalize the [`ServerCredentialsBuilder`] and build the [`ServerCredentials`].
     pub fn build(mut self) -> ServerCredentials {
-        let root_cert = self.root
+        let root_cert = self
+            .root
             .take()
             .map_or_else(ptr::null_mut, CString::into_raw);
         let cert_chains = self.cert_chains.as_mut_ptr();
@@ -163,13 +164,17 @@ impl ChannelCredentialsBuilder {
             clear_key_securely(&mut private_key);
             private_key = nil_key;
         }
-        self.cert_key_pair = Some((CString::new(cert).unwrap(), CString::new(private_key).unwrap()));
+        self.cert_key_pair = Some((
+            CString::new(cert).unwrap(),
+            CString::new(private_key).unwrap(),
+        ));
         self
     }
 
     /// Finalize the [`ChannelCredentialsBuilder`] and build the [`ChannelCredentials`].
     pub fn build(mut self) -> ChannelCredentials {
-        let root_ptr = self.root
+        let root_ptr = self
+            .root
             .take()
             .map_or_else(ptr::null_mut, CString::into_raw);
         let (cert_ptr, key_ptr) = self.cert_key_pair.take().map_or_else(

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -180,7 +180,7 @@ impl ChannelCredentialsBuilder {
             }
         }
 
-        ChannelCredentials { creds: creds }
+        ChannelCredentials { creds }
     }
 }
 
@@ -214,7 +214,7 @@ impl ChannelCredentials {
         if creds.is_null() {
             Err(Error::GoogleAuthenticationFailed)
         } else {
-            Ok(ChannelCredentials { creds: creds })
+            Ok(ChannelCredentials { creds })
         }
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
 use std::thread::{self, Builder as ThreadBuilder, JoinHandle};
 
 use grpc_sys;

--- a/src/env.rs
+++ b/src/env.rs
@@ -82,7 +82,7 @@ impl EnvBuilder {
         }
 
         Environment {
-            cqs: cqs,
+            cqs,
             idx: AtomicUsize::new(0),
             _handles: handles,
         }

--- a/src/env.rs
+++ b/src/env.rs
@@ -39,12 +39,14 @@ fn poll_queue(cq: Arc<CompletionQueueHandle>) {
     }
 }
 
+/// [`Environment`] factory in order to configure the properties.
 pub struct EnvBuilder {
     cq_count: usize,
     name_prefix: Option<String>,
 }
 
 impl EnvBuilder {
+    /// Initialize a new [`EnvBuilder`].
     pub fn new() -> EnvBuilder {
         EnvBuilder {
             cq_count: unsafe { grpc_sys::gpr_cpu_num_cores() as usize },
@@ -52,17 +54,25 @@ impl EnvBuilder {
         }
     }
 
+    /// Set the number of completion queues and polling threads. Each thread polls
+    /// one completion queue.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `count` is 0.
     pub fn cq_count(mut self, count: usize) -> EnvBuilder {
         assert!(count > 0);
         self.cq_count = count;
         self
     }
 
+    /// Set the thread name prefix of each polling thread.
     pub fn name_prefix<S: Into<String>>(mut self, prefix: S) -> EnvBuilder {
         self.name_prefix = Some(prefix.into());
         self
     }
 
+    /// Finalize the [`EnvBuilder`], build the [`Environment`] and initialize the gRPC library.
     pub fn build(self) -> Environment {
         unsafe {
             grpc_sys::grpc_init();
@@ -89,7 +99,7 @@ impl EnvBuilder {
     }
 }
 
-/// An object that used to control concurrency and start event loop.
+/// An object that used to control concurrency and start gRPC event loop.
 pub struct Environment {
     cqs: Vec<CompletionQueue>,
     idx: AtomicUsize,
@@ -97,9 +107,13 @@ pub struct Environment {
 }
 
 impl Environment {
-    /// Initialize grpc and create a threadpool to poll event loop.
+    /// Initialize gRPC and create a thread pool to poll completion queue. The thread pool size
+    /// and the number of completion queue is specified by `cq_count`. Each thread polls one
+    /// completion queue.
     ///
-    /// Each thread in threadpool will have one event loop.
+    /// # Panics
+    ///
+    /// This method will panic if `cq_count` is 0.
     pub fn new(cq_count: usize) -> Environment {
         assert!(cq_count > 0);
         EnvBuilder::new()

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{error, result};
 use std::fmt::{self, Display, Formatter};
+use std::{error, result};
 
 use grpc_sys::GrpcCallStatus;
 #[cfg(feature = "protobuf-codec")]
@@ -89,8 +89,8 @@ pub type Result<T> = result::Result<T, Error>;
 mod tests {
     use std::error::Error as StdError;
 
-    use protobuf::ProtobufError;
     use protobuf::error::WireError;
+    use protobuf::ProtobufError;
 
     use super::Error;
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,21 +20,28 @@ use protobuf::ProtobufError;
 
 use call::RpcStatus;
 
+/// Errors generated from this library.
 #[derive(Debug)]
 pub enum Error {
+    /// Codec error.
     Codec(Box<error::Error + Send + Sync>),
-    // return when failed to start an internal async call.
+    /// Failed to start an internal async call.
     CallFailure(GrpcCallStatus),
-    // fail when the rpc request fail.
+    /// Rpc request fail.
     RpcFailure(RpcStatus),
-    // return when trying to write to a finished rpc call.
+    /// Try to write to a finished rpc call.
     RpcFinished(Option<RpcStatus>),
+    /// Remote is stopped.
     RemoteStopped,
+    /// Failed to shutdown.
     ShutdownFailed,
+    /// Failed to bind.
     BindFail(String, u16),
+    /// gRPC completion queue is shutdown.
     QueueShutdown,
-    // Return when Google Default Credentials failed.
+    /// Failed to create Google default credentials.
     GoogleAuthenticationFailed,
+    /// Invalid format of metadata.
     InvalidMetadata(String),
 }
 
@@ -75,6 +82,7 @@ impl From<ProtobufError> for Error {
     }
 }
 
+/// Type alias to use this library's [`Error`] type in a `Result`.
 pub type Result<T> = result::Result<T, Error>;
 
 #[cfg(all(test, feature = "protobuf-codec"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/*!
+
+[grpcio] is a Rust implementation of [gRPC], which is a high performance, open source universal RPC
+framework that puts mobile and HTTP/2 first. grpcio is built on [gRPC Core] and [futures-rs].
+
+[grpcio]: https://github.com/pingcap/grpc-rs/
+[gRPC]: https://grpc.io/
+[gRPC Core]: https://github.com/grpc/grpc
+[futures-rs]: https://github.com/rust-lang-nursery/futures-rs
+
+## Optional features
+
+- **`secure`** *(enabled by default)* - Enables support for TLS encryption and some authentication
+  mechanisms.
+
+*/
+
 #![allow(unknown_lints)]
 #![allow(new_without_default_derive)]
 #![allow(new_without_default)]
@@ -46,7 +63,7 @@ pub use call::client::{CallOption, ClientCStreamReceiver, ClientCStreamSender,
 pub use call::server::{ClientStreamingSink, ClientStreamingSinkResult, Deadline, DuplexSink,
                        DuplexSinkFailure, RequestStream, RpcContext, ServerStreamingSink,
                        ServerStreamingSinkFailure, UnarySink, UnarySinkResult};
-pub use channel::{Channel, ChannelBuilder, CompressionAlgorithms, CompressionLevel};
+pub use channel::{OptTarget, Channel, ChannelBuilder, CompressionAlgorithms, CompressionLevel};
 pub use client::Client;
 pub use codec::Marshaller;
 #[cfg(feature = "protobuf-codec")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ framework that puts mobile and HTTP/2 first. grpcio is built on [gRPC Core] and 
 
 */
 
+// TODO: Remove it once Rust's tool_lints is stabilized.
+#![cfg_attr(feature = "cargo-clippy", allow(renamed_and_removed_lints))]
 #![cfg_attr(feature = "cargo-clippy", allow(new_without_default_derive))]
 #![cfg_attr(feature = "cargo-clippy", allow(new_without_default))]
 #![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,10 +28,10 @@ framework that puts mobile and HTTP/2 first. grpcio is built on [gRPC Core] and 
 
 */
 
-#![allow(unknown_lints)]
-#![allow(new_without_default_derive)]
-#![allow(new_without_default)]
-#![allow(cast_lossless)]
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default_derive))]
+#![cfg_attr(feature = "cargo-clippy", allow(new_without_default))]
+#![cfg_attr(feature = "cargo-clippy", allow(cast_lossless))]
+#![cfg_attr(feature = "cargo-clippy", allow(option_map_unit_fn))]
 
 #[macro_use]
 extern crate futures;
@@ -45,9 +45,9 @@ extern crate protobuf;
 mod async;
 mod call;
 mod channel;
+mod client;
 mod codec;
 mod cq;
-mod client;
 #[cfg(feature = "secure")]
 mod credentials;
 mod env;
@@ -56,21 +56,27 @@ mod log_util;
 mod metadata;
 mod server;
 
+pub use call::client::{
+    CallOption, ClientCStreamReceiver, ClientCStreamSender, ClientDuplexReceiver,
+    ClientDuplexSender, ClientSStreamReceiver, ClientUnaryReceiver, StreamingCallSink,
+};
+pub use call::server::{
+    ClientStreamingSink, ClientStreamingSinkResult, Deadline, DuplexSink, DuplexSinkFailure,
+    RequestStream, RpcContext, ServerStreamingSink, ServerStreamingSinkFailure, UnarySink,
+    UnarySinkResult,
+};
 pub use call::{Method, MethodType, RpcStatus, RpcStatusCode, WriteFlags};
-pub use call::client::{CallOption, ClientCStreamReceiver, ClientCStreamSender,
-                       ClientDuplexReceiver, ClientDuplexSender, ClientSStreamReceiver,
-                       ClientUnaryReceiver, StreamingCallSink};
-pub use call::server::{ClientStreamingSink, ClientStreamingSinkResult, Deadline, DuplexSink,
-                       DuplexSinkFailure, RequestStream, RpcContext, ServerStreamingSink,
-                       ServerStreamingSinkFailure, UnarySink, UnarySinkResult};
-pub use channel::{LbPolicy, OptTarget, Channel, ChannelBuilder, CompressionAlgorithms, CompressionLevel};
+pub use channel::{
+    Channel, ChannelBuilder, CompressionAlgorithms, CompressionLevel, LbPolicy, OptTarget,
+};
 pub use client::Client;
-pub use codec::Marshaller;
 #[cfg(feature = "protobuf-codec")]
 pub use codec::pb_codec::{de as pb_de, ser as pb_ser};
+pub use codec::Marshaller;
 #[cfg(feature = "secure")]
-pub use credentials::{ChannelCredentials, ChannelCredentialsBuilder, ServerCredentials,
-                      ServerCredentialsBuilder};
+pub use credentials::{
+    ChannelCredentials, ChannelCredentialsBuilder, ServerCredentials, ServerCredentialsBuilder,
+};
 pub use env::{EnvBuilder, Environment};
 pub use error::{Error, Result};
 pub use log_util::redirect_log;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub use call::client::{CallOption, ClientCStreamReceiver, ClientCStreamSender,
 pub use call::server::{ClientStreamingSink, ClientStreamingSinkResult, Deadline, DuplexSink,
                        DuplexSinkFailure, RequestStream, RpcContext, ServerStreamingSink,
                        ServerStreamingSinkFailure, UnarySink, UnarySinkResult};
-pub use channel::{OptTarget, Channel, ChannelBuilder, CompressionAlgorithms, CompressionLevel};
+pub use channel::{LbPolicy, OptTarget, Channel, ChannelBuilder, CompressionAlgorithms, CompressionLevel};
 pub use client::Client;
 pub use codec::Marshaller;
 #[cfg(feature = "protobuf-codec")]

--- a/src/log_util.rs
+++ b/src/log_util.rs
@@ -37,13 +37,15 @@ extern "C" fn delegate(c_args: *mut GprLogFuncArgs) {
     let line = args.line as u32;
 
     let msg = unsafe { CStr::from_ptr(args.message).to_string_lossy() };
-    log::logger().log(&Record::builder()
-        .args(format_args!("{}", msg))
-        .level(level)
-        .file(file_str.into())
-        .line(line.into())
-        .module_path(module_path!().into())
-        .build());
+    log::logger().log(
+        &Record::builder()
+            .args(format_args!("{}", msg))
+            .level(level)
+            .file(file_str.into())
+            .line(line.into())
+            .module_path(module_path!().into())
+            .build(),
+    );
 }
 
 /// Redirect grpc log to rust's log implementation.

--- a/src/log_util.rs
+++ b/src/log_util.rs
@@ -14,14 +14,14 @@
 use std::ffi::CStr;
 
 use grpc_sys::{self, GprLogFuncArgs, GprLogSeverity};
-use log::{self, LogLevel, LogLevelFilter, LogLocation};
+use log::{self, Level, LevelFilter, Record};
 
 #[inline]
-fn severity_to_log_level(severity: GprLogSeverity) -> LogLevel {
+fn severity_to_log_level(severity: GprLogSeverity) -> Level {
     match severity {
-        GprLogSeverity::Debug => LogLevel::Debug,
-        GprLogSeverity::Info => LogLevel::Info,
-        GprLogSeverity::Error => LogLevel::Error,
+        GprLogSeverity::Debug => Level::Debug,
+        GprLogSeverity::Info => Level::Info,
+        GprLogSeverity::Error => Level::Error,
     }
 }
 
@@ -36,28 +36,27 @@ extern "C" fn delegate(c_args: *mut GprLogFuncArgs) {
     let file_str = unsafe { CStr::from_ptr(args.file).to_str().unwrap() };
     let line = args.line as u32;
 
-    // use hidden API for now, will
-    // TODO: use public API once available.
-    let location = LogLocation {
-        __module_path: module_path!(),
-        __file: file_str,
-        __line: line,
-    };
     let msg = unsafe { CStr::from_ptr(args.message).to_string_lossy() };
-    log::__log(level, module_path!(), &location, format_args!("{}", msg));
+    log::logger().log(&Record::builder()
+        .args(format_args!("{}", msg))
+        .level(level)
+        .file(file_str.into())
+        .line(line.into())
+        .module_path(module_path!().into())
+        .build());
 }
 
 /// Redirect grpc log to rust's log implementation.
 pub fn redirect_log() {
-    let level = match log::max_log_level() {
-        LogLevelFilter::Off => unsafe {
+    let level = match log::max_level() {
+        LevelFilter::Off => unsafe {
             // disable log.
             grpc_sys::gpr_set_log_function(None);
             return;
         },
-        LogLevelFilter::Error | LogLevelFilter::Warn => GprLogSeverity::Error,
-        LogLevelFilter::Info => GprLogSeverity::Info,
-        LogLevelFilter::Debug | LogLevelFilter::Trace => GprLogSeverity::Debug,
+        LevelFilter::Error | LevelFilter::Warn => GprLogSeverity::Error,
+        LevelFilter::Info => GprLogSeverity::Info,
+        LevelFilter::Debug | LevelFilter::Trace => GprLogSeverity::Debug,
     };
 
     unsafe {

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -12,8 +12,8 @@
 // limitations under the License.
 
 use grpc_sys::{self, GrpcMetadataArray};
-use std::{mem, slice, str};
 use std::borrow::Cow;
+use std::{mem, slice, str};
 
 use libc;
 

--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -31,7 +31,12 @@ fn normalize_key(key: &str, binary: bool) -> Result<Cow<str>> {
         if b >= b'A' && b <= b'Z' {
             is_upper_case = true;
             continue;
-        } else if b >= b'a' && b <= b'z' || b >= b'0' && b <= b'9' || b == b'_' || b == b'-' {
+        } else if b >= b'a' && b <= b'z'
+            || b >= b'0' && b <= b'9'
+            || b == b'_'
+            || b == b'-'
+            || b == b'.'
+        {
             continue;
         }
         return Err(Error::InvalidMetadata(format!("key {:?} is invalid", key)));
@@ -263,7 +268,7 @@ mod tests {
         assert!(builder.add_bytes("key", b"value").is_err());
         // Key should not be empty.
         assert!(builder.add_str("", "value").is_err());
-        // Key should follow the rule ^[a-z0-9_-]+$
+        // Key should follow the rule ^[a-z0-9_-.]+$
         assert!(builder.add_str(":key", "value").is_err());
         assert!(builder.add_str("key~", "value").is_err());
         assert!(builder.add_str("ke+y", "value").is_err());
@@ -275,6 +280,7 @@ mod tests {
         builder.add_str("key", "value").unwrap();
         builder.add_str("_", "value").unwrap();
         builder.add_str("-", "value").unwrap();
+        builder.add_str(".", "value").unwrap();
         builder.add_bytes("key-bin", b"value").unwrap();
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,7 +34,7 @@ const DEFAULT_REQUEST_SLOTS_PER_CQ: usize = 1024;
 
 pub type CallBack = Box<Fn(RpcContext, &[u8])>;
 
-/// Handler is an rpc call holder.
+/// An RPC call holder.
 pub struct Handler {
     method_type: MethodType,
     cb: CallBack,
@@ -118,7 +118,7 @@ mod imp {
 
 use self::imp::Binder;
 
-/// Service configuration struct.
+/// [`Service`] factory in order to configure the properties.
 ///
 /// Use it to build a service which can be registered to a server.
 pub struct ServiceBuilder {
@@ -126,18 +126,19 @@ pub struct ServiceBuilder {
 }
 
 impl ServiceBuilder {
+    /// Initialize a new [`ServiceBuilder`].
     pub fn new() -> ServiceBuilder {
         ServiceBuilder {
             handlers: HashMap::new(),
         }
     }
 
-    /// Add a unary rpc call handler.
-    pub fn add_unary_handler<P, Q, F>(mut self, method: &Method<P, Q>, handler: F) -> ServiceBuilder
+    /// Add a unary RPC call handler.
+    pub fn add_unary_handler<Req, Resp, F>(mut self, method: &Method<Req, Resp>, handler: F) -> ServiceBuilder
     where
-        P: 'static,
-        Q: 'static,
-        F: Fn(RpcContext, P, UnarySink<Q>) + 'static,
+        Req: 'static,
+        Resp: 'static,
+        F: Fn(RpcContext, Req, UnarySink<Resp>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
         let h = Box::new(move |ctx: RpcContext, payload: &[u8]| {
@@ -148,16 +149,16 @@ impl ServiceBuilder {
         self
     }
 
-    /// Add a client streaming rpc call handler.
-    pub fn add_client_streaming_handler<P, Q, F>(
+    /// Add a client streaming RPC call handler.
+    pub fn add_client_streaming_handler<Req, Resp, F>(
         mut self,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         handler: F,
     ) -> ServiceBuilder
     where
-        P: 'static,
-        Q: 'static,
-        F: Fn(RpcContext, RequestStream<P>, ClientStreamingSink<Q>) + 'static,
+        Req: 'static,
+        Resp: 'static,
+        F: Fn(RpcContext, RequestStream<Req>, ClientStreamingSink<Resp>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
         let h = Box::new(move |ctx: RpcContext, _: &[u8]| {
@@ -170,16 +171,16 @@ impl ServiceBuilder {
         self
     }
 
-    /// Add a server streaming rpc call handler.
-    pub fn add_server_streaming_handler<P, Q, F>(
+    /// Add a server streaming RPC call handler.
+    pub fn add_server_streaming_handler<Req, Resp, F>(
         mut self,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         handler: F,
     ) -> ServiceBuilder
     where
-        P: 'static,
-        Q: 'static,
-        F: Fn(RpcContext, P, ServerStreamingSink<Q>) + 'static,
+        Req: 'static,
+        Resp: 'static,
+        F: Fn(RpcContext, Req, ServerStreamingSink<Resp>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
         let h = Box::new(move |ctx: RpcContext, payload: &[u8]| {
@@ -192,16 +193,16 @@ impl ServiceBuilder {
         self
     }
 
-    /// Add a duplex streaming rpc call handler.
-    pub fn add_duplex_streaming_handler<P, Q, F>(
+    /// Add a duplex streaming RPC call handler.
+    pub fn add_duplex_streaming_handler<Req, Resp, F>(
         mut self,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         handler: F,
     ) -> ServiceBuilder
     where
-        P: 'static,
-        Q: 'static,
-        F: Fn(RpcContext, RequestStream<P>, DuplexSink<Q>) + 'static,
+        Req: 'static,
+        Resp: 'static,
+        F: Fn(RpcContext, RequestStream<Req>, DuplexSink<Resp>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
         let h = Box::new(move |ctx: RpcContext, _: &[u8]| {
@@ -212,6 +213,7 @@ impl ServiceBuilder {
         self
     }
 
+    /// Finalize the [`ServiceBuilder`] and build the [`Service`].
     pub fn build(self) -> Service {
         Service {
             handlers: self.handlers,
@@ -219,11 +221,14 @@ impl ServiceBuilder {
     }
 }
 
+/// A gRPC service.
+///
+/// Use [`ServiceBuilder`] to build a [`Service`].
 pub struct Service {
     handlers: HashMap<&'static [u8], Handler>,
 }
 
-/// Server configuration struct.
+/// [`Server`] factory in order to configure the properties.
 pub struct ServerBuilder {
     env: Arc<Environment>,
     binders: Vec<Binder>,
@@ -233,6 +238,7 @@ pub struct ServerBuilder {
 }
 
 impl ServerBuilder {
+    /// Initialize a new [`ServerBuilder`].
     pub fn new(env: Arc<Environment>) -> ServerBuilder {
         ServerBuilder {
             env,
@@ -245,13 +251,14 @@ impl ServerBuilder {
 
     /// Bind to an address.
     ///
-    /// This function can be called multiple times.
+    /// This function can be called multiple times to bind to multiple ports.
     pub fn bind<S: Into<String>>(mut self, host: S, port: u16) -> ServerBuilder {
         self.binders.push(Binder::new(host.into(), port));
         self
     }
 
     /// Add additional configuration for each incoming channel.
+    #[doc(hidden)]
     pub fn channel_args(mut self, args: ChannelArgs) -> ServerBuilder {
         self.args = Some(args);
         self
@@ -269,6 +276,7 @@ impl ServerBuilder {
         self
     }
 
+    /// Finalize the [`ServerBuilder`] and build the [`Server`].
     pub fn build(mut self) -> Result<Server> {
         let args = self.args
             .as_ref()
@@ -318,7 +326,7 @@ mod secure_server {
     impl ServerBuilder {
         /// Bind to an address for secure connection.
         ///
-        /// This function can be called multiple times.
+        /// This function can be called multiple times to bind to multiple ports.
         pub fn bind_secure<S: Into<String>>(
             mut self,
             host: S,
@@ -388,7 +396,7 @@ pub fn request_call(inner: Arc<Inner>, cq: &CompletionQueue) {
     }
 }
 
-/// An asynchronize shutdown future.
+/// A `Future` that will resolve when shutdown completes.
 pub struct ShutdownFuture {
     cq_f: CqFuture<()>,
 }
@@ -407,6 +415,11 @@ impl Future for ShutdownFuture {
 unsafe impl Sync for Inner {}
 unsafe impl Send for Inner {}
 
+/// A gRPC server.
+///
+/// A single server can serve arbitrary number of services and can listen on more than one port.
+///
+/// Use [`ServerBuilder`] to build a [`Server`].
 pub struct Server {
     inner: Arc<Inner>,
 }
@@ -437,9 +450,7 @@ impl Server {
         unsafe { grpc_sys::grpc_server_cancel_all_calls(self.inner.server) }
     }
 
-    /// Start a server.
-    ///
-    /// Tells all listeners to start listening.
+    /// Start the server.
     pub fn start(&mut self) {
         unsafe {
             grpc_sys::grpc_server_start(self.inner.server);
@@ -451,7 +462,7 @@ impl Server {
         }
     }
 
-    /// Get the binded addresses.
+    /// Get binded addresses.
     pub fn bind_addrs(&self) -> &[(String, u16)] {
         &self.inner.bind_addrs
     }

--- a/src/server.rs
+++ b/src/server.rs
@@ -32,24 +32,41 @@ use RpcContext;
 
 const DEFAULT_REQUEST_SLOTS_PER_CQ: usize = 1024;
 
-pub type CallBack = Box<Fn(RpcContext, &[u8])>;
-
 /// An RPC call holder.
-pub struct Handler {
+#[derive(Clone)]
+pub struct Handler<F> {
     method_type: MethodType,
-    cb: CallBack,
+    cb: F,
 }
 
-impl Handler {
-    pub fn new(method_type: MethodType, cb: CallBack) -> Handler {
+impl<F> Handler<F> {
+    pub fn new(method_type: MethodType, cb: F) -> Handler<F> {
         Handler { method_type, cb }
     }
+}
 
-    pub fn cb(&self) -> &CallBack {
-        &self.cb
+pub trait CloneableHandler: Send {
+    fn handle(&self, ctx: RpcContext, reqs: &[u8]);
+    fn box_clone(&self) -> Box<CloneableHandler>;
+    fn method_type(&self) -> MethodType;
+}
+
+impl<F: 'static> CloneableHandler for Handler<F>
+where
+    F: Fn(RpcContext, &[u8]) + Send + Clone,
+{
+    #[inline]
+    fn handle(&self, ctx: RpcContext, reqs: &[u8]) {
+        (self.cb)(ctx, reqs)
     }
 
-    pub fn method_type(&self) -> MethodType {
+    #[inline]
+    fn box_clone(&self) -> Box<CloneableHandler> {
+        Box::new(self.clone())
+    }
+
+    #[inline]
+    fn method_type(&self) -> MethodType {
         self.method_type
     }
 }
@@ -119,7 +136,7 @@ use self::imp::Binder;
 ///
 /// Use it to build a service which can be registered to a server.
 pub struct ServiceBuilder {
-    handlers: HashMap<&'static [u8], Handler>,
+    handlers: HashMap<&'static [u8], BoxHandler>,
 }
 
 impl ServiceBuilder {
@@ -139,14 +156,13 @@ impl ServiceBuilder {
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, Req, UnarySink<Resp>) + 'static,
+        F: Fn(RpcContext, Req, UnarySink<Resp>) + Send + Clone + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx: RpcContext, payload: &[u8]| {
-            execute_unary(ctx, ser, de, payload, &handler)
-        });
-        self.handlers
-            .insert(method.name.as_bytes(), Handler::new(MethodType::Unary, h));
+        let h =
+            move |ctx: RpcContext, payload: &[u8]| execute_unary(ctx, ser, de, payload, &handler);
+        let ch = Box::new(Handler::new(MethodType::Unary, h));
+        self.handlers.insert(method.name.as_bytes(), ch);
         self
     }
 
@@ -159,16 +175,12 @@ impl ServiceBuilder {
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, RequestStream<Req>, ClientStreamingSink<Resp>) + 'static,
+        F: Fn(RpcContext, RequestStream<Req>, ClientStreamingSink<Resp>) + Send + Clone + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx: RpcContext, _: &[u8]| {
-            execute_client_streaming(ctx, ser, de, &handler)
-        });
-        self.handlers.insert(
-            method.name.as_bytes(),
-            Handler::new(MethodType::ClientStreaming, h),
-        );
+        let h = move |ctx: RpcContext, _: &[u8]| execute_client_streaming(ctx, ser, de, &handler);
+        let ch = Box::new(Handler::new(MethodType::ClientStreaming, h));
+        self.handlers.insert(method.name.as_bytes(), ch);
         self
     }
 
@@ -181,16 +193,14 @@ impl ServiceBuilder {
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, Req, ServerStreamingSink<Resp>) + 'static,
+        F: Fn(RpcContext, Req, ServerStreamingSink<Resp>) + Send + Clone + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx: RpcContext, payload: &[u8]| {
+        let h = move |ctx: RpcContext, payload: &[u8]| {
             execute_server_streaming(ctx, ser, de, payload, &handler)
-        });
-        self.handlers.insert(
-            method.name.as_bytes(),
-            Handler::new(MethodType::ServerStreaming, h),
-        );
+        };
+        let ch = Box::new(Handler::new(MethodType::ServerStreaming, h));
+        self.handlers.insert(method.name.as_bytes(), ch);
         self
     }
 
@@ -203,14 +213,12 @@ impl ServiceBuilder {
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, RequestStream<Req>, DuplexSink<Resp>) + 'static,
+        F: Fn(RpcContext, RequestStream<Req>, DuplexSink<Resp>) + Send + Clone + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = Box::new(move |ctx: RpcContext, _: &[u8]| {
-            execute_duplex_streaming(ctx, ser, de, &handler)
-        });
-        self.handlers
-            .insert(method.name.as_bytes(), Handler::new(MethodType::Duplex, h));
+        let h = move |ctx: RpcContext, _: &[u8]| execute_duplex_streaming(ctx, ser, de, &handler);
+        let ch = Box::new(Handler::new(MethodType::Duplex, h));
+        self.handlers.insert(method.name.as_bytes(), ch);
         self
     }
 
@@ -226,7 +234,7 @@ impl ServiceBuilder {
 ///
 /// Use [`ServiceBuilder`] to build a [`Service`].
 pub struct Service {
-    handlers: HashMap<&'static [u8], Handler>,
+    handlers: HashMap<&'static [u8], BoxHandler>,
 }
 
 /// [`Server`] factory in order to configure the properties.
@@ -235,7 +243,7 @@ pub struct ServerBuilder {
     binders: Vec<Binder>,
     args: Option<ChannelArgs>,
     slots_per_cq: usize,
-    handlers: HashMap<&'static [u8], Handler>,
+    handlers: HashMap<&'static [u8], BoxHandler>,
 }
 
 impl ServerBuilder {
@@ -306,14 +314,14 @@ impl ServerBuilder {
             }
 
             Ok(Server {
-                inner: Arc::new(Inner {
-                    env: self.env,
+                env: self.env,
+                core: Arc::new(ServerCore {
                     server,
                     shutdown: AtomicBool::new(false),
                     bind_addrs,
                     slots_per_cq: self.slots_per_cq,
-                    handlers: self.handlers,
                 }),
+                handlers: self.handlers,
             })
         }
     }
@@ -341,37 +349,46 @@ mod secure_server {
     }
 }
 
-pub struct Inner {
-    env: Arc<Environment>,
+struct ServerCore {
     server: *mut GrpcServer,
     bind_addrs: Vec<(String, u16)>,
     slots_per_cq: usize,
     shutdown: AtomicBool,
-    handlers: HashMap<&'static [u8], Handler>,
 }
 
-impl Inner {
-    /// Get the handler for the requested method path.
-    pub fn get_handler(&self, method: &[u8]) -> Option<&Handler> {
-        self.handlers.get(method)
-    }
-}
-
-impl Debug for Inner {
-    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "Server {:?}", self.bind_addrs)
-    }
-}
-
-impl Drop for Inner {
+impl Drop for ServerCore {
     fn drop(&mut self) {
         unsafe { grpc_sys::grpc_server_destroy(self.server) }
     }
 }
 
+unsafe impl Send for ServerCore {}
+unsafe impl Sync for ServerCore {}
+
+pub type BoxHandler = Box<CloneableHandler>;
+
+#[derive(Clone)]
+pub struct RequestCallContext {
+    server: Arc<ServerCore>,
+    registry: Arc<HashMap<&'static [u8], BoxHandler>>,
+}
+
+impl RequestCallContext {
+    /// Users should guarantee the method is always called from the same thread.
+    /// TODO: Is there a better way?
+    #[inline]
+    pub unsafe fn get_handler(&self, path: &[u8]) -> Option<&BoxHandler> {
+        self.registry.get(path)
+    }
+}
+
+// Apprently, its life time is guaranteed by the ref count, hence is safe to be sent
+// to other thread. However it's not `Sync`, as `BoxHandler` is neccessary not `Sync`.
+unsafe impl Send for RequestCallContext {}
+
 /// Request notification of a new call.
-pub fn request_call(inner: Arc<Inner>, cq: &CompletionQueue) {
-    if inner.shutdown.load(Ordering::Relaxed) {
+pub fn request_call(ctx: RequestCallContext, cq: &CompletionQueue) {
+    if ctx.server.shutdown.load(Ordering::Relaxed) {
         return;
     }
     let cq_ref = match cq.borrow() {
@@ -379,8 +396,8 @@ pub fn request_call(inner: Arc<Inner>, cq: &CompletionQueue) {
         Err(_) => return,
         Ok(c) => c,
     };
-    let server_ptr = inner.server;
-    let prom = CallTag::request(inner);
+    let server_ptr = ctx.server.server;
+    let prom = CallTag::request(ctx);
     let request_ptr = prom.request_ctx().unwrap().as_ptr();
     let prom_box = Box::new(prom);
     let tag = Box::into_raw(prom_box);
@@ -413,17 +430,15 @@ impl Future for ShutdownFuture {
     }
 }
 
-// It's safe to request call simultaneously.
-unsafe impl Sync for Inner {}
-unsafe impl Send for Inner {}
-
 /// A gRPC server.
 ///
 /// A single server can serve arbitrary number of services and can listen on more than one port.
 ///
 /// Use [`ServerBuilder`] to build a [`Server`].
 pub struct Server {
-    inner: Arc<Inner>,
+    env: Arc<Environment>,
+    core: Arc<ServerCore>,
+    handlers: HashMap<&'static [u8], BoxHandler>,
 }
 
 impl Server {
@@ -434,14 +449,14 @@ impl Server {
         let tag = Box::into_raw(prom_box);
         unsafe {
             // Since env still exists, no way can cq been shutdown.
-            let cq_ref = self.inner.env.completion_queues()[0].borrow().unwrap();
+            let cq_ref = self.env.completion_queues()[0].borrow().unwrap();
             grpc_sys::grpc_server_shutdown_and_notify(
-                self.inner.server,
+                self.core.server,
                 cq_ref.as_ptr(),
                 tag as *mut _,
             )
         }
-        self.inner.shutdown.store(true, Ordering::SeqCst);
+        self.core.shutdown.store(true, Ordering::SeqCst);
         ShutdownFuture { cq_f }
     }
 
@@ -449,16 +464,27 @@ impl Server {
     ///
     /// Only usable after shutdown.
     pub fn cancel_all_calls(&mut self) {
-        unsafe { grpc_sys::grpc_server_cancel_all_calls(self.inner.server) }
+        unsafe { grpc_sys::grpc_server_cancel_all_calls(self.core.server) }
     }
 
     /// Start the server.
     pub fn start(&mut self) {
         unsafe {
-            grpc_sys::grpc_server_start(self.inner.server);
-            for cq in self.inner.env.completion_queues() {
-                for _ in 0..self.inner.slots_per_cq {
-                    request_call(self.inner.clone(), cq);
+            grpc_sys::grpc_server_start(self.core.server);
+            for cq in self.env.completion_queues() {
+                // Handlers are Send and Clone, but not Sync. So we need to
+                // provide a replica for each completion queue.
+                let registry = self
+                    .handlers
+                    .iter()
+                    .map(|(k, v)| (k.to_owned(), v.box_clone()))
+                    .collect();
+                let rc = RequestCallContext {
+                    server: self.core.clone(),
+                    registry: Arc::new(registry),
+                };
+                for _ in 0..self.core.slots_per_cq {
+                    request_call(rc.clone(), cq);
                 }
             }
         }
@@ -466,7 +492,7 @@ impl Server {
 
     /// Get binded addresses.
     pub fn bind_addrs(&self) -> &[(String, u16)] {
-        &self.inner.bind_addrs
+        &self.core.bind_addrs
     }
 }
 
@@ -482,6 +508,6 @@ impl Drop for Server {
 
 impl Debug for Server {
     fn fmt(&self, f: &mut Formatter) -> fmt::Result {
-        write!(f, "{:?}", self.inner)
+        write!(f, "Server {:?}", self.core.bind_addrs)
     }
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -12,23 +12,23 @@
 // limitations under the License.
 
 use std::collections::HashMap;
-use std::ptr;
-use std::sync::Arc;
-use std::sync::atomic::{AtomicBool, Ordering};
 use std::fmt;
 use std::fmt::{Debug, Formatter};
+use std::ptr;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 
 use futures::{Async, Future, Poll};
 use grpc_sys::{self, GrpcCallStatus, GrpcServer};
 
-use RpcContext;
 use async::{CallTag, CqFuture};
-use call::{Method, MethodType};
 use call::server::*;
+use call::{Method, MethodType};
 use channel::ChannelArgs;
 use cq::CompletionQueue;
 use env::Environment;
 use error::{Error, Result};
+use RpcContext;
 
 const DEFAULT_REQUEST_SLOTS_PER_CQ: usize = 1024;
 
@@ -42,10 +42,7 @@ pub struct Handler {
 
 impl Handler {
     pub fn new(method_type: MethodType, cb: CallBack) -> Handler {
-        Handler {
-            method_type,
-            cb,
-        }
+        Handler { method_type, cb }
     }
 
     pub fn cb(&self) -> &CallBack {
@@ -134,7 +131,11 @@ impl ServiceBuilder {
     }
 
     /// Add a unary RPC call handler.
-    pub fn add_unary_handler<Req, Resp, F>(mut self, method: &Method<Req, Resp>, handler: F) -> ServiceBuilder
+    pub fn add_unary_handler<Req, Resp, F>(
+        mut self,
+        method: &Method<Req, Resp>,
+        handler: F,
+    ) -> ServiceBuilder
     where
         Req: 'static,
         Resp: 'static,
@@ -278,7 +279,8 @@ impl ServerBuilder {
 
     /// Finalize the [`ServerBuilder`] and build the [`Server`].
     pub fn build(mut self) -> Result<Server> {
-        let args = self.args
+        let args = self
+            .args
             .as_ref()
             .map_or_else(ptr::null, |args| args.as_ptr());
         unsafe {

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,8 +43,8 @@ pub struct Handler {
 impl Handler {
     pub fn new(method_type: MethodType, cb: CallBack) -> Handler {
         Handler {
-            method_type: method_type,
-            cb: cb,
+            method_type,
+            cb,
         }
     }
 
@@ -235,7 +235,7 @@ pub struct ServerBuilder {
 impl ServerBuilder {
     pub fn new(env: Arc<Environment>) -> ServerBuilder {
         ServerBuilder {
-            env: env,
+            env,
             binders: Vec::new(),
             args: None,
             slots_per_cq: DEFAULT_REQUEST_SLOTS_PER_CQ,
@@ -298,9 +298,9 @@ impl ServerBuilder {
             Ok(Server {
                 inner: Arc::new(Inner {
                     env: self.env,
-                    server: server,
+                    server,
                     shutdown: AtomicBool::new(false),
-                    bind_addrs: bind_addrs,
+                    bind_addrs,
                     slots_per_cq: self.slots_per_cq,
                     handlers: self.handlers,
                 }),
@@ -427,7 +427,7 @@ impl Server {
             )
         }
         self.inner.shutdown.store(true, Ordering::SeqCst);
-        ShutdownFuture { cq_f: cq_f }
+        ShutdownFuture { cq_f }
     }
 
     /// Cancel all in-progress calls.

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
@@ -46,17 +47,17 @@ impl<F> Handler<F> {
 }
 
 pub trait CloneableHandler: Send {
-    fn handle(&self, ctx: RpcContext, reqs: &[u8]);
+    fn handle(&mut self, ctx: RpcContext, reqs: &[u8]);
     fn box_clone(&self) -> Box<CloneableHandler>;
     fn method_type(&self) -> MethodType;
 }
 
 impl<F: 'static> CloneableHandler for Handler<F>
 where
-    F: Fn(RpcContext, &[u8]) + Send + Clone,
+    F: FnMut(RpcContext, &[u8]) + Send + Clone + 'static,
 {
     #[inline]
-    fn handle(&self, ctx: RpcContext, reqs: &[u8]) {
+    fn handle(&mut self, ctx: RpcContext, reqs: &[u8]) {
         (self.cb)(ctx, reqs)
     }
 
@@ -151,16 +152,17 @@ impl ServiceBuilder {
     pub fn add_unary_handler<Req, Resp, F>(
         mut self,
         method: &Method<Req, Resp>,
-        handler: F,
+        mut handler: F,
     ) -> ServiceBuilder
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, Req, UnarySink<Resp>) + Send + Clone + 'static,
+        F: FnMut(RpcContext, Req, UnarySink<Resp>) + Send + Clone + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h =
-            move |ctx: RpcContext, payload: &[u8]| execute_unary(ctx, ser, de, payload, &handler);
+        let h = move |ctx: RpcContext, payload: &[u8]| {
+            execute_unary(ctx, ser, de, payload, &mut handler)
+        };
         let ch = Box::new(Handler::new(MethodType::Unary, h));
         self.handlers.insert(method.name.as_bytes(), ch);
         self
@@ -170,15 +172,19 @@ impl ServiceBuilder {
     pub fn add_client_streaming_handler<Req, Resp, F>(
         mut self,
         method: &Method<Req, Resp>,
-        handler: F,
+        mut handler: F,
     ) -> ServiceBuilder
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, RequestStream<Req>, ClientStreamingSink<Resp>) + Send + Clone + 'static,
+        F: FnMut(RpcContext, RequestStream<Req>, ClientStreamingSink<Resp>)
+            + Send
+            + Clone
+            + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = move |ctx: RpcContext, _: &[u8]| execute_client_streaming(ctx, ser, de, &handler);
+        let h =
+            move |ctx: RpcContext, _: &[u8]| execute_client_streaming(ctx, ser, de, &mut handler);
         let ch = Box::new(Handler::new(MethodType::ClientStreaming, h));
         self.handlers.insert(method.name.as_bytes(), ch);
         self
@@ -188,16 +194,16 @@ impl ServiceBuilder {
     pub fn add_server_streaming_handler<Req, Resp, F>(
         mut self,
         method: &Method<Req, Resp>,
-        handler: F,
+        mut handler: F,
     ) -> ServiceBuilder
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, Req, ServerStreamingSink<Resp>) + Send + Clone + 'static,
+        F: FnMut(RpcContext, Req, ServerStreamingSink<Resp>) + Send + Clone + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
         let h = move |ctx: RpcContext, payload: &[u8]| {
-            execute_server_streaming(ctx, ser, de, payload, &handler)
+            execute_server_streaming(ctx, ser, de, payload, &mut handler)
         };
         let ch = Box::new(Handler::new(MethodType::ServerStreaming, h));
         self.handlers.insert(method.name.as_bytes(), ch);
@@ -208,15 +214,16 @@ impl ServiceBuilder {
     pub fn add_duplex_streaming_handler<Req, Resp, F>(
         mut self,
         method: &Method<Req, Resp>,
-        handler: F,
+        mut handler: F,
     ) -> ServiceBuilder
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, RequestStream<Req>, DuplexSink<Resp>) + Send + Clone + 'static,
+        F: FnMut(RpcContext, RequestStream<Req>, DuplexSink<Resp>) + Send + Clone + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = move |ctx: RpcContext, _: &[u8]| execute_duplex_streaming(ctx, ser, de, &handler);
+        let h =
+            move |ctx: RpcContext, _: &[u8]| execute_duplex_streaming(ctx, ser, de, &mut handler);
         let ch = Box::new(Handler::new(MethodType::Duplex, h));
         self.handlers.insert(method.name.as_bytes(), ch);
         self
@@ -370,20 +377,21 @@ pub type BoxHandler = Box<CloneableHandler>;
 #[derive(Clone)]
 pub struct RequestCallContext {
     server: Arc<ServerCore>,
-    registry: Arc<HashMap<&'static [u8], BoxHandler>>,
+    registry: Arc<UnsafeCell<HashMap<&'static [u8], BoxHandler>>>,
 }
 
 impl RequestCallContext {
     /// Users should guarantee the method is always called from the same thread.
     /// TODO: Is there a better way?
     #[inline]
-    pub unsafe fn get_handler(&self, path: &[u8]) -> Option<&BoxHandler> {
-        self.registry.get(path)
+    pub unsafe fn get_handler(&mut self, path: &[u8]) -> Option<&mut BoxHandler> {
+        let registry = &mut *self.registry.get();
+        registry.get_mut(path)
     }
 }
 
 // Apprently, its life time is guaranteed by the ref count, hence is safe to be sent
-// to other thread. However it's not `Sync`, as `BoxHandler` is neccessary not `Sync`.
+// to other thread. However it's not `Sync`, as `BoxHandler` is not neccessary `Sync`.
 unsafe impl Send for RequestCallContext {}
 
 /// Request notification of a new call.
@@ -481,7 +489,7 @@ impl Server {
                     .collect();
                 let rc = RequestCallContext {
                     server: self.core.clone(),
-                    registry: Arc::new(registry),
+                    registry: Arc::new(UnsafeCell::new(registry)),
                 };
                 for _ in 0..self.core.slots_per_cq {
                     request_call(rc.clone(), cq);

--- a/tests/cases/alarm.rs
+++ b/tests/cases/alarm.rs
@@ -11,8 +11,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use futures::*;
 use futures::sync::oneshot::{self, Sender};
+use futures::*;
 use grpcio::*;
 use grpcio_proto::example::helloworld::*;
 use grpcio_proto::example::helloworld_grpc::*;
@@ -30,7 +30,8 @@ impl Greeter for GreeterService {
         let (tx, rx) = oneshot::channel();
         let tx_lock = self.tx.clone();
         let name = req.take_name();
-        let f = rx.map_err(|_| panic!("should receive message"))
+        let f = rx
+            .map_err(|_| panic!("should receive message"))
             .join(lazy(move || {
                 *tx_lock.lock().unwrap() = Some(tx);
                 Ok(())

--- a/tests/cases/cancel.rs
+++ b/tests/cases/cancel.rs
@@ -1,0 +1,225 @@
+// Copyright 2018 PingCAP, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::{Arc, Mutex};
+
+use futures::{future, stream as streams, Async, Future, Poll, Sink, Stream};
+use grpcio::*;
+use grpcio_proto::example::route_guide::*;
+use grpcio_proto::example::route_guide_grpc::*;
+
+type Handler<T> = Arc<Mutex<Option<Box<T>>>>;
+type BoxFuture = Box<Future<Item = (), Error = ()> + Send + 'static>;
+type RecordRouteHandler =
+    Handler<Fn(RequestStream<Point>, ClientStreamingSink<RouteSummary>) -> BoxFuture + Send>;
+type RouteChatHandler =
+    Handler<Fn(RequestStream<RouteNote>, DuplexSink<RouteNote>) -> BoxFuture + Send>;
+
+#[derive(Clone)]
+struct CancelService {
+    record_route_handler: RecordRouteHandler,
+    route_chat_handler: RouteChatHandler,
+}
+
+impl CancelService {
+    fn new() -> CancelService {
+        CancelService {
+            record_route_handler: Arc::new(Mutex::new(None)),
+            route_chat_handler: Arc::new(Mutex::new(None)),
+        }
+    }
+}
+
+impl RouteGuide for CancelService {
+    fn get_feature(&mut self, _: RpcContext, _: Point, sink: UnarySink<Feature>) {
+        // Drop the sink, client should receive Cancelled.
+        drop(sink);
+    }
+
+    fn list_features(&mut self, _: RpcContext, _: Rectangle, sink: ServerStreamingSink<Feature>) {
+        // Drop the sink, client should receive Cancelled.
+        drop(sink);
+    }
+
+    fn record_route(
+        &mut self,
+        ctx: RpcContext,
+        stream: RequestStream<Point>,
+        sink: ClientStreamingSink<RouteSummary>,
+    ) {
+        let handler = self.record_route_handler.lock().unwrap();
+        if handler.is_some() {
+            let f = (handler.as_ref().unwrap())(stream, sink);
+            ctx.spawn(f);
+        }
+    }
+
+    fn route_chat(
+        &mut self,
+        ctx: RpcContext,
+        stream: RequestStream<RouteNote>,
+        sink: DuplexSink<RouteNote>,
+    ) {
+        let handler = self.route_chat_handler.lock().unwrap();
+        if handler.is_some() {
+            let f = (handler.as_ref().unwrap())(stream, sink);
+            ctx.spawn(f);
+        }
+    }
+}
+
+fn check_cancel<S, T>(rx: S)
+where
+    S: Stream<Item = T, Error = Error>,
+{
+    match rx.into_future().wait() {
+        Err((Error::RpcFailure(s), _)) | Err((Error::RpcFinished(Some(s)), _)) => {
+            assert_eq!(s.status, RpcStatusCode::Cancelled)
+        }
+        Err((e, _)) => panic!("expected cancel, but got: {:?}", e),
+        Ok(_) => panic!("expected error, but got: Ok(_)"),
+    }
+}
+
+fn prepare_suite() -> (CancelService, RouteGuideClient, Server) {
+    let env = Arc::new(EnvBuilder::new().build());
+    let service = CancelService::new();
+    let mut server = ServerBuilder::new(env.clone())
+        .register_service(create_route_guide(service.clone()))
+        .bind("127.0.0.1", 0)
+        .build()
+        .unwrap();
+    server.start();
+    let port = server.bind_addrs()[0].1;
+    let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+    let client = RouteGuideClient::new(ch);
+    (service, client, server)
+}
+
+#[test]
+fn test_client_cancel_on_dropping() {
+    let (service, client, _server) = prepare_suite();
+
+    // Client streaming.
+    *service.record_route_handler.lock().unwrap() = Some(Box::new(|stream, sink| {
+        // Start the call and keep the stream and the sink.
+        let f = stream.for_each(|_| Ok(())).then(|_| {
+            let _sink = sink;
+            Ok(())
+        });
+        Box::new(f)
+    }));
+    let (tx, rx) = client.record_route().unwrap();
+    drop(tx);
+    check_cancel(rx.into_stream());
+
+    let (tx, rx) = client.record_route().unwrap();
+    drop(rx);
+    check_cancel(tx.send(Default::default()).into_stream());
+
+    // Duplex streaming.
+    *service.record_route_handler.lock().unwrap() = Some(Box::new(|stream, sink| {
+        // Start the call and keep the stream and the sink.
+        let f = stream.for_each(|_| Ok(())).then(|_| {
+            let _sink = sink;
+            Ok(())
+        });
+        Box::new(f)
+    }));
+    let (tx, rx) = client.route_chat().unwrap();
+    drop(tx);
+    check_cancel(rx);
+
+    let (tx, rx) = client.route_chat().unwrap();
+    drop(rx);
+    check_cancel(tx.send(Default::default()).into_stream());
+}
+
+#[test]
+fn test_server_cancel_on_dropping() {
+    let (service, client, _server) = prepare_suite();
+
+    // Unary
+    let rx = client.get_feature_async(&Default::default()).unwrap();
+    check_cancel(rx.into_stream());
+
+    // Server streaming
+    let rx = client.list_features(&Default::default()).unwrap();
+    check_cancel(rx);
+
+    // Start the call, keep the stream and drop the sink.
+    fn drop_sink<S, R, T>(stream: S, sink: T) -> BoxFuture
+    where
+        S: Stream<Item = R, Error = Error> + Send + 'static,
+        R: Send + 'static,
+        T: Send + 'static,
+    {
+        let f = stream
+            .for_each(|_| Ok(()))
+            .join(future::result(Ok(())).map(move |_| {
+                drop(sink);
+            }))
+            .then(|_| Ok(()));
+        Box::new(f)
+    }
+
+    // Start the call, drop the stream and keep the sink.
+    fn drop_stream<S, R, T>(stream: S, sink: T) -> BoxFuture
+    where
+        S: Stream<Item = R, Error = Error> + Send + 'static,
+        R: Send + 'static,
+        T: Send + 'static,
+    {
+        let mut stream = Some(stream);
+        let f = streams::poll_fn(move || -> Poll<Option<()>, ()> {
+            if stream.is_some() {
+                let s = stream.as_mut().unwrap();
+                // start the call.
+                let _ = s.poll();
+            }
+            // drop the stream.
+            stream.take();
+            Ok(Async::NotReady)
+        });
+        // It never resolves.
+        let f = f.for_each(|_| Ok(())).then(move |_| {
+            let _sink = sink;
+            Ok(())
+        });
+        Box::new(f)
+    }
+
+    // Client streaming, drop sink.
+    *service.record_route_handler.lock().unwrap() =
+        Some(Box::new(|stream, sink| drop_sink(stream, sink)));
+    let (_tx, rx) = client.record_route().unwrap();
+    check_cancel(rx.into_stream());
+
+    // Client streaming, drop stream.
+    *service.record_route_handler.lock().unwrap() =
+        Some(Box::new(|stream, sink| drop_stream(stream, sink)));
+    let (_tx, rx) = client.record_route().unwrap();
+    check_cancel(rx.into_stream());
+
+    // Duplex streaming, drop sink.
+    *service.route_chat_handler.lock().unwrap() =
+        Some(Box::new(|stream, sink| drop_sink(stream, sink)));
+    let (_tx, rx) = client.route_chat().unwrap();
+    check_cancel(rx);
+
+    // Duplex streaming, drop stream.
+    *service.route_chat_handler.lock().unwrap() =
+        Some(Box::new(|stream, sink| drop_stream(stream, sink)));
+    let (_tx, rx) = client.route_chat().unwrap();
+    check_cancel(rx);
+}

--- a/tests/cases/health_check.rs
+++ b/tests/cases/health_check.rs
@@ -27,7 +27,7 @@ struct HealthService {
 
 impl Health for HealthService {
     fn check(
-        &self,
+        &mut self,
         ctx: RpcContext,
         req: HealthCheckRequest,
         sink: UnarySink<HealthCheckResponse>,

--- a/tests/cases/kick.rs
+++ b/tests/cases/kick.rs
@@ -47,7 +47,7 @@ impl Greeter for GreeterService {
 }
 
 #[test]
-fn test_alarm_notify() {
+fn test_kick() {
     let env = Arc::new(EnvBuilder::new().build());
     let tx = Arc::new(Mutex::new(None));
     let service = create_greeter(GreeterService { tx: tx.clone() });
@@ -74,4 +74,31 @@ fn test_alarm_notify() {
     }
     let reply = f.wait().expect("rpc");
     assert_eq!(reply.get_message(), "hello world");
+
+    // Spawn a future in the client.
+    let (tx1, rx2) = spawn_chianed_channel(&client);
+    thread::sleep(Duration::from_millis(10));
+    let _ = tx1.send(77);
+    assert_eq!(rx2.wait().unwrap(), 77);
+
+    // Drop the client before a future is resloved.
+    let (tx1, rx2) = spawn_chianed_channel(&client);
+    drop(client);
+    thread::sleep(Duration::from_millis(10));
+    let _ = tx1.send(88);
+    assert_eq!(rx2.wait().unwrap(), 88);
+}
+
+fn spawn_chianed_channel(
+    client: &GreeterClient,
+) -> (oneshot::Sender<usize>, oneshot::Receiver<usize>) {
+    let (tx1, rx1) = oneshot::channel();
+    let (tx2, rx2) = oneshot::channel();
+    let f =
+        rx1.map(|n| {
+            let _ = tx2.send(n);
+        }).map_err(|_| ());
+    client.spawn(f);
+
+    (tx1, rx2)
 }

--- a/tests/cases/kick.rs
+++ b/tests/cases/kick.rs
@@ -26,7 +26,7 @@ struct GreeterService {
 }
 
 impl Greeter for GreeterService {
-    fn say_hello(&self, ctx: RpcContext, mut req: HelloRequest, sink: UnarySink<HelloReply>) {
+    fn say_hello(&mut self, ctx: RpcContext, mut req: HelloRequest, sink: UnarySink<HelloReply>) {
         let (tx, rx) = oneshot::channel();
         let tx_lock = self.tx.clone();
         let name = req.take_name();

--- a/tests/cases/metadata.rs
+++ b/tests/cases/metadata.rs
@@ -25,7 +25,7 @@ struct GreeterService {
 }
 
 impl Greeter for GreeterService {
-    fn say_hello(&self, ctx: RpcContext, mut req: HelloRequest, sink: UnarySink<HelloReply>) {
+    fn say_hello(&mut self, ctx: RpcContext, mut req: HelloRequest, sink: UnarySink<HelloReply>) {
         for (key, value) in ctx.request_headers() {
             self.tx.send((key.to_owned(), value.to_owned())).unwrap();
         }

--- a/tests/cases/metadata.rs
+++ b/tests/cases/metadata.rs
@@ -12,10 +12,10 @@
 // limitations under the License.
 
 use futures::*;
-use std::sync::mpsc::{self, Sender};
 use grpcio::*;
 use grpcio_proto::example::helloworld::*;
 use grpcio_proto::example::helloworld_grpc::*;
+use std::sync::mpsc::{self, Sender};
 use std::sync::*;
 use std::time::*;
 

--- a/tests/cases/mod.rs
+++ b/tests/cases/mod.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+mod cancel;
 mod health_check;
 mod kick;
 mod metadata;

--- a/tests/cases/mod.rs
+++ b/tests/cases/mod.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod alarm;
+mod kick;
 mod health_check;
 mod metadata;
 mod misc;

--- a/tests/cases/mod.rs
+++ b/tests/cases/mod.rs
@@ -11,7 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-mod kick;
 mod health_check;
+mod kick;
 mod metadata;
 mod misc;


### PR DESCRIPTION
Currently grpc-sys builds with boringssl. Which causes issues when I try to use openssl-based crates )e.g. reqwest) in the same project. Main reason is ```rustc``` way linking of static libraries.

Building of this code fails with a lot of unresolved symbols

```rust
extern crate grpcio;
extern crate reqwest;

use std::sync::Arc;

fn main() {
    let _c = reqwest::Client::new();

    let e = Arc::new(grpcio::Environment::new(2));
    let cred = grpcio::ChannelCredentialsBuilder::new().build();
    let _channel = grpcio::ChannelBuilder::new(e).secure_connect("example.com:443", cred);

    println!("Hello, world!");
}

```

```bash
         /home/bacek/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/src/ssl/bio.rs:192: undefined reference to `BIO_meth_new'
          /home/bacek/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/src/ssl/bio.rs:195: undefined reference to `BIO_meth_set_write'
          /home/bacek/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/src/ssl/bio.rs:196: undefined reference to `BIO_meth_set_read'
          /home/bacek/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/src/ssl/bio.rs:197: undefined reference to `BIO_meth_set_puts'
          /home/bacek/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/src/ssl/bio.rs:198: undefined reference to `BIO_meth_set_ctrl'
          /home/bacek/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/src/ssl/bio.rs:199: undefined reference to `BIO_meth_set_create'
          /home/bacek/.cargo/registry/src/github.com-1ecc6299db9ec823/openssl-0.9.24/src/ssl/bio.rs:200: undefined reference to `BIO_meth_set_destroy'

```

Building with openssl solves it issue:

Cargo.toml
```toml
[package]
name = "req-test"
version = "0.1.0"
authors = ["Vasily Chekalkin <bacek@bacek.com>"]

[dependencies.grpcio]
version = "0.2.3"
path = "../grpc-rs"
features = ["secure", "openssl"]

[dependencies]
reqwest = "0.8.5"

```

Build results:
```bash
$ cargo build
    Updating registry `https://github.com/rust-lang/crates.io-index`
   Compiling req-test v0.1.0 (file:///home/bacek/work/req-test)                 
    Finished dev [unoptimized + debuginfo] target(s) in 3.36 secs
```