### PR TITLE
Format grpc_wrap.c with the clang-format from gRPC v1.13.0

### DIFF
--- a/grpc-sys/grpc_wrap.c
+++ b/grpc-sys/grpc_wrap.c
@@ -76,9 +76,9 @@
 #define GPR_CALLTYPE
 #endif
 
-grpc_byte_buffer *string_to_byte_buffer(const char *buffer, size_t len) {
+grpc_byte_buffer* string_to_byte_buffer(const char* buffer, size_t len) {
   grpc_slice slice = grpc_slice_from_copied_buffer(buffer, len);
-  grpc_byte_buffer *bb = grpc_raw_byte_buffer_create(&slice, 1);
+  grpc_byte_buffer* bb = grpc_raw_byte_buffer_create(&slice, 1);
   grpc_slice_unref(slice);
   return bb;
 }
@@ -88,12 +88,12 @@ grpc_byte_buffer *string_to_byte_buffer(const char *buffer, size_t len) {
  */
 typedef struct grpcwrap_batch_context {
   grpc_metadata_array send_initial_metadata;
-  grpc_byte_buffer *send_message;
+  grpc_byte_buffer* send_message;
   struct {
     grpc_metadata_array trailing_metadata;
   } send_status_from_server;
   grpc_metadata_array recv_initial_metadata;
-  grpc_byte_buffer *recv_message;
+  grpc_byte_buffer* recv_message;
   struct {
     grpc_metadata_array trailing_metadata;
     grpc_status_code status;
@@ -102,22 +102,22 @@ typedef struct grpcwrap_batch_context {
   int recv_close_on_server_cancelled;
 } grpcwrap_batch_context;
 
-GPR_EXPORT grpcwrap_batch_context *GPR_CALLTYPE
+GPR_EXPORT grpcwrap_batch_context* GPR_CALLTYPE
 grpcwrap_batch_context_create() {
-  grpcwrap_batch_context *ctx = gpr_malloc(sizeof(grpcwrap_batch_context));
+  grpcwrap_batch_context* ctx = gpr_malloc(sizeof(grpcwrap_batch_context));
   memset(ctx, 0, sizeof(grpcwrap_batch_context));
   return ctx;
 }
 
 typedef struct {
-  grpc_call *call;
+  grpc_call* call;
   grpc_call_details call_details;
   grpc_metadata_array request_metadata;
 } grpcwrap_request_call_context;
 
-GPR_EXPORT grpcwrap_request_call_context *GPR_CALLTYPE
+GPR_EXPORT grpcwrap_request_call_context* GPR_CALLTYPE
 grpcwrap_request_call_context_create() {
-  grpcwrap_request_call_context *ctx =
+  grpcwrap_request_call_context* ctx =
       gpr_malloc(sizeof(grpcwrap_request_call_context));
   memset(ctx, 0, sizeof(grpcwrap_request_call_context));
   return ctx;
@@ -127,7 +127,7 @@ grpcwrap_request_call_context_create() {
  * Destroys array->metadata.
  * The array pointer itself is not freed.
  */
-void grpcwrap_metadata_array_destroy_metadata_only(grpc_metadata_array *array) {
+void grpcwrap_metadata_array_destroy_metadata_only(grpc_metadata_array* array) {
   gpr_free(array->metadata);
 }
 
@@ -136,7 +136,7 @@ void grpcwrap_metadata_array_destroy_metadata_only(grpc_metadata_array *array) {
  * The array pointer itself is not freed.
  */
 void grpcwrap_metadata_array_destroy_metadata_including_entries(
-    grpc_metadata_array *array) {
+    grpc_metadata_array* array) {
   size_t i;
   if (array->metadata) {
     for (i = 0; i < array->count; i++) {
@@ -151,7 +151,7 @@ void grpcwrap_metadata_array_destroy_metadata_including_entries(
  * Fully destroys the metadata array.
  */
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_metadata_array_destroy_full(grpc_metadata_array *array) {
+grpcwrap_metadata_array_destroy_full(grpc_metadata_array* array) {
   if (!array) {
     return;
   }
@@ -163,7 +163,7 @@ grpcwrap_metadata_array_destroy_full(grpc_metadata_array *array) {
  * Allocate metadata array with given capacity.
  */
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_metadata_array_init(grpc_metadata_array *array, size_t capacity) {
+grpcwrap_metadata_array_init(grpc_metadata_array* array, size_t capacity) {
   array->count = 0;
   array->capacity = capacity;
   if (!capacity) {
@@ -171,15 +171,15 @@ grpcwrap_metadata_array_init(grpc_metadata_array *array, size_t capacity) {
     return;
   }
 
-  grpc_metadata *arr =
-      (grpc_metadata *)gpr_malloc(sizeof(grpc_metadata) * capacity);
+  grpc_metadata* arr =
+      (grpc_metadata*)gpr_malloc(sizeof(grpc_metadata) * capacity);
   memset(arr, 0, sizeof(grpc_metadata) * capacity);
   array->metadata = arr;
 }
 
 GPR_EXPORT void GPR_CALLTYPE grpcwrap_metadata_array_add(
-    grpc_metadata_array *array, const char *key, size_t key_length,
-    const char *value, size_t value_length) {
+    grpc_metadata_array* array, const char* key, size_t key_length,
+    const char* value, size_t value_length) {
   GPR_ASSERT(array->count <= array->capacity);
   size_t i = array->count;
   if (i == array->capacity) {
@@ -194,27 +194,27 @@ GPR_EXPORT void GPR_CALLTYPE grpcwrap_metadata_array_add(
   array->count++;
 }
 
-GPR_EXPORT const char *GPR_CALLTYPE grpcwrap_metadata_array_get_key(
-    const grpc_metadata_array *array, size_t index, size_t *key_length) {
+GPR_EXPORT const char* GPR_CALLTYPE grpcwrap_metadata_array_get_key(
+    const grpc_metadata_array* array, size_t index, size_t* key_length) {
   GPR_ASSERT(index < array->count);
   *key_length = GRPC_SLICE_LENGTH(array->metadata[index].key);
-  return (char *)GRPC_SLICE_START_PTR(array->metadata[index].key);
+  return (char*)GRPC_SLICE_START_PTR(array->metadata[index].key);
 }
 
-GPR_EXPORT const char *GPR_CALLTYPE grpcwrap_metadata_array_get_value(
-    const grpc_metadata_array *array, size_t index, size_t *value_length) {
+GPR_EXPORT const char* GPR_CALLTYPE grpcwrap_metadata_array_get_value(
+    const grpc_metadata_array* array, size_t index, size_t* value_length) {
   GPR_ASSERT(index < array->count);
   *value_length = GRPC_SLICE_LENGTH(array->metadata[index].value);
-  return (char *)GRPC_SLICE_START_PTR(array->metadata[index].value);
+  return (char*)GRPC_SLICE_START_PTR(array->metadata[index].value);
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_metadata_array_cleanup(grpc_metadata_array *array) {
+grpcwrap_metadata_array_cleanup(grpc_metadata_array* array) {
   grpcwrap_metadata_array_destroy_metadata_including_entries(array);
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_metadata_array_shrink_to_fit(grpc_metadata_array *array) {
+grpcwrap_metadata_array_shrink_to_fit(grpc_metadata_array* array) {
   GPR_ASSERT(array->count <= array->capacity);
   if (array->count == array->capacity) {
     return;
@@ -231,8 +231,8 @@ grpcwrap_metadata_array_shrink_to_fit(grpc_metadata_array *array) {
 }
 
 /* Move contents of metadata array */
-void grpcwrap_metadata_array_move(grpc_metadata_array *dest,
-                                  grpc_metadata_array *src) {
+void grpcwrap_metadata_array_move(grpc_metadata_array* dest,
+                                  grpc_metadata_array* src) {
   if (!src) {
     dest->capacity = 0;
     dest->count = 0;
@@ -250,7 +250,7 @@ void grpcwrap_metadata_array_move(grpc_metadata_array *dest,
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_batch_context_destroy(grpcwrap_batch_context *ctx) {
+grpcwrap_batch_context_destroy(grpcwrap_batch_context* ctx) {
   if (!ctx) {
     return;
   }
@@ -274,7 +274,7 @@ grpcwrap_batch_context_destroy(grpcwrap_batch_context *ctx) {
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_request_call_context_destroy(grpcwrap_request_call_context *ctx) {
+grpcwrap_request_call_context_destroy(grpcwrap_request_call_context* ctx) {
   if (!ctx) {
     return;
   }
@@ -289,14 +289,14 @@ grpcwrap_request_call_context_destroy(grpcwrap_request_call_context *ctx) {
   gpr_free(ctx);
 }
 
-GPR_EXPORT const grpc_metadata_array *GPR_CALLTYPE
+GPR_EXPORT const grpc_metadata_array* GPR_CALLTYPE
 grpcwrap_batch_context_recv_initial_metadata(
-    const grpcwrap_batch_context *ctx) {
+    const grpcwrap_batch_context* ctx) {
   return &(ctx->recv_initial_metadata);
 }
 
 GPR_EXPORT size_t GPR_CALLTYPE
-grpcwrap_batch_context_recv_message_length(const grpcwrap_batch_context *ctx) {
+grpcwrap_batch_context_recv_message_length(const grpcwrap_batch_context* ctx) {
   grpc_byte_buffer_reader reader;
   if (!ctx->recv_message) {
     return (size_t)-1;
@@ -314,7 +314,7 @@ grpcwrap_batch_context_recv_message_length(const grpcwrap_batch_context *ctx) {
  * buffer is too small.
  */
 GPR_EXPORT void GPR_CALLTYPE grpcwrap_batch_context_recv_message_to_buffer(
-    const grpcwrap_batch_context *ctx, char *buffer, size_t buffer_len) {
+    const grpcwrap_batch_context* ctx, char* buffer, size_t buffer_len) {
   grpc_byte_buffer_reader reader;
   grpc_slice slice;
   size_t offset = 0;
@@ -335,74 +335,73 @@ GPR_EXPORT void GPR_CALLTYPE grpcwrap_batch_context_recv_message_to_buffer(
 
 GPR_EXPORT grpc_status_code GPR_CALLTYPE
 grpcwrap_batch_context_recv_status_on_client_status(
-    const grpcwrap_batch_context *ctx) {
+    const grpcwrap_batch_context* ctx) {
   return ctx->recv_status_on_client.status;
 }
 
-GPR_EXPORT const char *GPR_CALLTYPE
+GPR_EXPORT const char* GPR_CALLTYPE
 grpcwrap_batch_context_recv_status_on_client_details(
-    const grpcwrap_batch_context *ctx, size_t *details_length) {
+    const grpcwrap_batch_context* ctx, size_t* details_length) {
   *details_length =
       GRPC_SLICE_LENGTH(ctx->recv_status_on_client.status_details);
-  return (char *)GRPC_SLICE_START_PTR(
-      ctx->recv_status_on_client.status_details);
+  return (char*)GRPC_SLICE_START_PTR(ctx->recv_status_on_client.status_details);
 }
 
-GPR_EXPORT const grpc_metadata_array *GPR_CALLTYPE
+GPR_EXPORT const grpc_metadata_array* GPR_CALLTYPE
 grpcwrap_batch_context_recv_status_on_client_trailing_metadata(
-    const grpcwrap_batch_context *ctx) {
+    const grpcwrap_batch_context* ctx) {
   return &(ctx->recv_status_on_client.trailing_metadata);
 }
 
-GPR_EXPORT grpc_call *GPR_CALLTYPE
-grpcwrap_request_call_context_ref_call(grpcwrap_request_call_context *ctx) {
-  grpc_call *call = ctx->call;
+GPR_EXPORT grpc_call* GPR_CALLTYPE
+grpcwrap_request_call_context_ref_call(grpcwrap_request_call_context* ctx) {
+  grpc_call* call = ctx->call;
   grpc_call_ref(call);
   return call;
 }
 
-GPR_EXPORT grpc_call *GPR_CALLTYPE
-grpcwrap_request_call_context_get_call(grpcwrap_request_call_context *ctx) {
+GPR_EXPORT grpc_call* GPR_CALLTYPE
+grpcwrap_request_call_context_get_call(grpcwrap_request_call_context* ctx) {
   return ctx->call;
 }
 
-GPR_EXPORT const char *GPR_CALLTYPE grpcwrap_request_call_context_method(
-    const grpcwrap_request_call_context *ctx, size_t *method_length) {
+GPR_EXPORT const char* GPR_CALLTYPE grpcwrap_request_call_context_method(
+    const grpcwrap_request_call_context* ctx, size_t* method_length) {
   *method_length = GRPC_SLICE_LENGTH(ctx->call_details.method);
-  return (char *)GRPC_SLICE_START_PTR(ctx->call_details.method);
+  return (char*)GRPC_SLICE_START_PTR(ctx->call_details.method);
 }
 
-GPR_EXPORT const char *GPR_CALLTYPE grpcwrap_request_call_context_host(
-    const grpcwrap_request_call_context *ctx, size_t *host_length) {
+GPR_EXPORT const char* GPR_CALLTYPE grpcwrap_request_call_context_host(
+    const grpcwrap_request_call_context* ctx, size_t* host_length) {
   *host_length = GRPC_SLICE_LENGTH(ctx->call_details.host);
-  return (char *)GRPC_SLICE_START_PTR(ctx->call_details.host);
+  return (char*)GRPC_SLICE_START_PTR(ctx->call_details.host);
 }
 
 GPR_EXPORT gpr_timespec GPR_CALLTYPE grpcwrap_request_call_context_deadline(
-    const grpcwrap_request_call_context *ctx) {
+    const grpcwrap_request_call_context* ctx) {
   return ctx->call_details.deadline;
 }
 
-GPR_EXPORT const grpc_metadata_array *GPR_CALLTYPE
+GPR_EXPORT const grpc_metadata_array* GPR_CALLTYPE
 grpcwrap_request_call_context_metadata_array(
-    const grpcwrap_request_call_context *ctx) {
+    const grpcwrap_request_call_context* ctx) {
   return &(ctx->request_metadata);
 }
 
 GPR_EXPORT int32_t GPR_CALLTYPE
 grpcwrap_batch_context_recv_close_on_server_cancelled(
-    const grpcwrap_batch_context *ctx) {
+    const grpcwrap_batch_context* ctx) {
   return (int32_t)ctx->recv_close_on_server_cancelled;
 }
 
 /* Channel */
 
-GPR_EXPORT grpc_call *GPR_CALLTYPE grpcwrap_channel_create_call(
-    grpc_channel *channel, grpc_call *parent_call, uint32_t propagation_mask,
-    grpc_completion_queue *cq, const char *method, size_t method_len,
-    const char *host, size_t host_len, gpr_timespec deadline) {
+GPR_EXPORT grpc_call* GPR_CALLTYPE grpcwrap_channel_create_call(
+    grpc_channel* channel, grpc_call* parent_call, uint32_t propagation_mask,
+    grpc_completion_queue* cq, const char* method, size_t method_len,
+    const char* host, size_t host_len, gpr_timespec deadline) {
   grpc_slice method_slice = grpc_slice_from_copied_buffer(method, method_len);
-  grpc_slice *host_slice_ptr = NULL;
+  grpc_slice* host_slice_ptr = NULL;
   grpc_slice host_slice;
   if (host != NULL) {
     host_slice = grpc_slice_from_copied_buffer(host, host_len);
@@ -411,7 +410,7 @@ GPR_EXPORT grpc_call *GPR_CALLTYPE grpcwrap_channel_create_call(
     // to silent msvc false warning
     host_slice = grpc_empty_slice();
   }
-  grpc_call *ret =
+  grpc_call* ret =
       grpc_channel_create_call(channel, parent_call, propagation_mask, cq,
                                method_slice, host_slice_ptr, deadline, NULL);
   grpc_slice_unref(method_slice);
@@ -423,20 +422,20 @@ GPR_EXPORT grpc_call *GPR_CALLTYPE grpcwrap_channel_create_call(
 
 /* Channel args */
 
-GPR_EXPORT grpc_channel_args *GPR_CALLTYPE
+GPR_EXPORT grpc_channel_args* GPR_CALLTYPE
 grpcwrap_channel_args_create(size_t num_args) {
-  grpc_channel_args *args =
-      (grpc_channel_args *)gpr_malloc(sizeof(grpc_channel_args));
+  grpc_channel_args* args =
+      (grpc_channel_args*)gpr_malloc(sizeof(grpc_channel_args));
   memset(args, 0, sizeof(grpc_channel_args));
 
   args->num_args = num_args;
-  args->args = (grpc_arg *)gpr_malloc(sizeof(grpc_arg) * num_args);
+  args->args = (grpc_arg*)gpr_malloc(sizeof(grpc_arg) * num_args);
   memset(args->args, 0, sizeof(grpc_arg) * num_args);
   return args;
 }
 
 GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_string(
-    grpc_channel_args *args, size_t index, const char *key, const char *value) {
+    grpc_channel_args* args, size_t index, const char* key, const char* value) {
   GPR_ASSERT(args);
   GPR_ASSERT(index < args->num_args);
   args->args[index].type = GRPC_ARG_STRING;
@@ -445,7 +444,7 @@ GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_string(
 }
 
 GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_integer(
-    grpc_channel_args *args, size_t index, const char *key, int value) {
+    grpc_channel_args* args, size_t index, const char* key, int value) {
   GPR_ASSERT(args);
   GPR_ASSERT(index < args->num_args);
   args->args[index].type = GRPC_ARG_INTEGER;
@@ -454,7 +453,7 @@ GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_integer(
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_channel_args_destroy(grpc_channel_args *args) {
+grpcwrap_channel_args_destroy(grpc_channel_args* args) {
   size_t i;
   if (args) {
     for (i = 0; i < args->num_args; i++) {
@@ -471,10 +470,10 @@ grpcwrap_channel_args_destroy(grpc_channel_args *args) {
 /* Call */
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_unary(
-    grpc_call *call, grpcwrap_batch_context *ctx, const char *send_buffer,
+    grpc_call* call, grpcwrap_batch_context* ctx, const char* send_buffer,
     size_t send_buffer_len, uint32_t write_flags,
-    grpc_metadata_array *initial_metadata, uint32_t initial_metadata_flags,
-    void *tag) {
+    grpc_metadata_array* initial_metadata, uint32_t initial_metadata_flags,
+    void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[6];
   memset(ops, 0, sizeof(ops));
@@ -522,9 +521,9 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_unary(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_client_streaming(
-    grpc_call *call, grpcwrap_batch_context *ctx,
-    grpc_metadata_array *initial_metadata, uint32_t initial_metadata_flags,
-    void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx,
+    grpc_metadata_array* initial_metadata, uint32_t initial_metadata_flags,
+    void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[4];
   memset(ops, 0, sizeof(ops));
@@ -562,10 +561,10 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_client_streaming(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_server_streaming(
-    grpc_call *call, grpcwrap_batch_context *ctx, const char *send_buffer,
+    grpc_call* call, grpcwrap_batch_context* ctx, const char* send_buffer,
     size_t send_buffer_len, uint32_t write_flags,
-    grpc_metadata_array *initial_metadata, uint32_t initial_metadata_flags,
-    void *tag) {
+    grpc_metadata_array* initial_metadata, uint32_t initial_metadata_flags,
+    void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[4];
   memset(ops, 0, sizeof(ops));
@@ -602,9 +601,9 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_server_streaming(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_duplex_streaming(
-    grpc_call *call, grpcwrap_batch_context *ctx,
-    grpc_metadata_array *initial_metadata, uint32_t initial_metadata_flags,
-    void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx,
+    grpc_metadata_array* initial_metadata, uint32_t initial_metadata_flags,
+    void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[2];
   memset(ops, 0, sizeof(ops));
@@ -631,7 +630,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_duplex_streaming(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_recv_initial_metadata(
-    grpc_call *call, grpcwrap_batch_context *ctx, void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[1];
   ops[0].op = GRPC_OP_RECV_INITIAL_METADATA;
@@ -645,9 +644,9 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_recv_initial_metadata(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_message(
-    grpc_call *call, grpcwrap_batch_context *ctx, const char *send_buffer,
+    grpc_call* call, grpcwrap_batch_context* ctx, const char* send_buffer,
     size_t send_buffer_len, uint32_t write_flags,
-    int32_t send_empty_initial_metadata, void *tag) {
+    int32_t send_empty_initial_metadata, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[2];
   memset(ops, 0, sizeof(ops));
@@ -665,7 +664,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_message(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE
-grpcwrap_call_send_close_from_client(grpc_call *call, void *tag) {
+grpcwrap_call_send_close_from_client(grpc_call* call, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[1];
   ops[0].op = GRPC_OP_SEND_CLOSE_FROM_CLIENT;
@@ -677,11 +676,11 @@ grpcwrap_call_send_close_from_client(grpc_call *call, void *tag) {
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_status_from_server(
-    grpc_call *call, grpcwrap_batch_context *ctx, grpc_status_code status_code,
-    const char *status_details, size_t status_details_len,
-    grpc_metadata_array *trailing_metadata, int32_t send_empty_initial_metadata,
-    const char *optional_send_buffer, size_t optional_send_buffer_len,
-    uint32_t write_flags, void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx, grpc_status_code status_code,
+    const char* status_details, size_t status_details_len,
+    grpc_metadata_array* trailing_metadata, int32_t send_empty_initial_metadata,
+    const char* optional_send_buffer, size_t optional_send_buffer_len,
+    uint32_t write_flags, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[3];
   memset(ops, 0, sizeof(ops));
@@ -720,7 +719,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_status_from_server(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_recv_message(
-    grpc_call *call, grpcwrap_batch_context *ctx, void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[1];
   ops[0].op = GRPC_OP_RECV_MESSAGE;
@@ -732,7 +731,7 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_recv_message(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_serverside(
-    grpc_call *call, grpcwrap_batch_context *ctx, void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[1];
   ops[0].op = GRPC_OP_RECV_CLOSE_ON_SERVER;
@@ -746,8 +745,8 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_start_serverside(
 }
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_initial_metadata(
-    grpc_call *call, grpcwrap_batch_context *ctx,
-    grpc_metadata_array *initial_metadata, void *tag) {
+    grpc_call* call, grpcwrap_batch_context* ctx,
+    grpc_metadata_array* initial_metadata, void* tag) {
   /* TODO: don't use magic number */
   grpc_op ops[1];
   memset(ops, 0, sizeof(ops));
@@ -766,8 +765,8 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_initial_metadata(
 /* Server */
 
 GPR_EXPORT grpc_call_error GPR_CALLTYPE
-grpcwrap_server_request_call(grpc_server *server, grpc_completion_queue *cq,
-                             grpcwrap_request_call_context *ctx, void *tag) {
+grpcwrap_server_request_call(grpc_server* server, grpc_completion_queue* cq,
+                             grpcwrap_request_call_context* ctx, void* tag) {
   return grpc_server_request_call(server, &(ctx->call), &(ctx->call_details),
                                   &(ctx->request_metadata), cq, cq, tag);
 }
@@ -776,10 +775,10 @@ grpcwrap_server_request_call(grpc_server *server, grpc_completion_queue *cq,
 
 /* Security */
 
-static char *default_pem_root_certs = NULL;
+static char* default_pem_root_certs = NULL;
 
 static grpc_ssl_roots_override_result override_ssl_roots_handler(
-    char **pem_root_certs) {
+    char** pem_root_certs) {
   if (!default_pem_root_certs) {
     *pem_root_certs = NULL;
     return GRPC_SSL_ROOTS_OVERRIDE_FAIL_PERMANENTLY;
@@ -789,7 +788,7 @@ static grpc_ssl_roots_override_result override_ssl_roots_handler(
 }
 
 GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_override_default_ssl_roots(const char *pem_root_certs) {
+grpcwrap_override_default_ssl_roots(const char* pem_root_certs) {
   /*
    * This currently wastes ~300kB of memory by keeping a copy of roots
    * in a static variable, but for desktop/server use, the overhead
@@ -800,10 +799,10 @@ grpcwrap_override_default_ssl_roots(const char *pem_root_certs) {
   grpc_set_ssl_roots_override_callback(override_ssl_roots_handler);
 }
 
-GPR_EXPORT grpc_channel_credentials *GPR_CALLTYPE
-grpcwrap_ssl_credentials_create(const char *pem_root_certs,
-                                const char *key_cert_pair_cert_chain,
-                                const char *key_cert_pair_private_key) {
+GPR_EXPORT grpc_channel_credentials* GPR_CALLTYPE
+grpcwrap_ssl_credentials_create(const char* pem_root_certs,
+                                const char* key_cert_pair_cert_chain,
+                                const char* key_cert_pair_private_key) {
   grpc_ssl_pem_key_cert_pair key_cert_pair;
   if (key_cert_pair_cert_chain || key_cert_pair_private_key) {
     key_cert_pair.cert_chain = key_cert_pair_cert_chain;
@@ -816,14 +815,14 @@ grpcwrap_ssl_credentials_create(const char *pem_root_certs,
   }
 }
 
-GPR_EXPORT grpc_server_credentials *GPR_CALLTYPE
+GPR_EXPORT grpc_server_credentials* GPR_CALLTYPE
 grpcwrap_ssl_server_credentials_create(
-    const char *pem_root_certs, const char **key_cert_pair_cert_chain_array,
-    const char **key_cert_pair_private_key_array, size_t num_key_cert_pairs,
+    const char* pem_root_certs, const char** key_cert_pair_cert_chain_array,
+    const char** key_cert_pair_private_key_array, size_t num_key_cert_pairs,
     int force_client_auth) {
   size_t i;
-  grpc_server_credentials *creds;
-  grpc_ssl_pem_key_cert_pair *key_cert_pairs =
+  grpc_server_credentials* creds;
+  grpc_ssl_pem_key_cert_pair* key_cert_pairs =
       gpr_malloc(sizeof(grpc_ssl_pem_key_cert_pair) * num_key_cert_pairs);
   memset(key_cert_pairs, 0,
          sizeof(grpc_ssl_pem_key_cert_pair) * num_key_cert_pairs);


### PR DESCRIPTION
Address https://github.com/pingcap/grpc-rs/pull/203#issuecomment-406257048.

```diff
diff --git a/.clang-format b/.clang-format
index 4b3f13fa55..f9af7637aa 100644
--- a/.clang-format
+++ b/.clang-format
@@ -1,5 +1,12 @@
 ---
 Language:        Cpp
 BasedOnStyle:  Google
+DerivePointerAlignment: false
+PointerAlignment: Left
+---
+Language: ObjC
+BasedOnStyle: Google
+ColumnLimit: 100
+ObjCBlockIndentWidth: 2
 ...
 
```