### PR TITLE
Add verbose documentations

### DIFF
--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -72,6 +72,9 @@ fn build_grpc(cc: &mut Build, library: &str) {
         if cfg!(target_os = "macos") {
             config.cxxflag("-stdlib=libc++");
         }
+        if env::var("CARGO_CFG_TARGET_ENV").unwrap_or("".to_owned()) == "musl" {
+            config.define("CMAKE_CXX_COMPILER", "g++");
+        }
         config.build_target(library).uses_cxx11().build()
     };
 

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -236,10 +236,10 @@ pub enum GrpcCompletionType {
     /// Shutting down.
     QueueShutdown,
 
-    /// No event before timeout
+    /// No event before timeout.
     QueueTimeout,
 
-    /// Operation completion
+    /// Operation completion.
     OpComplete,
 }
 

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -18,20 +18,38 @@ extern crate libc;
 use libc::{c_char, c_int, c_uint, c_void, size_t, int32_t, int64_t, uint32_t};
 use std::time::Duration;
 
+/// The clocks gRPC support.
+///
+/// Based on `gpr_clock_type`.
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub enum GprClockType {
+    /// Monotonic clock. Epoch undefined. Always moves forwards.
     Monotonic = 0,
+
+    /// Realtime clock. May jump forwards or backwards. Settable by the system administrator.
+    /// Has its epoch at 0:00:00 UTC 1 Jan 1970.
     Realtime,
+
+    /// CPU cycle time obtained by rdtsc instruction on x86 platforms. Epoch undefined. Degrades
+    /// to GPR_CLOCK_REALTIME on other platforms.
     Precise,
+
+    /// Unmeasurable clock type: no base, created by taking the difference between two times.
     Timespan,
 }
 
+/// Analogous to struct timespec. On some machines, absolute times may be in local time.
+///
+/// Based on `gpr_timespec`.
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct GprTimespec {
     pub tv_sec: int64_t,
     pub tv_nsec: int32_t,
+
+    /// Against which clock was this time measured? (or GPR_TIMESPAN if this is a relative time
+    /// meaure)
     pub clock_type: GprClockType,
 }
 
@@ -51,25 +69,78 @@ impl From<Duration> for GprTimespec {
     }
 }
 
+/// Result of a remote procedure call.
+///
+/// Based on `grpc_status_code`.
 #[repr(C)]
 #[derive(Debug, PartialEq, Clone, Copy)]
 pub enum GrpcStatusCode {
+    /// Not an error; returned on success.
     Ok = 0,
+
+    /// The operation was cancelled (typically by the caller).
     Cancelled = 1,
+
+    /// Unknown error. An example of where this error may be returned is if a Status value received
+    /// from another address space belongs to an error-space that is not known in this address
+    /// space. Also errors raised by APIs that do not return enough error information may be
+    /// converted to this error.
     Unknown = 2,
+
+    /// Client specified an invalid argument. Note that this differs from FAILED_PRECONDITION.
+    /// INVALID_ARGUMENT indicates arguments that are problematic regardless of the state of the
+    /// system (e.g., a malformed file name).
     InvalidArgument = 3,
+
+    /// Deadline expired before operation could complete. For operations that change the state of
+    /// the system, this error may be returned even if the operation has completed successfully.
+    /// For example, a successful response from a server could have been delayed long enough for
+    /// the deadline to expire.
     DeadlineExceeded = 4,
+
+    /// Some requested entity (e.g., file or directory) was not found.
     NotFound = 5,
+
+    /// Some entity that we attempted to create (e.g., file or directory) already exists.
     AlreadyExists = 6,
+
+    /// The caller does not have permission to execute the specified operation. PERMISSION_DENIED
+    /// must not be used for rejections caused by exhausting some resource (use RESOURCE_EXHAUSTED
+    /// instead for those errors). PERMISSION_DENIED must not be used if the caller can not be
+    /// identified (use UNAUTHENTICATED instead for those errors).
     PermissionDenied = 7,
+
+    /// The request does not have valid authentication credentials for the operation.
     Unauthenticated = 16,
+
+    /// Some resource has been exhausted, perhaps a per-user quota, or perhaps the entire file
+    /// system is out of space.
     ResourceExhausted = 8,
+
+    /// Operation was rejected because the system is not in a state required for the operation's
+    /// execution. For example, directory to be deleted may be non-empty, an rmdir operation is
+    /// applied to a non-directory, etc.
     FailedPrecondition = 9,
+
+    /// The operation was aborted, typically due to a concurrency issue like sequencer check
+    /// failures, transaction aborts, etc.
     Aborted = 10,
+
+    /// Operation was attempted past the valid range. E.g., seeking or reading past end of file.
     OutOfRange = 11,
+
+    /// Operation is not implemented or not supported/enabled in this service.
     Unimplemented = 12,
+
+    /// Internal errors. Means some invariants expected by underlying system has been broken. If
+    /// you see one of these errors, something is very broken.
     Internal = 13,
+
+    /// The service is currently unavailable. This is a most likely a transient condition and may
+    /// be corrected by retrying with a backoff.
     Unavailable = 14,
+
+    /// Unrecoverable data loss or corruption.
     DataLoss = 15,
 }
 
@@ -97,33 +168,83 @@ impl From<i32> for GrpcStatusCode {
     }
 }
 
+/// Result of a gRPC call.
+///
+/// If the caller satisfies the prerequisites of a
+/// particular operation, the `GrpcCallStatus` returned will be `Ok`.
+/// Receiving any other value listed here is an indication of a bug in the caller.
+///
+/// Based on `grpc_call_error`.
 #[repr(C)]
 #[derive(Debug, PartialEq)]
 pub enum GrpcCallStatus {
+    /// Everything went ok.
     Ok = 0,
+
+    /// Something failed, we don't know what.
     Error,
+
+    /// This method is not available on the server.
     ErrorNotOnServer,
+
+    /// This method is not available on the client.
     ErrorNotOnClient,
+
+    /// This method must be called before server_accept.
     ErrorAlreadyAccepted,
+
+    /// This method must be called before invoke.
     ErrorAlreadyInvoked,
+
+    /// This method must be called after invoke.
     ErrorNotInvoked,
+
+    /// This call is already finished (writes_done or write_status has already been called).
     ErrorAlreadyFinished,
+
+    /// There is already an outstanding read/write operation on the call.
     ErrorTooManyOperations,
+
+    /// The flags value was illegal for this call.
     ErrorInvalidFlags,
+
+    /// Invalid metadata was passed to this call.
     ErrorInvalidMetadata,
+
+    /// Invalid message was passed to this call.
     ErrorInvalidMessage,
+
+    /// Completion queue for notification has not been registered with the server.
     ErrorNotServerCompletionQueue,
+
+    /// This batch of operations leads to more operations than allowed.
     ErrorBatchTooBig,
+
+    /// Payload type requested is not the type registered.
     ErrorPayloadTypeMismatch,
+
+    /// Completion queue has been shutdown.
+    ErrorCompletionQueueShutdown,
 }
 
+/// The type of completion.
+///
+/// Based on `grpc_completion_type`.
 #[repr(C)]
 pub enum GrpcCompletionType {
+    /// Shutting down.
     QueueShutdown,
+
+    /// No event before timeout
     QueueTimeout,
+
+    /// Operation completion
     OpComplete,
 }
 
