### PR TITLE
Reduce warning and remove redundant variables

### DIFF
--- a/src/async/callback.rs
+++ b/src/async/callback.rs
@@ -25,7 +25,7 @@ pub struct Request {
 impl Request {
     pub fn new(inner: Arc<ServerInner>) -> Request {
         let ctx = RequestContext::new(inner);
-        Request { ctx: ctx }
+        Request { ctx }
     }
 
     pub fn context(&self) -> &RequestContext {
@@ -53,7 +53,7 @@ pub struct UnaryRequest {
 impl UnaryRequest {
     pub fn new(ctx: RequestContext, inner: Arc<ServerInner>) -> UnaryRequest {
         let ctx = UnaryRequestContext::new(ctx, inner);
-        UnaryRequest { ctx: ctx }
+        UnaryRequest { ctx }
     }
 
     pub fn batch_ctx(&self) -> &BatchContext {

--- a/src/async/executor.rs
+++ b/src/async/executor.rs
@@ -40,7 +40,7 @@ impl Alarm {
             grpc_sys::grpc_alarm_set(alarm, cq_ref.as_ptr(), timeout, ptr as _, ptr::null_mut());
             alarm
         };
-        Ok(Alarm { alarm: alarm })
+        Ok(Alarm { alarm })
     }
 
     fn alarm(&mut self) {
@@ -106,7 +106,7 @@ impl SpawnNotify {
             worker_id: cq.worker_id(),
             handle: Arc::new(SpinLock::new(Some(s))),
             ctx: Arc::new(SpinLock::new(NotifyContext {
-                cq: cq,
+                cq,
                 alarmed: false,
                 alarm: None,
             })),
@@ -169,7 +169,7 @@ pub struct Executor<'a> {
 
 impl<'a> Executor<'a> {
     pub fn new(cq: &CompletionQueue) -> Executor {
-        Executor { cq: cq }
+        Executor { cq }
     }
 
     pub(crate) fn cq(&self) -> &CompletionQueue {

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -87,7 +87,7 @@ pub struct CqFuture<T> {
 
 impl<T> CqFuture<T> {
     fn new(inner: Arc<Inner<T>>) -> CqFuture<T> {
-        CqFuture { inner: inner }
+        CqFuture { inner }
     }
 }
 

--- a/src/async/promise.rs
+++ b/src/async/promise.rs
@@ -39,9 +39,9 @@ pub struct Batch {
 impl Batch {
     pub fn new(ty: BatchType, inner: Arc<Inner<BatchMessage>>) -> Batch {
         Batch {
-            ty: ty,
+            ty,
             ctx: BatchContext::new(),
-            inner: inner,
+            inner,
         }
     }
 
@@ -122,7 +122,7 @@ pub struct Shutdown {
 
 impl Shutdown {
     pub fn new(inner: Arc<Inner<()>>) -> Shutdown {
-        Shutdown { inner: inner }
+        Shutdown { inner }
     }
 
     pub fn resolve(self, success: bool) {

--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -235,8 +235,8 @@ impl<T> ClientUnaryReceiver<T> {
         de: DeserializeFn<T>,
     ) -> ClientUnaryReceiver<T> {
         ClientUnaryReceiver {
-            call: call,
-            resp_f: resp_f,
+            call,
+            resp_f,
             resp_de: de,
         }
     }
@@ -297,7 +297,7 @@ pub struct StreamingCallSink<P> {
 impl<P> StreamingCallSink<P> {
     fn new(call: Arc<SpinLock<ShareCall>>, ser: SerializeFn<P>) -> StreamingCallSink<P> {
         StreamingCallSink {
-            call: call,
+            call,
             sink_base: SinkBase::new(false),
             close_f: None,
             req_ser: ser,
@@ -369,10 +369,10 @@ struct ResponseStreamImpl<H, T> {
 impl<H: ShareCallHolder, T> ResponseStreamImpl<H, T> {
     fn new(call: H, resp_de: DeserializeFn<T>) -> ResponseStreamImpl<H, T> {
         ResponseStreamImpl {
-            call: call,
+            call,
             msg_f: None,
             read_done: false,
-            resp_de: resp_de,
+            resp_de,
         }
     }
 

--- a/src/call/mod.rs
+++ b/src/call/mod.rs
@@ -76,8 +76,8 @@ pub struct RpcStatus {
 impl RpcStatus {
     pub fn new(status: RpcStatusCode, details: Option<String>) -> RpcStatus {
         RpcStatus {
-            status: status,
-            details: details,
+            status,
+            details,
         }
     }
 
@@ -122,8 +122,8 @@ impl BatchContext {
         };
 
         RpcStatus {
-            status: status,
-            details: details,
+            status,
+            details,
         }
     }
 
@@ -361,8 +361,8 @@ struct ShareCall {
 impl ShareCall {
     fn new(call: Call, close_f: CqFuture<BatchMessage>) -> ShareCall {
         ShareCall {
-            call: call,
-            close_f: close_f,
+            call,
+            close_f,
             finished: false,
             status: None,
         }
@@ -428,7 +428,7 @@ struct StreamingBase {
 impl StreamingBase {
     fn new(close_f: Option<BatchFuture>) -> StreamingBase {
         StreamingBase {
-            close_f: close_f,
+            close_f,
             msg_f: None,
             read_done: false,
         }
@@ -534,7 +534,7 @@ impl SinkBase {
         SinkBase {
             batch_f: None,
             buf: Vec::new(),
-            send_metadata: send_metadata,
+            send_metadata,
         }
     }
 

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -60,7 +60,7 @@ impl RequestContext {
         let ctx = unsafe { grpc_sys::grpcwrap_request_call_context_create() };
 
         RequestContext {
-            ctx: ctx,
+            ctx,
             inner: Some(inner),
         }
     }
@@ -223,9 +223,9 @@ pub struct RequestStream<T> {
 impl<T> RequestStream<T> {
     fn new(call: Arc<SpinLock<ShareCall>>, de: DeserializeFn<T>) -> RequestStream<T> {
         RequestStream {
-            call: call,
+            call,
             base: StreamingBase::new(None),
-            de: de,
+            de,
         }
     }
 }
@@ -477,7 +477,7 @@ impl<'a> RpcContext<'a> {
     fn new(ctx: RequestContext, cq: &CompletionQueue) -> RpcContext {
         RpcContext {
             deadline: ctx.deadline(),
-            ctx: ctx,
+            ctx,
             executor: Executor::new(cq),
         }
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -32,34 +32,34 @@ pub use grpc_sys::{GrpcCompressionAlgorithms as CompressionAlgorithms,
                    GrpcCompressionLevel as CompressionLevel};
 
 // hack: add a '\0' to be compatible with c string without extra allocation.
-const OPT_DEFAULT_AUTHORITY: &'static [u8] = b"grpc.default_authority\0";
-const OPT_MAX_CONCURRENT_STREAMS: &'static [u8] = b"grpc.max_concurrent_streams\0";
-const OPT_MAX_RECEIVE_MESSAGE_LENGTH: &'static [u8] = b"grpc.max_receive_message_length\0";
-const OPT_MAX_SEND_MESSAGE_LENGTH: &'static [u8] = b"grpc.max_send_message_length\0";
-const OPT_MAX_RECONNECT_BACKOFF_MS: &'static [u8] = b"grpc.max_reconnect_backoff_ms\0";
-const OPT_INITIAL_RECONNECT_BACKOFF_MS: &'static [u8] = b"grpc.initial_reconnect_backoff_ms\0";
-const OPT_HTTP2_INITIAL_SEQUENCE_NUMBER: &'static [u8] = b"grpc.http2.initial_sequence_number\0";
-const OPT_SO_REUSE_PORT: &'static [u8] = b"grpc.so_reuseport\0";
-const OPT_STREAM_INITIAL_WINDOW_SIZE: &'static [u8] = b"grpc.http2.lookahead_bytes\0";
-const OPT_TCP_READ_CHUNK_SIZE: &'static [u8] = b"grpc.experimental.tcp_read_chunk_size\0";
-const OPT_TCP_MIN_READ_CHUNK_SIZE: &'static [u8] = b"grpc.experimental.tcp_min_read_chunk_size\0";
-const OPT_TCP_MAX_READ_CHUNK_SIZE: &'static [u8] = b"grpc.experimental.tcp_max_read_chunk_size\0";
-const OPT_HTTP2_WRITE_BUFFER_SIZE: &'static [u8] = b"grpc.http2.write_buffer_size\0";
-const OPT_HTTP2_MAX_FRAME_SIZE: &'static [u8] = b"grpc.http2.max_frame_size\0";
-const OPT_HTTP2_BDP_PROBE: &'static [u8] = b"grpc.http2.bdp_probe\0";
-const OPT_HTTP2_MIN_SENT_PING_INTERVAL_WITHOUT_DATA_MS: &'static [u8] =
+const OPT_DEFAULT_AUTHORITY: &[u8] = b"grpc.default_authority\0";
+const OPT_MAX_CONCURRENT_STREAMS: &[u8] = b"grpc.max_concurrent_streams\0";
+const OPT_MAX_RECEIVE_MESSAGE_LENGTH: &[u8] = b"grpc.max_receive_message_length\0";
+const OPT_MAX_SEND_MESSAGE_LENGTH: &[u8] = b"grpc.max_send_message_length\0";
+const OPT_MAX_RECONNECT_BACKOFF_MS: &[u8] = b"grpc.max_reconnect_backoff_ms\0";
+const OPT_INITIAL_RECONNECT_BACKOFF_MS: &[u8] = b"grpc.initial_reconnect_backoff_ms\0";
+const OPT_HTTP2_INITIAL_SEQUENCE_NUMBER: &[u8] = b"grpc.http2.initial_sequence_number\0";
+const OPT_SO_REUSE_PORT: &[u8] = b"grpc.so_reuseport\0";
+const OPT_STREAM_INITIAL_WINDOW_SIZE: &[u8] = b"grpc.http2.lookahead_bytes\0";
+const OPT_TCP_READ_CHUNK_SIZE: &[u8] = b"grpc.experimental.tcp_read_chunk_size\0";
+const OPT_TCP_MIN_READ_CHUNK_SIZE: &[u8] = b"grpc.experimental.tcp_min_read_chunk_size\0";
+const OPT_TCP_MAX_READ_CHUNK_SIZE: &[u8] = b"grpc.experimental.tcp_max_read_chunk_size\0";
+const OPT_HTTP2_WRITE_BUFFER_SIZE: &[u8] = b"grpc.http2.write_buffer_size\0";
+const OPT_HTTP2_MAX_FRAME_SIZE: &[u8] = b"grpc.http2.max_frame_size\0";
+const OPT_HTTP2_BDP_PROBE: &[u8] = b"grpc.http2.bdp_probe\0";
+const OPT_HTTP2_MIN_SENT_PING_INTERVAL_WITHOUT_DATA_MS: &[u8] =
     b"grpc.http2.min_time_between_pings_ms\0";
-const OPT_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS: &'static [u8] =
+const OPT_HTTP2_MIN_RECV_PING_INTERVAL_WITHOUT_DATA_MS: &[u8] =
     b"grpc.http2.min_ping_interval_without_data_ms\0";
-const OPT_HTTP2_MAX_PINGS_WITHOUT_DATA: &'static [u8] = b"grpc.http2.max_pings_without_data\0";
-const OPT_HTTP2_MAX_PING_STRIKES: &'static [u8] = b"grpc.http2.max_ping_strikes\0";
-const OPT_DEFALUT_COMPRESSION_ALGORITHM: &'static [u8] = b"grpc.default_compression_algorithm\0";
-const OPT_DEFAULT_COMPRESSION_LEVEL: &'static [u8] = b"grpc.default_compression_level\0";
-const OPT_KEEPALIVE_TIME_MS: &'static [u8] = b"grpc.keepalive_time_ms\0";
-const OPT_KEEPALIVE_TIMEOUT_MS: &'static [u8] = b"grpc.keepalive_timeout_ms\0";
-const OPT_KEEPALIVE_PERMIT_WITHOUT_CALLS: &'static [u8] = b"grpc.keepalive_permit_without_calls\0";
-const OPT_OPTIMIZATION_TARGET: &'static [u8] = b"grpc.optimization_target\0";
-const PRIMARY_USER_AGENT_STRING: &'static [u8] = b"grpc.primary_user_agent\0";
+const OPT_HTTP2_MAX_PINGS_WITHOUT_DATA: &[u8] = b"grpc.http2.max_pings_without_data\0";
+const OPT_HTTP2_MAX_PING_STRIKES: &[u8] = b"grpc.http2.max_ping_strikes\0";
+const OPT_DEFALUT_COMPRESSION_ALGORITHM: &[u8] = b"grpc.default_compression_algorithm\0";
+const OPT_DEFAULT_COMPRESSION_LEVEL: &[u8] = b"grpc.default_compression_level\0";
+const OPT_KEEPALIVE_TIME_MS: &[u8] = b"grpc.keepalive_time_ms\0";
+const OPT_KEEPALIVE_TIMEOUT_MS: &[u8] = b"grpc.keepalive_timeout_ms\0";
+const OPT_KEEPALIVE_PERMIT_WITHOUT_CALLS: &[u8] = b"grpc.keepalive_permit_without_calls\0";
+const OPT_OPTIMIZATION_TARGET: &[u8] = b"grpc.optimization_target\0";
+const PRIMARY_USER_AGENT_STRING: &[u8] = b"grpc.primary_user_agent\0";
 
 /// Ref: http://www.grpc.io/docs/guides/wire.html#user-agents
 fn format_user_agent_string(agent: &str) -> CString {
@@ -102,7 +102,7 @@ pub struct ChannelBuilder {
 impl ChannelBuilder {
     pub fn new(env: Arc<Environment>) -> ChannelBuilder {
         ChannelBuilder {
-            env: env,
+            env,
             options: HashMap::new(),
         }
     }
@@ -410,7 +410,7 @@ impl ChannelBuilder {
                 },
             }
         }
-        ChannelArgs { args: args }
+        ChannelArgs { args }
     }
 
     fn prepare_connect_args(&mut self) -> ChannelArgs {
@@ -444,7 +444,7 @@ mod secure_channel {
 
     use super::{Channel, ChannelBuilder, Options};
 
-    const OPT_SSL_TARGET_NAME_OVERRIDE: &'static [u8] = b"grpc.ssl_target_name_override\0";
+    const OPT_SSL_TARGET_NAME_OVERRIDE: &[u8] = b"grpc.ssl_target_name_override\0";
 
     impl ChannelBuilder {
         /// The caller of the secure_channel_create functions may override the target name used
@@ -523,9 +523,9 @@ impl Channel {
         Channel {
             inner: Arc::new(ChannelInner {
                 _env: env,
-                channel: channel,
+                channel,
             }),
-            cq: cq,
+            cq,
         }
     }
 

--- a/src/client.rs
+++ b/src/client.rs
@@ -28,7 +28,7 @@ pub struct Client {
 
 impl Client {
     pub fn new(channel: Channel) -> Client {
-        Client { channel: channel }
+        Client { channel }
     }
 
     /// Create a synchronized unary rpc call.

--- a/src/cq.rs
+++ b/src/cq.rs
@@ -138,8 +138,8 @@ pub struct CompletionQueue {
 impl CompletionQueue {
     pub fn new(handle: Arc<CompletionQueueHandle>, id: ThreadId) -> CompletionQueue {
         CompletionQueue {
-            handle: handle,
-            id: id,
+            handle,
+            id,
         }
     }
 

--- a/src/credentials.rs
+++ b/src/credentials.rs
@@ -180,7 +180,7 @@ impl ChannelCredentialsBuilder {
             }
         }
 
-        ChannelCredentials { creds: creds }
+        ChannelCredentials { creds }
     }
 }
 
@@ -214,7 +214,7 @@ impl ChannelCredentials {
         if creds.is_null() {
             Err(Error::GoogleAuthenticationFailed)
         } else {
-            Ok(ChannelCredentials { creds: creds })
+            Ok(ChannelCredentials { creds })
         }
     }
 }

--- a/src/env.rs
+++ b/src/env.rs
@@ -82,7 +82,7 @@ impl EnvBuilder {
         }
 
         Environment {
-            cqs: cqs,
+            cqs,
             idx: AtomicUsize::new(0),
             _handles: handles,
         }

--- a/src/server.rs
+++ b/src/server.rs
@@ -43,8 +43,8 @@ pub struct Handler {
 impl Handler {
     pub fn new(method_type: MethodType, cb: CallBack) -> Handler {
         Handler {
-            method_type: method_type,
-            cb: cb,
+            method_type,
+            cb,
         }
     }
 
@@ -235,7 +235,7 @@ pub struct ServerBuilder {
 impl ServerBuilder {
     pub fn new(env: Arc<Environment>) -> ServerBuilder {
         ServerBuilder {
-            env: env,
+            env,
             binders: Vec::new(),
             args: None,
             slots_per_cq: DEFAULT_REQUEST_SLOTS_PER_CQ,
@@ -298,9 +298,9 @@ impl ServerBuilder {
             Ok(Server {
                 inner: Arc::new(Inner {
                     env: self.env,
-                    server: server,
+                    server,
                     shutdown: AtomicBool::new(false),
-                    bind_addrs: bind_addrs,
+                    bind_addrs,
                     slots_per_cq: self.slots_per_cq,
                     handlers: self.handlers,
                 }),
@@ -427,7 +427,7 @@ impl Server {
             )
         }
         self.inner.shutdown.store(true, Ordering::SeqCst);
-        ShutdownFuture { cq_f: cq_f }
+        ShutdownFuture { cq_f }
     }
 
     /// Cancel all in-progress calls.


### PR DESCRIPTION
Removed redundant variables as pointed out by clippy and some files that might have caused build to fail on travis ci