### PR TITLE
Make secure feature optional and not by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This project is still under development. The following features with the check m
 
 - CMake >= 3.8.0
 - Rust >= 1.19.0
-- If you want to enable [secure feature](#feature-secure), Go (>=1.7) is required.
+- By default, the [secure feature](#feature-secure) is enabled, therefore Go (>=1.7) is required.
 
 For Linux and MacOS, you also need to install gcc (or clang) too.
 


### PR DESCRIPTION
Part of #149.

The README states:

> If you want to enable secure feature, Go (>=1.7) is required.

Then you'd expect the `secure` feature to be optional and not by default.