+/// The result of an operation.
+///
+/// Returned by a completion queue when the operation started with tag.
 #[repr(C)]
 pub struct GrpcEvent {
     pub event_type: GrpcCompletionType,
@@ -133,24 +254,57 @@ pub struct GrpcEvent {
 
 pub enum GrpcChannelArgs {}
 
+/// Connectivity state of a channel.
+///
+/// Based on `grpc_connectivity_state`.
 #[repr(C)]
 pub enum GrpcConnectivityState {
+    /// Channel has just been initialized.
     Init = -1,
+
+    /// Channel is idle.
     Idle,
+
+    /// Channel is connecting.
     Connecting,
+
+    /// Channel is ready for work.
     Ready,
+
+    /// Channel has seen a failure but expects to recover.
     TransientFailure,
+
+    /// Channel has seen a failure that it cannot recover from.
     Shutdown,
 }
 
+/// Compression levels supported by gRPC.
+///
+/// Compression levels allow a party with knowledge of its peer's accepted
+/// encodings to request compression in an abstract way. The level-algorithm
+/// mapping is performed internally and depends on the peer's supported
+/// compression algorithms.
+///
+/// Based on `grpc_compression_level`.
 #[repr(C)]
 pub enum GrpcCompressionLevel {
+    /// No compression.
     None = 0,
+
+    /// Low compression.
     Low,
+
+    /// Medium compression.
+    // TODO: Change to `Medium`.
     Med,
+
+    /// High compression.
     High,
 }
 
+/// Various compression algorithms supported by gRPC.
+///
+/// Based on `grpc_compression_algorithm`.
 #[repr(C)]
 pub enum GrpcCompressionAlgorithms {
     None = 0,
@@ -158,9 +312,15 @@ pub enum GrpcCompressionAlgorithms {
     Gzip,
 }
 
+/// How to handle payloads for a registered method.
+///
+/// Based on `grpc_server_register_method_payload_handling`.
 #[repr(C)]
 pub enum GrpcServerRegisterMethodPayloadHandling {
+    /// Don't try to read the payload.
     None,
+
+    /// Read the initial payload as a byte buffer.
     ReadInitialByteBuffer,
 }
 

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -18,7 +18,7 @@ extern crate libc;
 use libc::{c_char, c_int, c_uint, c_void, size_t, int32_t, int64_t, uint32_t};
 use std::time::Duration;
 
-/// The clocks gRPC support.
+/// The clocks gRPC supports.
 ///
 /// Based on `gpr_clock_type`.
 #[derive(Clone, Copy)]
@@ -224,7 +224,7 @@ pub enum GrpcCallStatus {
     /// Payload type requested is not the type registered.
     ErrorPayloadTypeMismatch,
 
-    /// Completion queue has been shutdown.
+    /// Completion queue has been shut down.
     ErrorCompletionQueueShutdown,
 }
 

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -24,7 +24,7 @@ use std::time::Duration;
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub enum GprClockType {
-    /// Monotonic clock. Epoch undefined. Always moves forwards.
+    /// Monotonic clock. Epoch undefined. Always moves forward.
     Monotonic = 0,
 
     /// Realtime clock. May jump forwards or backwards. Settable by the system administrator.
@@ -32,14 +32,14 @@ pub enum GprClockType {
     Realtime,
 
     /// CPU cycle time obtained by rdtsc instruction on x86 platforms. Epoch undefined. Degrades
-    /// to GPR_CLOCK_REALTIME on other platforms.
+    /// to [`GprClockType::Realtime`] on other platforms.
     Precise,
 
     /// Unmeasurable clock type: no base, created by taking the difference between two times.
     Timespan,
 }
 
-/// Analogous to struct timespec. On some machines, absolute times may be in local time.
+/// Analogous to struct `timespec`. On some machines, absolute times may be in local time.
 ///
 /// Based on `gpr_timespec`.
 #[derive(Clone, Copy)]
@@ -48,8 +48,8 @@ pub struct GprTimespec {
     pub tv_sec: int64_t,
     pub tv_nsec: int32_t,
 
-    /// Against which clock was this time measured? (or GPR_TIMESPAN if this is a relative time
-    /// meaure)
+    /// Against which clock was this time measured? (or [`GprClockType::Timespan`] if this is a
+    /// relative time measure)
     pub clock_type: GprClockType,
 }
 
@@ -87,8 +87,8 @@ pub enum GrpcStatusCode {
     /// converted to this error.
     Unknown = 2,
 
-    /// Client specified an invalid argument. Note that this differs from FAILED_PRECONDITION.
-    /// INVALID_ARGUMENT indicates arguments that are problematic regardless of the state of the
+    /// Client specified an invalid argument. Note that this differs from `FailedPrecondition`.
+    /// `InvalidArgument` indicates arguments that are problematic regardless of the state of the
     /// system (e.g., a malformed file name).
     InvalidArgument = 3,
 
@@ -104,10 +104,11 @@ pub enum GrpcStatusCode {
     /// Some entity that we attempted to create (e.g., file or directory) already exists.
     AlreadyExists = 6,
 
-    /// The caller does not have permission to execute the specified operation. PERMISSION_DENIED
-    /// must not be used for rejections caused by exhausting some resource (use RESOURCE_EXHAUSTED
-    /// instead for those errors). PERMISSION_DENIED must not be used if the caller can not be
-    /// identified (use UNAUTHENTICATED instead for those errors).
+    /// The caller does not have permission to execute the specified operation.
+    /// `PermissionDenied` must not be used for rejections caused by exhausting
+    /// some resource (use `ResourceExhausted` instead for those errors).
+    /// `PermissionDenied` must not be used if the caller can not be
+    /// identified (use `Unauthenticated` instead for those errors).
     PermissionDenied = 7,
 
     /// The request does not have valid authentication credentials for the operation.

--- a/src/async/executor.rs
+++ b/src/async/executor.rs
@@ -161,7 +161,7 @@ fn poll(notify: Arc<SpawnNotify>, woken: bool) {
     }
 }
 
-/// An executor that drives a future in the grpc poll thread, which
+/// An executor that drives a future in the gRPC poll thread, which
 /// can reduce thread context switching.
 pub struct Executor<'a> {
     cq: &'a CompletionQueue,

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -36,6 +36,7 @@ pub fn change_flag(res: &mut u32, flag: u32, set: bool) {
     }
 }
 
+/// Options for calls made by client.
 #[derive(Clone, Default)]
 pub struct CallOption {
     timeout: Option<Duration>,
@@ -45,7 +46,7 @@ pub struct CallOption {
 }
 
 impl CallOption {
-    /// Signal that the call is idempotent
+    /// Signal that the call is idempotent.
     pub fn idempotent(mut self, is_idempotent: bool) -> CallOption {
         change_flag(
             &mut self.call_flags,
@@ -55,7 +56,7 @@ impl CallOption {
         self
     }
 
-    /// Signal that the call should not return UNAVAILABLE before it has started
+    /// Signal that the call should not return UNAVAILABLE before it has started.
     pub fn wait_for_ready(mut self, wait_for_ready: bool) -> CallOption {
         change_flag(
             &mut self.call_flags,
@@ -65,7 +66,7 @@ impl CallOption {
         self
     }
 
-    /// Signal that the call is cacheable. GRPC is free to use GET verb
+    /// Signal that the call is cacheable. gRPC is free to use GET verb.
     pub fn cacheable(mut self, cacheable: bool) -> CallOption {
         change_flag(
             &mut self.call_flags,
@@ -75,6 +76,7 @@ impl CallOption {
         self
     }
 
+    /// Set write flags.
     pub fn write_flags(mut self, write_flags: WriteFlags) -> CallOption {
         self.write_flags = write_flags;
         self
@@ -97,19 +99,19 @@ impl CallOption {
         self
     }
 
-    /// Get the headers.
+    /// Get headers to be sent with the call.
     pub fn get_headers(&self) -> Option<&Metadata> {
         self.headers.as_ref()
     }
 }
 
 impl Call {
-    pub fn unary_async<P, Q>(
+    pub fn unary_async<Req, Resp>(
         channel: &Channel,
-        method: &Method<P, Q>,
-        req: &P,
+        method: &Method<Req, Resp>,
+        req: &Req,
         mut opt: CallOption,
-    ) -> Result<ClientUnaryReceiver<Q>> {
+    ) -> Result<ClientUnaryReceiver<Resp>> {
         let call = channel.create_call(method, &opt)?;
         let mut payload = vec![];
         (method.req_ser())(req, &mut payload);
@@ -130,11 +132,11 @@ impl Call {
         Ok(ClientUnaryReceiver::new(call, cq_f, method.resp_de()))
     }
 
-    pub fn client_streaming<P, Q>(
+    pub fn client_streaming<Req, Resp>(
         channel: &Channel,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         mut opt: CallOption,
-    ) -> Result<(ClientCStreamSender<P>, ClientCStreamReceiver<Q>)> {
+    ) -> Result<(ClientCStreamSender<Req>, ClientCStreamReceiver<Resp>)> {
         let call = channel.create_call(method, &opt)?;
         let cq_f = check_run(BatchType::CheckRead, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_client_streaming(
@@ -157,12 +159,12 @@ impl Call {
         Ok((sink, recv))
     }
 
-    pub fn server_streaming<P, Q>(
+    pub fn server_streaming<Req, Resp>(
         channel: &Channel,
-        method: &Method<P, Q>,
-        req: &P,
+        method: &Method<Req, Resp>,
+        req: &Req,
         mut opt: CallOption,
-    ) -> Result<ClientSStreamReceiver<Q>> {
+    ) -> Result<ClientSStreamReceiver<Resp>> {
         let call = channel.create_call(method, &opt)?;
         let mut payload = vec![];
         (method.req_ser())(req, &mut payload);
@@ -189,11 +191,11 @@ impl Call {
         Ok(ClientSStreamReceiver::new(call, cq_f, method.resp_de()))
     }
 
-    pub fn duplex_streaming<P, Q>(
+    pub fn duplex_streaming<Req, Resp>(
         channel: &Channel,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         mut opt: CallOption,
-    ) -> Result<(ClientDuplexSender<P>, ClientDuplexReceiver<Q>)> {
+    ) -> Result<(ClientDuplexSender<Req>, ClientDuplexReceiver<Resp>)> {
         let call = channel.create_call(method, &opt)?;
         let cq_f = check_run(BatchType::Finish, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_duplex_streaming(
@@ -287,15 +289,15 @@ impl<T> Future for ClientCStreamReceiver<T> {
 }
 
 /// A sink for client streaming call and duplex streaming call.
-pub struct StreamingCallSink<P> {
+pub struct StreamingCallSink<Req> {
     call: Arc<SpinLock<ShareCall>>,
     sink_base: SinkBase,
     close_f: Option<BatchFuture>,
-    req_ser: SerializeFn<P>,
+    req_ser: SerializeFn<Req>,
 }
 
-impl<P> StreamingCallSink<P> {
-    fn new(call: Arc<SpinLock<ShareCall>>, ser: SerializeFn<P>) -> StreamingCallSink<P> {
+impl<Req> StreamingCallSink<Req> {
+    fn new(call: Arc<SpinLock<ShareCall>>, ser: SerializeFn<Req>) -> StreamingCallSink<Req> {
         StreamingCallSink {
             call: call,
             sink_base: SinkBase::new(false),
@@ -310,8 +312,8 @@ impl<P> StreamingCallSink<P> {
     }
 }
 
-impl<P> Sink for StreamingCallSink<P> {
-    type SinkItem = (P, WriteFlags);
+impl<Req> Sink for StreamingCallSink<Req> {
+    type SinkItem = (Req, WriteFlags);
     type SinkError = Error;
 
     fn start_send(&mut self, (msg, flags): Self::SinkItem) -> StartSend<Self::SinkItem, Error> {
@@ -424,16 +426,16 @@ impl<H: ShareCallHolder, T> ResponseStreamImpl<H, T> {
 }
 
 /// A receiver for server streaming call.
-pub struct ClientSStreamReceiver<Q> {
-    imp: ResponseStreamImpl<ShareCall, Q>,
+pub struct ClientSStreamReceiver<Resp> {
+    imp: ResponseStreamImpl<ShareCall, Resp>,
 }
 
-impl<Q> ClientSStreamReceiver<Q> {
+impl<Resp> ClientSStreamReceiver<Resp> {
     fn new(
         call: Call,
         finish_f: CqFuture<BatchMessage>,
-        de: DeserializeFn<Q>,
-    ) -> ClientSStreamReceiver<Q> {
+        de: DeserializeFn<Resp>,
+    ) -> ClientSStreamReceiver<Resp> {
         let share_call = ShareCall::new(call, finish_f);
         ClientSStreamReceiver {
             imp: ResponseStreamImpl::new(share_call, de),
@@ -445,22 +447,22 @@ impl<Q> ClientSStreamReceiver<Q> {
     }
 }
 
-impl<Q> Stream for ClientSStreamReceiver<Q> {
-    type Item = Q;
+impl<Resp> Stream for ClientSStreamReceiver<Resp> {
+    type Item = Resp;
     type Error = Error;
 
-    fn poll(&mut self) -> Poll<Option<Q>, Error> {
+    fn poll(&mut self) -> Poll<Option<Resp>, Error> {
         self.imp.poll()
     }
 }
 
 /// A response receiver for duplex call.
-pub struct ClientDuplexReceiver<Q> {
-    imp: ResponseStreamImpl<Arc<SpinLock<ShareCall>>, Q>,
+pub struct ClientDuplexReceiver<Resp> {
+    imp: ResponseStreamImpl<Arc<SpinLock<ShareCall>>, Resp>,
 }
 
-impl<Q> ClientDuplexReceiver<Q> {
-    fn new(call: Arc<SpinLock<ShareCall>>, de: DeserializeFn<Q>) -> ClientDuplexReceiver<Q> {
+impl<Resp> ClientDuplexReceiver<Resp> {
+    fn new(call: Arc<SpinLock<ShareCall>>, de: DeserializeFn<Resp>) -> ClientDuplexReceiver<Resp> {
         ClientDuplexReceiver {
             imp: ResponseStreamImpl::new(call, de),
         }
@@ -471,11 +473,11 @@ impl<Q> ClientDuplexReceiver<Q> {
     }
 }
 
-impl<Q> Stream for ClientDuplexReceiver<Q> {
-    type Item = Q;
+impl<Resp> Stream for ClientDuplexReceiver<Resp> {
+    type Item = Resp;
     type Error = Error;
 
-    fn poll(&mut self) -> Poll<Option<Q>, Error> {
+    fn poll(&mut self) -> Poll<Option<Resp>, Error> {
         self.imp.poll()
     }
 }

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -34,7 +34,7 @@ pub enum MethodType {
     /// Single request sent from client, single response received from server.
     Unary,
 
-    /// Stream of request sent from client, single response received from server.
+    /// Stream of requests sent from client, single response received from server.
     ClientStreaming,
 
     /// Single request sent from client, stream of responses received from server.

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -28,60 +28,85 @@ use error::{Error, Result};
 
 pub use grpc_sys::GrpcStatusCode as RpcStatusCode;
 
+/// Method types supported by gRPC.
 #[derive(Clone, Copy)]
 pub enum MethodType {
+    /// Single request sent from client, single response received from server.
     Unary,
+
+    /// Stream of request sent from client, single response received from server.
     ClientStreaming,
+
+    /// Single request sent from client, stream of responses received from server.
     ServerStreaming,
+
+    /// Both server and client can stream arbitrary number of requests and responses simultaneously.
     Duplex,
 }
 
+
+/// A description of a remote method.
 // TODO: add serializer and deserializer.
-pub struct Method<P, Q> {
+pub struct Method<Req, Resp> {
+    /// Type of method.
     pub ty: MethodType,
+
+    /// Full qualified name of the method.
     pub name: &'static str,
-    pub req_mar: Marshaller<P>,
-    pub resp_mar: Marshaller<Q>,
+
+    /// The marshaller used for request messages.
+    pub req_mar: Marshaller<Req>,
+
+    /// The marshaller used for response messages.
+    pub resp_mar: Marshaller<Resp>,
 }
 
-impl<P, Q> Method<P, Q> {
+impl<Req, Resp> Method<Req, Resp> {
+    /// Get the request serializer.
     #[inline]
-    pub fn req_ser(&self) -> SerializeFn<P> {
+    pub fn req_ser(&self) -> SerializeFn<Req> {
         self.req_mar.ser
     }
 
+    /// Get the request deserializer.
     #[inline]
-    pub fn req_de(&self) -> DeserializeFn<P> {
+    pub fn req_de(&self) -> DeserializeFn<Req> {
         self.req_mar.de
     }
 
+    /// Get the response serializer.
     #[inline]
-    pub fn resp_ser(&self) -> SerializeFn<Q> {
+    pub fn resp_ser(&self) -> SerializeFn<Resp> {
         self.resp_mar.ser
     }
 
+    /// Get the response deserializer.
     #[inline]
-    pub fn resp_de(&self) -> DeserializeFn<Q> {
+    pub fn resp_de(&self) -> DeserializeFn<Resp> {
         self.resp_mar.de
     }
 }
 
-/// Status return from server.
+/// Represents RPC result return from server.
 #[derive(Debug, Clone)]
 pub struct RpcStatus {
+    /// gRPC status code. `Ok` indicates success, all other values indicate an error.
     pub status: RpcStatusCode,
+
+    /// Optional detail string.
     pub details: Option<String>,
 }
 
 impl RpcStatus {
+    /// Create a new [`RpcStatus`].
     pub fn new(status: RpcStatusCode, details: Option<String>) -> RpcStatus {
         RpcStatus {
-            status: status,
-            details: details,
+            status,
+            details,
         }
     }
 
-    /// Generate an Ok status.
+    /// Create a new [`RpcStatus`] that status code is Ok.
     pub fn ok() -> RpcStatus {
         RpcStatus::new(RpcStatusCode::Ok, None)
     }
@@ -485,6 +510,7 @@ impl StreamingBase {
     }
 }
 
+/// Flags for write operations.
 #[derive(Default, Clone, Copy)]
 pub struct WriteFlags {
     flags: u32,
@@ -492,6 +518,9 @@ pub struct WriteFlags {
 
 impl WriteFlags {
     /// Hint that the write may be buffered and need not go out on the wire immediately.
+    ///
+    /// gRPC is free to buffer the message until the next non-buffered write, or until write stream
+    /// completion, but it need not buffer completely or at all.
     pub fn buffer_hint(mut self, need_buffered: bool) -> WriteFlags {
         client::change_flag(
             &mut self.flags,
@@ -511,12 +540,12 @@ impl WriteFlags {
         self
     }
 
-    /// Get if buffer hint is enabled.
+    /// Get whether buffer hint is enabled.
     pub fn get_buffer_hint(&self) -> bool {
         (self.flags & grpc_sys::GRPC_WRITE_BUFFER_HINT) != 0
     }
 
-    /// Get if compression is disabled.
+    /// Get whether compression is disabled.
     pub fn get_force_no_compress(&self) -> bool {
         (self.flags & grpc_sys::GRPC_WRITE_NO_COMPRESS) != 0
     }

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -87,7 +87,7 @@ impl<Req, Resp> Method<Req, Resp> {
     }
 }
 
-/// Represents RPC result return from server.
+/// RPC result returned from the server.
 #[derive(Debug, Clone)]
 pub struct RpcStatus {
     /// gRPC status code. `Ok` indicates success, all other values indicate an error.

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -251,9 +251,10 @@ impl<T> Stream for RequestStream<T> {
     }
 }
 
-// A helper macro used to implement server side unary sink.
-// Not using generic here because we don't need to expose
-// `CallHolder` or `Call` to caller.
+/// A helper macro used to implement server side unary sink.
+/// Not using generic here because we don't need to expose
+/// `CallHolder` or `Call` to caller.
+// TODO: Use type alias to be friendly for documentations.
 macro_rules! impl_unary_sink {
     ($t:ident, $rt:ident, $holder:ty) => (
         pub struct $rt {
@@ -507,7 +508,7 @@ impl<'a> RpcContext<'a> {
         self.ctx.peer()
     }
 
-    /// Spawn the future into current grpc poll thread.
+    /// Spawn the future into current gRPC poll thread.
     ///
     /// This can reduce a lot of context switching, but please make
     /// sure there is no heavy work in the future.

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -254,7 +254,7 @@ impl<T> Stream for RequestStream<T> {
 /// A helper macro used to implement server side unary sink.
 /// Not using generic here because we don't need to expose
 /// `CallHolder` or `Call` to caller.
-// TODO: Use type alias to be friendly for documentations.
+// TODO: Use type alias to be friendly for documentation.
 macro_rules! impl_unary_sink {
     ($t:ident, $rt:ident, $holder:ty) => (
         pub struct $rt {

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -83,7 +83,7 @@ enum Options {
     String(CString),
 }
 
-/// Optimization target for a channel.
+/// The optimization target for a [`Channel`].
 pub enum OptTarget {
     /// Minimize latency at the cost of throughput.
     Latency,
@@ -93,13 +93,14 @@ pub enum OptTarget {
     Throughput,
 }
 
-/// Channel configuration object.
+/// [`Channel`] factory in order to configure the properties.
 pub struct ChannelBuilder {
     env: Arc<Environment>,
     options: HashMap<Cow<'static, [u8]>, Options>,
 }
 
 impl ChannelBuilder {
+    /// Initialize a new [`ChannelBuilder`].
     pub fn new(env: Arc<Environment>) -> ChannelBuilder {
         ChannelBuilder {
             env: env,
@@ -107,7 +108,7 @@ impl ChannelBuilder {
         }
     }
 
-    /// Default authority to pass if none specified on call construction.
+    /// Set default authority to pass if none specified on call construction.
     pub fn default_authority<S: Into<Vec<u8>>>(mut self, authority: S) -> ChannelBuilder {
         let authority = CString::new(authority).unwrap();
         self.options.insert(
@@ -117,7 +118,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Maximum number of concurrent incoming streams to allow on a http2 connection.
+    /// Set maximum number of concurrent incoming streams to allow on a HTTP/2 connection.
     pub fn max_concurrent_stream(mut self, num: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_MAX_CONCURRENT_STREAMS),
@@ -126,7 +127,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Maximum message length that the channel can receive. usize::MAX means unlimited.
+    /// Set maximum message length that the channel can receive. `usize::MAX` means unlimited.
     pub fn max_receive_message_len(mut self, len: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_MAX_RECEIVE_MESSAGE_LENGTH),
@@ -135,7 +136,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Maximum message length that the channel can send. -1 means unlimited.
+    /// Set maximum message length that the channel can send. `-1` means unlimited.
     pub fn max_send_message_len(mut self, len: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_MAX_SEND_MESSAGE_LENGTH),
@@ -144,7 +145,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// The maximum time between subsequent connection attempts.
+    /// Set maximum time between subsequent connection attempts.
     pub fn max_reconnect_backoff(mut self, backoff: Duration) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_MAX_RECONNECT_BACKOFF_MS),
@@ -153,7 +154,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// The time between the first and second connection attempts.
+    /// Set time between the first and second connection attempts.
     pub fn initial_reconnect_backoff(mut self, backoff: Duration) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_INITIAL_RECONNECT_BACKOFF_MS),
@@ -162,7 +163,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Initial sequence number for http2 transports.
+    /// Set initial sequence number for HTTP/2 transports.
     pub fn https_initial_seq_number(mut self, number: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_HTTP2_INITIAL_SEQUENCE_NUMBER),
@@ -171,8 +172,8 @@ impl ChannelBuilder {
         self
     }
 
-    /// Amount to read ahead on individual streams. Defaults to 64kb, larger
-    /// values can help throughput on high-latency connections.
+    /// Set amount to read ahead on individual streams. Defaults to 64KB. Larger
+    /// values help throughput on high-latency connections.
     pub fn stream_initial_window_size(mut self, window_size: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_STREAM_INITIAL_WINDOW_SIZE),
@@ -181,7 +182,8 @@ impl ChannelBuilder {
         self
     }
 
-    /// Primary user agent: goes at the start of the user-agent metadata sent on each request.
+    /// Set primary user agent, which goes at the start of the user-agent metadata sent on
+    /// each request.
     pub fn primary_user_agent(mut self, agent: &str) -> ChannelBuilder {
         let agent_string = format_user_agent_string(agent);
         self.options.insert(
@@ -191,7 +193,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// If enable, allow the use of SO_REUSEPORT if it's available (default true).
+    /// Set whether to allow the use of `SO_REUSEPORT` if available. Defaults to `true`.
     pub fn reuse_port(mut self, reuse: bool) -> ChannelBuilder {
         let opt = if reuse { 1 } else { 0 };
         self.options
@@ -199,7 +201,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// How large a slice to try and read from the wire each time.
+    /// Set the size of slice to try and read from the wire each time.
     pub fn tcp_read_chunk_size(mut self, bytes: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_TCP_READ_CHUNK_SIZE),
@@ -208,7 +210,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// How minimal large a slice to try and read from the wire each time.
+    /// Set the minimum size of slice to try and read from the wire each time.
     pub fn tcp_min_read_chunk_size(mut self, bytes: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_TCP_MIN_READ_CHUNK_SIZE),
@@ -217,7 +219,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// How maximal large a slice to try and read from the wire each time.
+    /// Set the maximum size of slice to try and read from the wire each time.
     pub fn tcp_max_read_chunk_size(mut self, bytes: i32) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_TCP_MAX_READ_CHUNK_SIZE),
@@ -236,7 +238,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// How big a frame are we willing to receive via HTTP2.
+    /// How big a frame are we willing to receive via HTTP/2.
     /// Min 16384, max 16777215.
     /// Larger values give lower CPU usage for large messages, but more head of line
     /// blocking for small messages.
@@ -248,7 +250,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Set BDP probing.
+    /// Set whether to enable BDP probing.
     pub fn http2_bdp_probe(mut self, enable: bool) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_HTTP2_BDP_PROBE),
@@ -305,7 +307,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Default compression algorithm for the channel.
+    /// Set default compression algorithm for the channel.
     pub fn default_compression_algorithm(mut self, algo: CompressionAlgorithms) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_DEFALUT_COMPRESSION_ALGORITHM),
@@ -314,7 +316,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Default compression level for the channel.
+    /// Set default compression level for the channel.
     pub fn default_compression_level(mut self, level: CompressionLevel) -> ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_DEFAULT_COMPRESSION_LEVEL),
@@ -352,9 +354,8 @@ impl ChannelBuilder {
         self
     }
 
-    /// Optimize a channel.
-    ///
-    /// Default is `OptTarget::Blend`.
+    /// Set optimization target for the channel. See [`OptTarget`] for all available
+    /// optimization targets. Defaults to `OptTarget::Blend`.
     pub fn optimize_for(mut self, target: OptTarget) -> ChannelBuilder {
         let val = match target {
             OptTarget::Latency => CString::new("latency"),
@@ -368,7 +369,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Set a raw int configuration.
+    /// Set a raw Int configuration.
     ///
     /// This method is only for bench usage, users should use the encapsulated API instead.
     #[doc(hidden)]
@@ -378,7 +379,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Set a raw string configuration.
+    /// Set a raw String configuration.
     ///
     /// This method is only for bench usage, users should use the encapsulated API instead.
     #[doc(hidden)]
@@ -388,7 +389,10 @@ impl ChannelBuilder {
         self
     }
 
-    /// Build a channel args from the current configuration.
+    /// Build `ChannelArgs` from the current configuration.
+    ///
+    /// This method is only for bench usage, users should use the encapsulated API instead.
+    #[doc(hidden)]
     pub fn build_args(&self) -> ChannelArgs {
         let args = unsafe { grpc_sys::grpcwrap_channel_args_create(self.options.len()) };
         for (i, (k, v)) in self.options.iter().enumerate() {
@@ -420,7 +424,7 @@ impl ChannelBuilder {
         self.build_args()
     }
 
-    /// Build an insure connection to the address.
+    /// Build a unsecure [`Channel`] that connects to a specific address.
     pub fn connect(mut self, addr: &str) -> Channel {
         let args = self.prepare_connect_args();
         let addr = CString::new(addr).unwrap();
@@ -448,8 +452,10 @@ mod secure_channel {
 
     impl ChannelBuilder {
         /// The caller of the secure_channel_create functions may override the target name used
-        /// for SSL host name checking using this channel argument. This *should* be used for
-        /// testing only.
+        /// for SSL host name checking using this channel argument.
+        ///
+        /// This *should* be used for testing only.
+        #[doc(hidden)]
         pub fn override_ssl_target<S: Into<Vec<u8>>>(mut self, target: S) -> ChannelBuilder {
             let target = CString::new(target).unwrap();
             self.options.insert(
@@ -459,6 +465,7 @@ mod secure_channel {
             self
         }
 
+        /// Build a secure [`Channel`] that connects to a specific address.
         pub fn secure_connect(mut self, addr: &str, mut creds: ChannelCredentials) -> Channel {
             let args = self.prepare_connect_args();
             let addr = CString::new(addr).unwrap();
@@ -506,9 +513,12 @@ impl Drop for ChannelInner {
     }
 }
 
-/// The Channel struct allows creation of Call objects.
+/// A gRPC channel.
 ///
-/// Typically created by a [`ChannelBuilder`](struct.ChannelBuilder.html).
+/// Channels are an abstraction of long-lived connections to remote servers. More client objects
+/// can reuse the same channel.
+///
+/// Use [`ChannelBuilder`] to build a [`Channel`].
 #[derive(Clone)]
 pub struct Channel {
     inner: Arc<ChannelInner>,
@@ -530,7 +540,7 @@ impl Channel {
     }
 
     /// Create a call using the method and option.
-    pub fn create_call<P, Q>(&self, method: &Method<P, Q>, opt: &CallOption) -> Result<Call> {
+    pub(crate) fn create_call<Req, Resp>(&self, method: &Method<Req, Resp>, opt: &CallOption) -> Result<Call> {
         let cq_ref = self.cq.borrow()?;
         let raw_call = unsafe {
             let ch = self.inner.channel;
@@ -556,7 +566,7 @@ impl Channel {
         unsafe { Ok(Call::from_raw(raw_call, self.cq.clone())) }
     }
 
-    pub fn cq(&self) -> &CompletionQueue {
+    pub(crate) fn cq(&self) -> &CompletionQueue {
         &self.cq
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -507,6 +507,8 @@ impl Drop for ChannelInner {
 }
 
 /// The Channel struct allows creation of Call objects.
+///
+/// Typically created by a [`ChannelBuilder`](struct.ChannelBuilder.html).
 #[derive(Clone)]
 pub struct Channel {
     inner: Arc<ChannelInner>,

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -369,7 +369,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Set a raw Int configuration.
+    /// Set a raw integer configuration.
     ///
     /// This method is only for bench usage, users should use the encapsulated API instead.
     #[doc(hidden)]
@@ -379,7 +379,7 @@ impl ChannelBuilder {
         self
     }
 
-    /// Set a raw String configuration.
+    /// Set a raw string configuration.
     ///
     /// This method is only for bench usage, users should use the encapsulated API instead.
     #[doc(hidden)]
@@ -424,7 +424,7 @@ impl ChannelBuilder {
         self.build_args()
     }
 
-    /// Build a unsecure [`Channel`] that connects to a specific address.
+    /// Build an insecure [`Channel`] that connects to a specific address.
     pub fn connect(mut self, addr: &str) -> Channel {
         let args = self.prepare_connect_args();
         let addr = CString::new(addr).unwrap();

--- a/src/client.rs
+++ b/src/client.rs
@@ -21,52 +21,53 @@ use channel::Channel;
 
 use error::Result;
 
-/// A generic client for making rpc calls.
+/// A generic client for making RPC calls.
 pub struct Client {
     channel: Channel,
 }
 
 impl Client {
+    /// Initialize a new [`Client`].
     pub fn new(channel: Channel) -> Client {
         Client { channel: channel }
     }
 
-    /// Create a synchronized unary rpc call.
-    pub fn unary_call<P, Q>(&self, method: &Method<P, Q>, req: &P, opt: CallOption) -> Result<Q> {
+    /// Create a synchronized unary RPC call.
+    pub fn unary_call<Req, Resp>(&self, method: &Method<Req, Resp>, req: &Req, opt: CallOption) -> Result<Resp> {
         let f = self.unary_call_async(method, req, opt)?;
         f.wait()
     }
 
-    /// Create a asynchronized unary rpc call.
-    pub fn unary_call_async<P, Q>(
+    /// Create an asynchronized unary RPC call.
+    pub fn unary_call_async<Req, Resp>(
         &self,
-        method: &Method<P, Q>,
-        req: &P,
+        method: &Method<Req, Resp>,
+        req: &Req,
         opt: CallOption,
-    ) -> Result<ClientUnaryReceiver<Q>> {
+    ) -> Result<ClientUnaryReceiver<Resp>> {
         Call::unary_async(&self.channel, method, req, opt)
     }
 
-    /// Create a asynchronized client streaming call.
+    /// Create an asynchronized client streaming call.
     ///
     /// Client can send a stream of requests and server responds with a single response.
-    pub fn client_streaming<P, Q>(
+    pub fn client_streaming<Req, Resp>(
         &self,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         opt: CallOption,
-    ) -> Result<(ClientCStreamSender<P>, ClientCStreamReceiver<Q>)> {
+    ) -> Result<(ClientCStreamSender<Req>, ClientCStreamReceiver<Resp>)> {
         Call::client_streaming(&self.channel, method, opt)
     }
 
-    /// Create a asynchronized server streaming call.
+    /// Create an asynchronized server streaming call.
     ///
     /// Client sends on request and server responds with a stream of responses.
-    pub fn server_streaming<P, Q>(
+    pub fn server_streaming<Req, Resp>(
         &self,
-        method: &Method<P, Q>,
-        req: &P,
+        method: &Method<Req, Resp>,
+        req: &Req,
         opt: CallOption,
-    ) -> Result<ClientSStreamReceiver<Q>> {
+    ) -> Result<ClientSStreamReceiver<Resp>> {
         Call::server_streaming(&self.channel, method, req, opt)
     }
 
@@ -75,15 +76,15 @@ impl Client {
     /// Client sends a stream of requests and server responds with a stream of responses.
     /// The response stream is completely independent and both side can be sending messages
     /// at the same time.
-    pub fn duplex_streaming<P, Q>(
+    pub fn duplex_streaming<Req, Resp>(
         &self,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         opt: CallOption,
-    ) -> Result<(ClientDuplexSender<P>, ClientDuplexReceiver<Q>)> {
+    ) -> Result<(ClientDuplexSender<Req>, ClientDuplexReceiver<Resp>)> {
         Call::duplex_streaming(&self.channel, method, opt)
     }
 
-    /// Spawn the future into current grpc poll thread.
+    /// Spawn the future into current gRPC poll thread.
     ///
     /// This can reduce a lot of context switching, but please make
     /// sure there is no heavy work in the future.

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -22,7 +22,7 @@ pub struct Marshaller<T> {
     // Compiler will probably inline the function so performance
     // impact can be omitted.
     //
-    // Use trait will require trait object or generic which will
+    // Using trait will require a trait object or generic, which will
     // either have performance impact or make signature complicated.
     //
     // const function is not stable yet (rust-lang/rust#24111), hence

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -16,18 +16,22 @@ use error::Result;
 pub type DeserializeFn<T> = fn(&[u8]) -> Result<T>;
 pub type SerializeFn<T> = fn(&T, &mut Vec<u8>);
 
-/// Marshaller defines how to serialize and deserialize between T and byte slice.
+/// Defines how to serialize and deserialize between the specialized type and byte slice.
 pub struct Marshaller<T> {
     // Use function pointer here to simplify the signature.
     // Compiler will probably inline the function so performance
     // impact can be omitted.
     //
-    // Use trait will require trait object or Generic which will
+    // Use trait will require trait object or generic which will
     // either have performance impact or make signature complicated.
     //
     // const function is not stable yet (rust-lang/rust#24111), hence
     // make all fields public.
+
+    /// The serialize function.
     pub ser: SerializeFn<T>,
+
+    /// The deserialize function.
     pub de: DeserializeFn<T>,
 }
 

--- a/src/env.rs
+++ b/src/env.rs
@@ -39,12 +39,14 @@ fn poll_queue(cq: Arc<CompletionQueueHandle>) {
     }
 }
 
+/// [`Environment`] factory in order to configure the properties.
 pub struct EnvBuilder {
     cq_count: usize,
     name_prefix: Option<String>,
 }
 
 impl EnvBuilder {
+    /// Initialize a new [`EnvBuilder`].
     pub fn new() -> EnvBuilder {
         EnvBuilder {
             cq_count: unsafe { grpc_sys::gpr_cpu_num_cores() as usize },
@@ -52,17 +54,25 @@ impl EnvBuilder {
         }
     }
 
+    /// Set the number of completion queues and polling threads. Each thread polls
+    /// one completion queue.
+    ///
+    /// # Panics
+    ///
+    /// This method will panic if `count` is 0.
     pub fn cq_count(mut self, count: usize) -> EnvBuilder {
         assert!(count > 0);
         self.cq_count = count;
         self
     }
 
+    /// Set the thread name prefix of each polling thread.
     pub fn name_prefix<S: Into<String>>(mut self, prefix: S) -> EnvBuilder {
         self.name_prefix = Some(prefix.into());
         self
     }
 
+    /// Finalize the [`EnvBuilder`], build the [`Environment`] and initialize the gRPC library.
     pub fn build(self) -> Environment {
         unsafe {
             grpc_sys::grpc_init();
@@ -89,7 +99,7 @@ impl EnvBuilder {
     }
 }
 
-/// An object that used to control concurrency and start event loop.
+/// An object that used to control concurrency and start gRPC event loop.
 pub struct Environment {
     cqs: Vec<CompletionQueue>,
     idx: AtomicUsize,
@@ -97,9 +107,13 @@ pub struct Environment {
 }
 
 impl Environment {
-    /// Initialize grpc and create a threadpool to poll event loop.
+    /// Initialize gRPC and create a thread pool to poll completion queue. The thread pool size
+    /// and the number of completion queue is specified by `cq_count`. Each thread polls one
+    /// completion queue.
     ///
-    /// Each thread in threadpool will have one event loop.
+    /// # Panics
+    ///
+    /// This method will panic if `cq_count` is 0.
     pub fn new(cq_count: usize) -> Environment {
         assert!(cq_count > 0);
         EnvBuilder::new()

--- a/src/error.rs
+++ b/src/error.rs
@@ -20,21 +20,28 @@ use protobuf::ProtobufError;
 
 use call::RpcStatus;
 
+/// Errors generated from this library.
 #[derive(Debug)]
 pub enum Error {
+    /// Codec error.
     Codec(Box<error::Error + Send + Sync>),
-    // return when failed to start an internal async call.
+    /// Failed to start an internal async call.
     CallFailure(GrpcCallStatus),
-    // fail when the rpc request fail.
+    /// Rpc request fail.
     RpcFailure(RpcStatus),
-    // return when trying to write to a finished rpc call.
+    /// Try to write to a finished rpc call.
     RpcFinished(Option<RpcStatus>),
+    /// Remote is stopped.
     RemoteStopped,
+    /// Failed to shutdown.
     ShutdownFailed,
+    /// Failed to bind.
     BindFail(String, u16),
+    /// gRPC completion queue is shutdown.
     QueueShutdown,
-    // Return when Google Default Credentials failed.
+    /// Failed to create Google default credentials.
     GoogleAuthenticationFailed,
+    /// Invalid format of metadata.
     InvalidMetadata(String),
 }
 
@@ -75,6 +82,7 @@ impl From<ProtobufError> for Error {
     }
 }
 
+/// Type alias to use this library's [`Error`] type in a `Result`.
 pub type Result<T> = result::Result<T, Error>;
 
 #[cfg(all(test, feature = "protobuf-codec"))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -24,7 +24,7 @@ framework that puts mobile and HTTP/2 first. grpcio is built on [gRPC Core] and 
 ## Optional features
 
 - **`secure`** *(enabled by default)* - Enables support for TLS encryption and some authentication
-  mechanism.
+  mechanisms.
 
 */
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,23 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+/*!
+
+[grpcio] is a Rust implementation of [gRPC], which is a high performance, open source universal RPC
+framework that puts mobile and HTTP/2 first. grpcio is built on [gRPC Core] and [futures-rs].
+
+[grpcio]: https://github.com/pingcap/grpc-rs/
+[gRPC]: https://grpc.io/
+[gRPC Core]: https://github.com/grpc/grpc
+[futures-rs]: https://github.com/rust-lang-nursery/futures-rs
+
+## Optional features
+
+- **`secure`** *(enabled by default)* - Enables support for TLS encryption and some authentication
+  mechanism.
+
+*/
+
 #![allow(unknown_lints)]
 #![allow(new_without_default_derive)]
 #![allow(new_without_default)]
@@ -46,7 +63,7 @@ pub use call::client::{CallOption, ClientCStreamReceiver, ClientCStreamSender,
 pub use call::server::{ClientStreamingSink, ClientStreamingSinkResult, Deadline, DuplexSink,
                        DuplexSinkFailure, RequestStream, RpcContext, ServerStreamingSink,
                        ServerStreamingSinkFailure, UnarySink, UnarySinkResult};
-pub use channel::{Channel, ChannelBuilder, CompressionAlgorithms, CompressionLevel};
+pub use channel::{OptTarget, Channel, ChannelBuilder, CompressionAlgorithms, CompressionLevel};
 pub use client::Client;
 pub use codec::Marshaller;
 #[cfg(feature = "protobuf-codec")]

--- a/src/server.rs
+++ b/src/server.rs
@@ -417,7 +417,7 @@ unsafe impl Send for Inner {}
 
 /// A gRPC server.
 ///
-/// A single server can server arbitrary number of services and can listen on more than one ports.
+/// A single server can serve arbitrary number of services and can listen on more than one port.
 ///
 /// Use [`ServerBuilder`] to build a [`Server`].
 pub struct Server {

--- a/src/server.rs
+++ b/src/server.rs
@@ -34,7 +34,7 @@ const DEFAULT_REQUEST_SLOTS_PER_CQ: usize = 1024;
 
 pub type CallBack = Box<Fn(RpcContext, &[u8])>;
 
-/// Handler is an rpc call holder.
+/// An RPC call holder.
 pub struct Handler {
     method_type: MethodType,
     cb: CallBack,
@@ -118,7 +118,7 @@ mod imp {
 
 use self::imp::Binder;
 
-/// Service configuration struct.
+/// [`Service`] factory in order to configure the properties.
 ///
 /// Use it to build a service which can be registered to a server.
 pub struct ServiceBuilder {
@@ -126,18 +126,19 @@ pub struct ServiceBuilder {
 }
 
 impl ServiceBuilder {
+    /// Initialize a new [`ServiceBuilder`].
     pub fn new() -> ServiceBuilder {
         ServiceBuilder {
             handlers: HashMap::new(),
         }
     }
 
-    /// Add a unary rpc call handler.
-    pub fn add_unary_handler<P, Q, F>(mut self, method: &Method<P, Q>, handler: F) -> ServiceBuilder
+    /// Add a unary RPC call handler.
+    pub fn add_unary_handler<Req, Resp, F>(mut self, method: &Method<Req, Resp>, handler: F) -> ServiceBuilder
     where
-        P: 'static,
-        Q: 'static,
-        F: Fn(RpcContext, P, UnarySink<Q>) + 'static,
+        Req: 'static,
+        Resp: 'static,
+        F: Fn(RpcContext, Req, UnarySink<Resp>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
         let h = Box::new(move |ctx: RpcContext, payload: &[u8]| {
@@ -148,16 +149,16 @@ impl ServiceBuilder {
         self
     }
 
-    /// Add a client streaming rpc call handler.
-    pub fn add_client_streaming_handler<P, Q, F>(
+    /// Add a client streaming RPC call handler.
+    pub fn add_client_streaming_handler<Req, Resp, F>(
         mut self,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         handler: F,
     ) -> ServiceBuilder
     where
-        P: 'static,
-        Q: 'static,
-        F: Fn(RpcContext, RequestStream<P>, ClientStreamingSink<Q>) + 'static,
+        Req: 'static,
+        Resp: 'static,
+        F: Fn(RpcContext, RequestStream<Req>, ClientStreamingSink<Resp>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
         let h = Box::new(move |ctx: RpcContext, _: &[u8]| {
@@ -170,16 +171,16 @@ impl ServiceBuilder {
         self
     }
 
-    /// Add a server streaming rpc call handler.
-    pub fn add_server_streaming_handler<P, Q, F>(
+    /// Add a server streaming RPC call handler.
+    pub fn add_server_streaming_handler<Req, Resp, F>(
         mut self,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         handler: F,
     ) -> ServiceBuilder
     where
-        P: 'static,
-        Q: 'static,
-        F: Fn(RpcContext, P, ServerStreamingSink<Q>) + 'static,
+        Req: 'static,
+        Resp: 'static,
+        F: Fn(RpcContext, Req, ServerStreamingSink<Resp>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
         let h = Box::new(move |ctx: RpcContext, payload: &[u8]| {
@@ -192,16 +193,16 @@ impl ServiceBuilder {
         self
     }
 
-    /// Add a duplex streaming rpc call handler.
-    pub fn add_duplex_streaming_handler<P, Q, F>(
+    /// Add a duplex streaming RPC call handler.
+    pub fn add_duplex_streaming_handler<Req, Resp, F>(
         mut self,
-        method: &Method<P, Q>,
+        method: &Method<Req, Resp>,
         handler: F,
     ) -> ServiceBuilder
     where
-        P: 'static,
-        Q: 'static,
-        F: Fn(RpcContext, RequestStream<P>, DuplexSink<Q>) + 'static,
+        Req: 'static,
+        Resp: 'static,
+        F: Fn(RpcContext, RequestStream<Req>, DuplexSink<Resp>) + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
         let h = Box::new(move |ctx: RpcContext, _: &[u8]| {
@@ -212,6 +213,7 @@ impl ServiceBuilder {
         self
     }
 
+    /// Finalize the [`ServiceBuilder`] and build the [`Service`].
     pub fn build(self) -> Service {
         Service {
             handlers: self.handlers,
@@ -219,11 +221,14 @@ impl ServiceBuilder {
     }
 }
 
+/// A gRPC service.
+///
+/// Use [`ServiceBuilder`] to build a [`Service`].
 pub struct Service {
     handlers: HashMap<&'static [u8], Handler>,
 }
 
-/// Server configuration struct.
+/// [`Server`] factory in order to configure the properties.
 pub struct ServerBuilder {
     env: Arc<Environment>,
     binders: Vec<Binder>,
@@ -233,6 +238,7 @@ pub struct ServerBuilder {
 }
 
 impl ServerBuilder {
+    /// Initialize a new [`ServerBuilder`].
     pub fn new(env: Arc<Environment>) -> ServerBuilder {
         ServerBuilder {
             env: env,
@@ -245,13 +251,14 @@ impl ServerBuilder {
 
     /// Bind to an address.
     ///
-    /// This function can be called multiple times.
+    /// This function can be called multiple times to bind to multiple ports.
     pub fn bind<S: Into<String>>(mut self, host: S, port: u16) -> ServerBuilder {
         self.binders.push(Binder::new(host.into(), port));
         self
     }
 
     /// Add additional configuration for each incoming channel.
+    #[doc(hidden)]
     pub fn channel_args(mut self, args: ChannelArgs) -> ServerBuilder {
         self.args = Some(args);
         self
@@ -269,6 +276,7 @@ impl ServerBuilder {
         self
     }
 
+    /// Finalize the [`ServerBuilder`] and build the [`Server`].
     pub fn build(mut self) -> Result<Server> {
         let args = self.args
             .as_ref()
@@ -318,7 +326,7 @@ mod secure_server {
     impl ServerBuilder {
         /// Bind to an address for secure connection.
         ///
-        /// This function can be called multiple times.
+        /// This function can be called multiple times to bind to multiple ports.
         pub fn bind_secure<S: Into<String>>(
             mut self,
             host: S,
@@ -388,7 +396,7 @@ pub fn request_call(inner: Arc<Inner>, cq: &CompletionQueue) {
     }
 }
 
-/// An asynchronize shutdown future.
+/// A `Future` that will resolve when shutdown completes.
 pub struct ShutdownFuture {
     cq_f: CqFuture<()>,
 }
@@ -407,6 +415,11 @@ impl Future for ShutdownFuture {
 unsafe impl Sync for Inner {}
 unsafe impl Send for Inner {}
 
+/// A gRPC server.
+///
+/// A single server can server arbitrary number of services and can listen on more than one ports.
+///
+/// Use [`ServerBuilder`] to build a [`Server`].
 pub struct Server {
     inner: Arc<Inner>,
 }
@@ -437,9 +450,7 @@ impl Server {
         unsafe { grpc_sys::grpc_server_cancel_all_calls(self.inner.server) }
     }
 
-    /// Start a server.
-    ///
-    /// Tells all listeners to start listening.
+    /// Start the server.
     pub fn start(&mut self) {
         unsafe {
             grpc_sys::grpc_server_start(self.inner.server);
@@ -451,7 +462,7 @@ impl Server {
         }
     }
 
-    /// Get the binded addresses.
+    /// Get binded addresses.
     pub fn bind_addrs(&self) -> &[(String, u16)] {
         &self.inner.bind_addrs
     }


### PR DESCRIPTION
1. Add documentation for most of the public stuffs
2. Rename `<P, Q>` to `<Req, Resp>` to be clear.
3. Add `#[doc(hidden)]` for those internal methods used only in benchmark or tests.
4. rpc -> RPC, grpc -> gRPC.