### PR TITLE
*: fix soundness of service handler

### DIFF
--- a/src/async/callback.rs
+++ b/src/async/callback.rs
@@ -11,20 +11,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::sync::Arc;
 
 use call::{BatchContext, Call};
 use call::server::{RequestContext, UnaryRequestContext};
 use cq::CompletionQueue;
-use server::{self, Inner as ServerInner};
+use server::{self, RequestCallContext};
 
 pub struct Request {
     ctx: RequestContext,
 }
 
 impl Request {
-    pub fn new(inner: Arc<ServerInner>) -> Request {
-        let ctx = RequestContext::new(inner);
+    pub fn new(rc: RequestCallContext) -> Request {
+        let ctx = RequestContext::new(rc);
         Request { ctx }
     }
 
@@ -33,15 +32,15 @@ impl Request {
     }
 
     pub fn resolve(mut self, cq: &CompletionQueue, success: bool) {
-        let inner = self.ctx.take_inner().unwrap();
+        let rc = self.ctx.take_request_call_context().unwrap();
         if !success {
-            server::request_call(inner, cq);
+            server::request_call(rc, cq);
             return;
         }
 
-        match self.ctx.handle_stream_req(cq, &inner) {
-            Ok(_) => server::request_call(inner, cq),
-            Err(ctx) => ctx.handle_unary_req(inner, cq),
+        match self.ctx.handle_stream_req(cq, &rc) {
+            Ok(_) => server::request_call(rc, cq),
+            Err(ctx) => ctx.handle_unary_req(rc, cq),
         }
     }
 }
@@ -51,8 +50,8 @@ pub struct UnaryRequest {
 }
 
 impl UnaryRequest {
-    pub fn new(ctx: RequestContext, inner: Arc<ServerInner>) -> UnaryRequest {
-        let ctx = UnaryRequestContext::new(ctx, inner);
+    pub fn new(ctx: RequestContext, rc: RequestCallContext) -> UnaryRequest {
+        let ctx = UnaryRequestContext::new(ctx, rc);
         UnaryRequest { ctx }
     }
 
@@ -65,16 +64,16 @@ impl UnaryRequest {
     }
 
     pub fn resolve(mut self, cq: &CompletionQueue, success: bool) {
-        let inner = self.ctx.take_inner().unwrap();
+        let rc = self.ctx.take_request_call_context().unwrap();
         if !success {
-            server::request_call(inner, cq);
+            server::request_call(rc, cq);
             return;
         }
 
         let data = self.ctx.batch_ctx().recv_message();
         self.ctx
-            .handle(&inner, cq, data.as_ref().map(|v| v.as_slice()));
-        server::request_call(inner, cq);
+            .handle(&rc, cq, data.as_ref().map(|v| v.as_slice()));
+        server::request_call(rc, cq);
     }
 }
 

--- a/src/async/mod.rs
+++ b/src/async/mod.rs
@@ -29,7 +29,7 @@ use error::{Error, Result};
 use self::executor::SpawnNotify;
 use self::callback::{Abort, Request as RequestCallback, UnaryRequest as UnaryRequestCallback};
 use self::promise::{Batch as BatchPromise, Shutdown as ShutdownPromise};
-use server::Inner as ServerInner;
+use server::RequestCallContext;
 
 pub use self::executor::Executor;
 pub use self::promise::BatchType;
@@ -140,8 +140,8 @@ impl CallTag {
 
     /// Generate a CallTag for request job. We don't have an eventloop
     /// to pull the future, so just the tag is enough.
-    pub fn request(inner: Arc<ServerInner>) -> CallTag {
-        CallTag::Request(RequestCallback::new(inner))
+    pub fn request(ctx: RequestCallContext) -> CallTag {
+        CallTag::Request(RequestCallback::new(ctx))
     }
 
     /// Generate a Future/CallTag pair for shutdown call.
@@ -157,8 +157,8 @@ impl CallTag {
     }
 
     /// Generate a CallTag for unary request job.
-    pub fn unary_request(ctx: RequestContext, inner: Arc<ServerInner>) -> CallTag {
-        let cb = UnaryRequestCallback::new(ctx, inner);
+    pub fn unary_request(ctx: RequestContext, rc: RequestCallContext) -> CallTag {
+        let cb = UnaryRequestCallback::new(ctx, rc);
         CallTag::UnaryRequest(cb)
     }
 

--- a/src/server.rs
+++ b/src/server.rs
@@ -374,7 +374,7 @@ pub struct RequestCallContext {
 }
 
 impl RequestCallContext {
-    /// Users should gurantee the method is always called from the same thread.
+    /// Users should guarantee the method is always called from the same thread.
     /// TODO: Is there a better way?
     #[inline]
     pub unsafe fn get_handler(&self, path: &[u8]) -> Option<&BoxHandler> {
@@ -382,7 +382,7 @@ impl RequestCallContext {
     }
 }
 
-// Apprently, its life time is guranteed by the ref count, hence is safe to be sent
+// Apprently, its life time is guaranteed by the ref count, hence is safe to be sent
 // to other thread. However it's not `Sync`, as `BoxHandler` is neccessary not `Sync`.
 unsafe impl Send for RequestCallContext {}
 

--- a/tests/cases/misc.rs
+++ b/tests/cases/misc.rs
@@ -19,6 +19,7 @@ use std::sync::*;
 use std::sync::atomic::*;
 use std::cell::UnsafeCell;
 use std::thread::{self, JoinHandle};
+use std::time::*;
 
 #[test]
 fn test_peer() {
@@ -80,6 +81,12 @@ impl Counter {
     }
 }
 
+impl Drop for Counter {
+    fn drop(&mut self) {
+        self.flush();
+    }
+}
+
 impl Clone for Counter {
     fn clone(&self) -> Counter {
         Counter {
@@ -97,14 +104,9 @@ fn test_soundness() {
     }
 
     impl Greeter for CounterService {
-        fn say_hello(&self, ctx: RpcContext, req: HelloRequest, sink: UnarySink<HelloReply>) {
+        fn say_hello(&self, ctx: RpcContext, _: HelloRequest, sink: UnarySink<HelloReply>) {
             self.c.incr();
-            let name = req.get_name();
-            if name == "flush" {
-                self.c.flush();
-            }
-            let mut resp = HelloReply::new();
-            resp.set_message(name.to_string());
+            let resp = HelloReply::new();
             ctx.spawn(
                 sink.success(resp)
                     .map_err(|e| panic!("failed to reply {:?}", e)),
@@ -122,34 +124,33 @@ fn test_soundness() {
         .unwrap();
     server.start();
     let port = server.bind_addrs()[0].1;
-    let mut reqs = Vec::with_capacity(3000);
-    for i in 0..3000 {
-        let mut req = HelloRequest::new();
-        if i == 1000 || i > 2000 {
-            req.set_name("flush".to_string());
-        } else {
-            req.set_name("test".to_string());
-        }
-        reqs.push(req);
-    }
 
-    let spanw_reqs = || -> JoinHandle<()> {
-        let ch = ChannelBuilder::new(env.clone()).connect(&format!("127.0.0.1:{}", port));
+    let spanw_reqs = |env| -> JoinHandle<()> {
+        let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
         let client = GreeterClient::new(ch);
-        let mut resps = Vec::with_capacity(reqs.len());
-        let reqs1 = reqs.clone();
+        let mut resps = Vec::with_capacity(3000);
         thread::spawn(move || {
-            for req in &reqs1 {
-                resps.push(client.say_hello_async(req).unwrap());
+            for _ in 0..3000 {
+                resps.push(client.say_hello_async(&HelloRequest::new()).unwrap());
             }
             future::join_all(resps).wait().unwrap();
         })
     };
-    let j1 = spanw_reqs();
-    let j2 = spanw_reqs();
-    let j3 = spanw_reqs();
+    let j1 = spanw_reqs(env.clone());
+    let j2 = spanw_reqs(env.clone());
+    let j3 = spanw_reqs(env.clone());
     j1.join().unwrap();
     j2.join().unwrap();
     j3.join().unwrap();
+    server.shutdown().wait().unwrap();
+    drop(server);
+    drop(env);
+    for _ in 0..100 {
+        let cnt = counter.load(Ordering::SeqCst);
+        if cnt == 9000 {
+            return;
+        }
+        thread::sleep(Duration::from_millis(50));
+    }
     assert_eq!(counter.load(Ordering::SeqCst), 9000);
 }

--- a/tests/cases/misc.rs
+++ b/tests/cases/misc.rs
@@ -16,6 +16,9 @@ use grpcio::*;
 use grpcio_proto::example::helloworld::*;
 use grpcio_proto::example::helloworld_grpc::*;
 use std::sync::*;
+use std::sync::atomic::*;
+use std::cell::UnsafeCell;
+use std::thread::{self, JoinHandle};
 
 #[test]
 fn test_peer() {
@@ -50,4 +53,103 @@ fn test_peer() {
     let resp = client.say_hello(&req).unwrap();
 
     assert!(resp.get_message().contains("127.0.0.1"), "{:?}", resp);
+}
+
+
+struct Counter {
+    global_counter: Arc<AtomicUsize>,
+    local_counter: UnsafeCell<usize>,
+}
+
+impl Counter {
+    fn incr(&self) {
+        unsafe {
+            let counter = self.local_counter.get();
+            let c = &mut *counter;
+            *c += 1;
+        }
+    }
+
+    fn flush(&self) {
+        unsafe {
+            let counter = self.local_counter.get();
+            let c = &mut *counter;
+            self.global_counter.fetch_add(*c, Ordering::SeqCst);
+            *c = 0;
+        }
+    }
+}
+
+impl Clone for Counter {
+    fn clone(&self) -> Counter {
+        Counter {
+            global_counter: self.global_counter.clone(),
+            local_counter: UnsafeCell::new(0),
+        }
+    }
+}
+
+#[test]
+fn test_soundness() {
+    #[derive(Clone)]
+    struct CounterService {
+        c: Counter,
+    }
+
+    impl Greeter for CounterService {
+        fn say_hello(&self, ctx: RpcContext, req: HelloRequest, sink: UnarySink<HelloReply>) {
+            self.c.incr();
+            let name = req.get_name();
+            if name == "flush" {
+                self.c.flush();
+            }
+            let mut resp = HelloReply::new();
+            resp.set_message(name.to_string());
+            ctx.spawn(
+                sink.success(resp)
+                    .map_err(|e| panic!("failed to reply {:?}", e)),
+            );
+        }
+    }
+
+    let env = Arc::new(EnvBuilder::new().cq_count(4).build());
+    let counter = Arc::new(AtomicUsize::new(0));
+    let service = CounterService { c: Counter { global_counter: counter.clone(), local_counter: UnsafeCell::new(0) } };
+    let mut server = ServerBuilder::new(env.clone())
+        .register_service(create_greeter(service))
+        .bind("127.0.0.1", 0)
+        .build()
+        .unwrap();
+    server.start();
+    let port = server.bind_addrs()[0].1;
+    let mut reqs = Vec::with_capacity(3000);
+    for i in 0..3000 {
+        let mut req = HelloRequest::new();
+        if i == 1000 || i > 2000 {
+            req.set_name("flush".to_string());
+        } else {
+            req.set_name("test".to_string());
+        }
+        reqs.push(req);
+    }
+
+    let spanw_reqs = || -> JoinHandle<()> {
+        let ch = ChannelBuilder::new(env.clone()).connect(&format!("127.0.0.1:{}", port));
+        let client = GreeterClient::new(ch);
+        let mut resps = Vec::with_capacity(reqs.len());
+        let reqs1 = reqs.clone();
+        thread::spawn(move || {
+            for req in &reqs1 {
+                resps.push(client.say_hello_async(req).unwrap());
+            }
+            future::join_all(resps).wait().unwrap();
+        })
+    };
+    let j1 = spanw_reqs();
+    let j2 = spanw_reqs();
+    let j3 = spanw_reqs();
+    j1.join().unwrap();
+    j2.join().unwrap();
+    j3.join().unwrap();
+    assert_eq!(counter.load(Ordering::SeqCst), 9000);
 }

--- a/tests/cases/misc.rs
+++ b/tests/cases/misc.rs
@@ -129,7 +129,7 @@ fn test_soundness() {
     server.start();
     let port = server.bind_addrs()[0].1;
 
-    let spanw_reqs = |env| -> JoinHandle<()> {
+    let spawn_reqs = |env| -> JoinHandle<()> {
         let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
         let client = GreeterClient::new(ch);
         let mut resps = Vec::with_capacity(3000);
@@ -140,9 +140,9 @@ fn test_soundness() {
             future::join_all(resps).wait().unwrap();
         })
     };
-    let j1 = spanw_reqs(env.clone());
-    let j2 = spanw_reqs(env.clone());
-    let j3 = spanw_reqs(env.clone());
+    let j1 = spawn_reqs(env.clone());
+    let j2 = spawn_reqs(env.clone());
+    let j3 = spawn_reqs(env.clone());
     j1.join().unwrap();
     j2.join().unwrap();
     j3.join().unwrap();


### PR DESCRIPTION
We use Send + Clone pattern to achieve concurrency without lock.
However our service handler registry treat them as if it's Send + Sync,
which will lead to data race.