### PR TITLE
Add load_balancing_policy to ChannelBuilder

### DIFF
--- a/src/channel.rs
+++ b/src/channel.rs
@@ -61,6 +61,8 @@ const OPT_KEEPALIVE_PERMIT_WITHOUT_CALLS: &[u8] = b"grpc.keepalive_permit_withou
 const OPT_OPTIMIZATION_TARGET: &[u8] = b"grpc.optimization_target\0";
 const PRIMARY_USER_AGENT_STRING: &[u8] = b"grpc.primary_user_agent\0";
 
+const OPT_GRPC_ARG_LB_POLICY_NAME: &[u8] = b"grpc.lb_policy_name\0";
+
 /// Ref: http://www.grpc.io/docs/guides/wire.html#user-agents
 fn format_user_agent_string(agent: &str) -> CString {
     let version = env!("CARGO_PKG_VERSION");
@@ -91,6 +93,11 @@ pub enum OptTarget {
     Blend,
     /// Maximize throughput at the expense of latency.
     Throughput,
+}
+
+pub enum LBPolicy {
+    RoundRobin,
+    Default,
 }
 
 /// [`Channel`] factory in order to configure the properties.
@@ -365,6 +372,21 @@ impl ChannelBuilder {
         self.options.insert(
             Cow::Borrowed(OPT_OPTIMIZATION_TARGET),
             Options::String(val.unwrap()),
+        );
+        self
+    }
+
+    /// Set LBPolicy for channel
+    ///
+    /// This method allows one to set the load-balancing policy for a given channel.
+    pub fn load_balancing_policy_name(mut self, lb_policy: LBPolicy) -> ChannelBuilder {
+        let val = match lb_policy {
+            LBPolicy::RoundRobin => CString::new("round_robin"),
+            LBPolicy::Default => CString::new(""),
+        };
+        self.options.insert(
+            Cow::Borrowed(OPT_GRPC_ARG_LB_POLICY_NAME),
+            Options::String(val.unwrap())
         );
         self
     }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -95,7 +95,7 @@ pub enum OptTarget {
 }
 
 pub enum LbPolicy {
-    Default,
+    PickFirst,
     RoundRobin,
 }
 
@@ -380,8 +380,8 @@ impl ChannelBuilder {
     /// This method allows one to set the load-balancing policy for a given channel.
     pub fn load_balancing_policy(mut self, lb_policy: LbPolicy) -> ChannelBuilder {
         let val = match lb_policy {
+            LbPolicy::PickFirst => CString::new("pick_first"),
             LbPolicy::RoundRobin => CString::new("round_robin"),
-            LbPolicy::Default => CString::new(""),
         };
         self.options.insert(
             Cow::Borrowed(OPT_GRPC_ARG_LB_POLICY_NAME),

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -60,7 +60,6 @@ const OPT_KEEPALIVE_TIMEOUT_MS: &[u8] = b"grpc.keepalive_timeout_ms\0";
 const OPT_KEEPALIVE_PERMIT_WITHOUT_CALLS: &[u8] = b"grpc.keepalive_permit_without_calls\0";
 const OPT_OPTIMIZATION_TARGET: &[u8] = b"grpc.optimization_target\0";
 const PRIMARY_USER_AGENT_STRING: &[u8] = b"grpc.primary_user_agent\0";
-
 const OPT_GRPC_ARG_LB_POLICY_NAME: &[u8] = b"grpc.lb_policy_name\0";
 
 /// Ref: http://www.grpc.io/docs/guides/wire.html#user-agents
@@ -96,8 +95,8 @@ pub enum OptTarget {
 }
 
 pub enum LbPolicy {
-    RoundRobin,
     Default,
+    RoundRobin,
 }
 
 /// [`Channel`] factory in order to configure the properties.

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -95,7 +95,7 @@ pub enum OptTarget {
     Throughput,
 }
 
-pub enum LBPolicy {
+pub enum LbPolicy {
     RoundRobin,
     Default,
 }
@@ -376,13 +376,13 @@ impl ChannelBuilder {
         self
     }
 
-    /// Set LBPolicy for channel
+    /// Set LbPolicy for channel
     ///
     /// This method allows one to set the load-balancing policy for a given channel.
-    pub fn load_balancing_policy_name(mut self, lb_policy: LBPolicy) -> ChannelBuilder {
+    pub fn load_balancing_policy(mut self, lb_policy: LbPolicy) -> ChannelBuilder {
         let val = match lb_policy {
-            LBPolicy::RoundRobin => CString::new("round_robin"),
-            LBPolicy::Default => CString::new(""),
+            LbPolicy::RoundRobin => CString::new("round_robin"),
+            LbPolicy::Default => CString::new(""),
         };
         self.options.insert(
             Cow::Borrowed(OPT_GRPC_ARG_LB_POLICY_NAME),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -63,7 +63,7 @@ pub use call::client::{CallOption, ClientCStreamReceiver, ClientCStreamSender,
 pub use call::server::{ClientStreamingSink, ClientStreamingSinkResult, Deadline, DuplexSink,
                        DuplexSinkFailure, RequestStream, RpcContext, ServerStreamingSink,
                        ServerStreamingSinkFailure, UnarySink, UnarySinkResult};
-pub use channel::{OptTarget, Channel, ChannelBuilder, CompressionAlgorithms, CompressionLevel};
+pub use channel::{LbPolicy, OptTarget, Channel, ChannelBuilder, CompressionAlgorithms, CompressionLevel};
 pub use client::Client;
 pub use codec::Marshaller;
 #[cfg(feature = "protobuf-codec")]

--- a/tests/cases/misc.rs
+++ b/tests/cases/misc.rs
@@ -43,9 +43,7 @@ fn test_peer() {
         .unwrap();
     server.start();
     let port = server.bind_addrs()[0].1;
-    let cb = ChannelBuilder::new(env);
-    let cb = cb.load_balancing_policy(LbPolicy::RoundRobin);
-    let ch = cb.connect(&format!("127.0.0.1:{}", port));
+    let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
     let client = GreeterClient::new(ch);
 
     let req = HelloRequest::new();

--- a/tests/cases/misc.rs
+++ b/tests/cases/misc.rs
@@ -43,7 +43,9 @@ fn test_peer() {
         .unwrap();
     server.start();
     let port = server.bind_addrs()[0].1;
-    let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
+    let cb = ChannelBuilder::new(env);
+    let cb = cb.load_balancing_policy(LbPolicy::RoundRobin);
+    let ch = cb.connect(&format!("127.0.0.1:{}", port));
     let client = GreeterClient::new(ch);
 
     let req = HelloRequest::new();


### PR DESCRIPTION
The C library implements `round_robin` load balancing. This patch exposes an api to set this option. This fits my use-case.

Debugging with 
```
GRPC_TRACE=client_channel GRPC_VERBOSITY=DEBUG  cargo test 
```

I see it's being used:
```
D0727 13:49:12.471451992    4814 client_channel.c:482]       chand=0x7f5c0ce2b388: resolver result: lb_policy_name="round_robin" (changed), service_config="(null)"
D0727 13:49:12.471457240    4814 client_channel.c:564]       chand=0x7f5c0ce2b388: initializing new LB policy
```