### PR TITLE
*: make service accept mut reference

### DIFF
--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -36,14 +36,14 @@ pub struct Benchmark {
 }
 
 impl BenchmarkService for Benchmark {
-    fn unary_call(&self, ctx: RpcContext, req: SimpleRequest, sink: UnarySink<SimpleResponse>) {
+    fn unary_call(&mut self, ctx: RpcContext, req: SimpleRequest, sink: UnarySink<SimpleResponse>) {
         let f = sink.success(gen_resp(&req));
         let keep_running = self.keep_running.clone();
         spawn!(ctx, keep_running, "unary", f)
     }
 
     fn streaming_call(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<SimpleRequest>,
         sink: DuplexSink<SimpleResponse>,
@@ -54,7 +54,7 @@ impl BenchmarkService for Benchmark {
     }
 
     fn streaming_from_client(
-        &self,
+        &mut self,
         ctx: RpcContext,
         _: RequestStream<SimpleRequest>,
         sink: ClientStreamingSink<SimpleResponse>,
@@ -65,7 +65,7 @@ impl BenchmarkService for Benchmark {
     }
 
     fn streaming_from_server(
-        &self,
+        &mut self,
         ctx: RpcContext,
         _: SimpleRequest,
         sink: ServerStreamingSink<SimpleResponse>,
@@ -76,7 +76,7 @@ impl BenchmarkService for Benchmark {
     }
 
     fn streaming_both_ways(
-        &self,
+        &mut self,
         ctx: RpcContext,
         _: RequestStream<SimpleRequest>,
         sink: DuplexSink<SimpleResponse>,

--- a/benchmark/src/worker.rs
+++ b/benchmark/src/worker.rs
@@ -41,7 +41,7 @@ impl Worker {
 
 impl WorkerService for Worker {
     fn run_server(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<ServerArgs>,
         sink: DuplexSink<ServerStatus>,
@@ -78,7 +78,7 @@ impl WorkerService for Worker {
     }
 
     fn run_client(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<ClientArgs>,
         sink: DuplexSink<ClientStatus>,
@@ -114,7 +114,7 @@ impl WorkerService for Worker {
         ctx.spawn(f)
     }
 
-    fn core_count(&self, ctx: RpcContext, _: CoreRequest, sink: UnarySink<CoreResponse>) {
+    fn core_count(&mut self, ctx: RpcContext, _: CoreRequest, sink: UnarySink<CoreResponse>) {
         let cpu_count = util::cpu_num_cores();
         let mut resp = CoreResponse::new();
         resp.set_cores(cpu_count as i32);
@@ -124,7 +124,7 @@ impl WorkerService for Worker {
         )
     }
 
-    fn quit_worker(&self, ctx: RpcContext, _: Void, sink: ::grpc::UnarySink<Void>) {
+    fn quit_worker(&mut self, ctx: RpcContext, _: Void, sink: ::grpc::UnarySink<Void>) {
         let notifier = self.shutdown_notifier.lock().unwrap().take();
         if let Some(notifier) = notifier {
             let _ = notifier.send(());

--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -368,7 +368,7 @@ impl<'a> MethodGen<'a> {
             MethodType::Duplex => ("stream", req_stream_type, "DuplexSink"),
         };
         let sig = format!(
-            "{}(&self, ctx: {}, {}: {}, sink: {}<{}>)",
+            "{}(&mut self, ctx: {}, {}: {}, sink: {}<{}>)",
             self.name(),
             fq_grpc("RpcContext"),
             req,
@@ -487,7 +487,7 @@ impl<'a> ServiceGen<'a> {
         w.pub_fn(&s, |w| {
             w.write_line("let mut builder = ::grpcio::ServiceBuilder::new();");
             for method in &self.methods {
-                w.write_line("let instance = s.clone();");
+                w.write_line("let mut instance = s.clone();");
                 method.write_bind(w);
             }
             w.write_line("builder.build()");

--- a/examples/hello_world/server.rs
+++ b/examples/hello_world/server.rs
@@ -38,7 +38,7 @@ use grpcio_proto::example::helloworld_grpc::{self, Greeter};
 struct GreeterService;
 
 impl Greeter for GreeterService {
-    fn say_hello(&self, ctx: RpcContext, req: HelloRequest, sink: UnarySink<HelloReply>) {
+    fn say_hello(&mut self, ctx: RpcContext, req: HelloRequest, sink: UnarySink<HelloReply>) {
         let msg = format!("Hello {}", req.get_name());
         let mut resp = HelloReply::new();
         resp.set_message(msg);

--- a/examples/route_guide/server.rs
+++ b/examples/route_guide/server.rs
@@ -46,7 +46,7 @@ struct RouteGuideService {
 }
 
 impl RouteGuide for RouteGuideService {
-    fn get_feature(&self, ctx: RpcContext, point: Point, sink: UnarySink<Feature>) {
+    fn get_feature(&mut self, ctx: RpcContext, point: Point, sink: UnarySink<Feature>) {
         let data = self.data.clone();
         let resp = data
             .iter()
@@ -58,7 +58,12 @@ impl RouteGuide for RouteGuideService {
         ctx.spawn(f)
     }
 
-    fn list_features(&self, ctx: RpcContext, rect: Rectangle, resp: ServerStreamingSink<Feature>) {
+    fn list_features(
+        &mut self,
+        ctx: RpcContext,
+        rect: Rectangle,
+        resp: ServerStreamingSink<Feature>,
+    ) {
         let data = self.data.clone();
         let features: Vec<_> = data
             .iter()
@@ -78,7 +83,7 @@ impl RouteGuide for RouteGuideService {
     }
 
     fn record_route(
-        &self,
+        &mut self,
         ctx: RpcContext,
         points: RequestStream<Point>,
         resp: ClientStreamingSink<RouteSummary>,
@@ -115,7 +120,7 @@ impl RouteGuide for RouteGuideService {
     }
 
     fn route_chat(
-        &self,
+        &mut self,
         ctx: RpcContext,
         notes: RequestStream<RouteNote>,
         resp: DuplexSink<RouteNote>,

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -40,7 +40,7 @@ impl From<grpc::Error> for Error {
 pub struct InteropTestService;
 
 impl TestService for InteropTestService {
-    fn empty_call(&self, ctx: RpcContext, _: Empty, resp: UnarySink<Empty>) {
+    fn empty_call(&mut self, ctx: RpcContext, _: Empty, resp: UnarySink<Empty>) {
         let res = Empty::new();
         let f = resp
             .success(res)
@@ -48,7 +48,12 @@ impl TestService for InteropTestService {
         ctx.spawn(f)
     }
 
-    fn unary_call(&self, ctx: RpcContext, mut req: SimpleRequest, sink: UnarySink<SimpleResponse>) {
+    fn unary_call(
+        &mut self,
+        ctx: RpcContext,
+        mut req: SimpleRequest,
+        sink: UnarySink<SimpleResponse>,
+    ) {
         if req.has_response_status() {
             let code = req.get_response_status().get_code();
             let msg = Some(req.take_response_status().take_message());
@@ -68,12 +73,17 @@ impl TestService for InteropTestService {
         ctx.spawn(f)
     }
 
-    fn cacheable_unary_call(&self, _: RpcContext, _: SimpleRequest, _: UnarySink<SimpleResponse>) {
+    fn cacheable_unary_call(
+        &mut self,
+        _: RpcContext,
+        _: SimpleRequest,
+        _: UnarySink<SimpleResponse>,
+    ) {
         unimplemented!()
     }
 
     fn streaming_output_call(
-        &self,
+        &mut self,
         ctx: RpcContext,
         mut req: StreamingOutputCallRequest,
         sink: ServerStreamingSink<StreamingOutputCallResponse>,
@@ -91,7 +101,7 @@ impl TestService for InteropTestService {
     }
 
     fn streaming_input_call(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<StreamingInputCallRequest>,
         sink: ClientStreamingSink<StreamingInputCallResponse>,
@@ -113,7 +123,7 @@ impl TestService for InteropTestService {
     }
 
     fn full_duplex_call(
-        &self,
+        &mut self,
         ctx: RpcContext,
         stream: RequestStream<StreamingOutputCallRequest>,
         sink: DuplexSink<StreamingOutputCallResponse>,
@@ -156,7 +166,7 @@ impl TestService for InteropTestService {
     }
 
     fn half_duplex_call(
-        &self,
+        &mut self,
         _: RpcContext,
         _: RequestStream<StreamingOutputCallRequest>,
         _: DuplexSink<StreamingOutputCallResponse>,
@@ -164,7 +174,7 @@ impl TestService for InteropTestService {
         unimplemented!()
     }
 
-    fn unimplemented_call(&self, ctx: RpcContext, _: Empty, sink: UnarySink<Empty>) {
+    fn unimplemented_call(&mut self, ctx: RpcContext, _: Empty, sink: UnarySink<Empty>) {
         let f = sink
             .fail(RpcStatus::new(RpcStatusCode::Unimplemented, None))
             .map_err(|e| error!("failed to report unimplemented method: {:?}", e));

--- a/src/async/callback.rs
+++ b/src/async/callback.rs
@@ -31,13 +31,13 @@ impl Request {
     }
 
     pub fn resolve(mut self, cq: &CompletionQueue, success: bool) {
-        let rc = self.ctx.take_request_call_context().unwrap();
+        let mut rc = self.ctx.take_request_call_context().unwrap();
         if !success {
             server::request_call(rc, cq);
             return;
         }
 
-        match self.ctx.handle_stream_req(cq, &rc) {
+        match self.ctx.handle_stream_req(cq, &mut rc) {
             Ok(_) => server::request_call(rc, cq),
             Err(ctx) => ctx.handle_unary_req(rc, cq),
         }
@@ -63,7 +63,7 @@ impl UnaryRequest {
     }
 
     pub fn resolve(mut self, cq: &CompletionQueue, success: bool) {
-        let rc = self.ctx.take_request_call_context().unwrap();
+        let mut rc = self.ctx.take_request_call_context().unwrap();
         if !success {
             server::request_call(rc, cq);
             return;
@@ -71,7 +71,7 @@ impl UnaryRequest {
 
         let data = self.ctx.batch_ctx().recv_message();
         self.ctx
-            .handle(&rc, cq, data.as_ref().map(|v| v.as_slice()));
+            .handle(&mut rc, cq, data.as_ref().map(|v| v.as_slice()));
         server::request_call(rc, cq);
     }
 }

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -71,7 +71,7 @@ impl RequestContext {
     pub fn handle_stream_req(
         self,
         cq: &CompletionQueue,
-        rc: &RequestCallContext,
+        rc: &mut RequestCallContext,
     ) -> result::Result<(), Self> {
         let handler = unsafe { rc.get_handler(self.method()) };
         match handler {
@@ -204,7 +204,12 @@ impl UnaryRequestContext {
         self.request_call.take()
     }
 
-    pub fn handle(mut self, rc: &RequestCallContext, cq: &CompletionQueue, data: Option<&[u8]>) {
+    pub fn handle(
+        mut self,
+        rc: &mut RequestCallContext,
+        cq: &CompletionQueue,
+        data: Option<&[u8]>,
+    ) {
         let handler = unsafe { rc.get_handler(self.request.method()).unwrap() };
         if let Some(data) = data {
             return execute(self.request, cq, data, handler);
@@ -544,9 +549,9 @@ pub fn execute_unary<P, Q, F>(
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
     payload: &[u8],
-    f: &F,
+    f: &mut F,
 ) where
-    F: Fn(RpcContext, P, UnarySink<Q>),
+    F: FnMut(RpcContext, P, UnarySink<Q>),
 {
     let mut call = ctx.call();
     let close_f = accept_call!(call);
@@ -570,9 +575,9 @@ pub fn execute_client_streaming<P, Q, F>(
     mut ctx: RpcContext,
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
-    f: &F,
+    f: &mut F,
 ) where
-    F: Fn(RpcContext, RequestStream<P>, ClientStreamingSink<Q>),
+    F: FnMut(RpcContext, RequestStream<P>, ClientStreamingSink<Q>),
 {
     let mut call = ctx.call();
     let close_f = accept_call!(call);
@@ -589,9 +594,9 @@ pub fn execute_server_streaming<P, Q, F>(
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
     payload: &[u8],
-    f: &F,
+    f: &mut F,
 ) where
-    F: Fn(RpcContext, P, ServerStreamingSink<Q>),
+    F: FnMut(RpcContext, P, ServerStreamingSink<Q>),
 {
     let mut call = ctx.call();
     let close_f = accept_call!(call);
@@ -617,9 +622,9 @@ pub fn execute_duplex_streaming<P, Q, F>(
     mut ctx: RpcContext,
     ser: SerializeFn<Q>,
     de: DeserializeFn<P>,
-    f: &F,
+    f: &mut F,
 ) where
-    F: Fn(RpcContext, RequestStream<P>, DuplexSink<Q>),
+    F: FnMut(RpcContext, RequestStream<P>, DuplexSink<Q>),
 {
     let mut call = ctx.call();
     let close_f = accept_call!(call);
@@ -640,7 +645,7 @@ pub fn execute_unimplemented(mut ctx: RequestContext, cq: CompletionQueue) {
 // Helper function to call handler.
 //
 // Invoked after a request is ready to be handled.
-fn execute(ctx: RequestContext, cq: &CompletionQueue, payload: &[u8], f: &BoxHandler) {
+fn execute(ctx: RequestContext, cq: &CompletionQueue, payload: &[u8], f: &mut BoxHandler) {
     let rpc_ctx = RpcContext::new(ctx, cq);
     f.handle(rpc_ctx, payload)
 }

--- a/src/server.rs
+++ b/src/server.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::cell::UnsafeCell;
 use std::collections::HashMap;
 use std::fmt;
 use std::fmt::{Debug, Formatter};
@@ -46,17 +47,17 @@ impl<F> Handler<F> {
 }
 
 pub trait CloneableHandler: Send {
-    fn handle(&self, ctx: RpcContext, reqs: &[u8]);
+    fn handle(&mut self, ctx: RpcContext, reqs: &[u8]);
     fn box_clone(&self) -> Box<CloneableHandler>;
     fn method_type(&self) -> MethodType;
 }
 
 impl<F: 'static> CloneableHandler for Handler<F>
 where
-    F: Fn(RpcContext, &[u8]) + Send + Clone,
+    F: FnMut(RpcContext, &[u8]) + Send + Clone + 'static,
 {
     #[inline]
-    fn handle(&self, ctx: RpcContext, reqs: &[u8]) {
+    fn handle(&mut self, ctx: RpcContext, reqs: &[u8]) {
         (self.cb)(ctx, reqs)
     }
 
@@ -151,16 +152,17 @@ impl ServiceBuilder {
     pub fn add_unary_handler<Req, Resp, F>(
         mut self,
         method: &Method<Req, Resp>,
-        handler: F,
+        mut handler: F,
     ) -> ServiceBuilder
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, Req, UnarySink<Resp>) + Send + Clone + 'static,
+        F: FnMut(RpcContext, Req, UnarySink<Resp>) + Send + Clone + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h =
-            move |ctx: RpcContext, payload: &[u8]| execute_unary(ctx, ser, de, payload, &handler);
+        let h = move |ctx: RpcContext, payload: &[u8]| {
+            execute_unary(ctx, ser, de, payload, &mut handler)
+        };
         let ch = Box::new(Handler::new(MethodType::Unary, h));
         self.handlers.insert(method.name.as_bytes(), ch);
         self
@@ -170,15 +172,19 @@ impl ServiceBuilder {
     pub fn add_client_streaming_handler<Req, Resp, F>(
         mut self,
         method: &Method<Req, Resp>,
-        handler: F,
+        mut handler: F,
     ) -> ServiceBuilder
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, RequestStream<Req>, ClientStreamingSink<Resp>) + Send + Clone + 'static,
+        F: FnMut(RpcContext, RequestStream<Req>, ClientStreamingSink<Resp>)
+            + Send
+            + Clone
+            + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = move |ctx: RpcContext, _: &[u8]| execute_client_streaming(ctx, ser, de, &handler);
+        let h =
+            move |ctx: RpcContext, _: &[u8]| execute_client_streaming(ctx, ser, de, &mut handler);
         let ch = Box::new(Handler::new(MethodType::ClientStreaming, h));
         self.handlers.insert(method.name.as_bytes(), ch);
         self
@@ -188,16 +194,16 @@ impl ServiceBuilder {
     pub fn add_server_streaming_handler<Req, Resp, F>(
         mut self,
         method: &Method<Req, Resp>,
-        handler: F,
+        mut handler: F,
     ) -> ServiceBuilder
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, Req, ServerStreamingSink<Resp>) + Send + Clone + 'static,
+        F: FnMut(RpcContext, Req, ServerStreamingSink<Resp>) + Send + Clone + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
         let h = move |ctx: RpcContext, payload: &[u8]| {
-            execute_server_streaming(ctx, ser, de, payload, &handler)
+            execute_server_streaming(ctx, ser, de, payload, &mut handler)
         };
         let ch = Box::new(Handler::new(MethodType::ServerStreaming, h));
         self.handlers.insert(method.name.as_bytes(), ch);
@@ -208,15 +214,16 @@ impl ServiceBuilder {
     pub fn add_duplex_streaming_handler<Req, Resp, F>(
         mut self,
         method: &Method<Req, Resp>,
-        handler: F,
+        mut handler: F,
     ) -> ServiceBuilder
     where
         Req: 'static,
         Resp: 'static,
-        F: Fn(RpcContext, RequestStream<Req>, DuplexSink<Resp>) + Send + Clone + 'static,
+        F: FnMut(RpcContext, RequestStream<Req>, DuplexSink<Resp>) + Send + Clone + 'static,
     {
         let (ser, de) = (method.resp_ser(), method.req_de());
-        let h = move |ctx: RpcContext, _: &[u8]| execute_duplex_streaming(ctx, ser, de, &handler);
+        let h =
+            move |ctx: RpcContext, _: &[u8]| execute_duplex_streaming(ctx, ser, de, &mut handler);
         let ch = Box::new(Handler::new(MethodType::Duplex, h));
         self.handlers.insert(method.name.as_bytes(), ch);
         self
@@ -370,20 +377,21 @@ pub type BoxHandler = Box<CloneableHandler>;
 #[derive(Clone)]
 pub struct RequestCallContext {
     server: Arc<ServerCore>,
-    registry: Arc<HashMap<&'static [u8], BoxHandler>>,
+    registry: Arc<UnsafeCell<HashMap<&'static [u8], BoxHandler>>>,
 }
 
 impl RequestCallContext {
     /// Users should guarantee the method is always called from the same thread.
     /// TODO: Is there a better way?
     #[inline]
-    pub unsafe fn get_handler(&self, path: &[u8]) -> Option<&BoxHandler> {
-        self.registry.get(path)
+    pub unsafe fn get_handler(&mut self, path: &[u8]) -> Option<&mut BoxHandler> {
+        let registry = &mut *self.registry.get();
+        registry.get_mut(path)
     }
 }
 
 // Apprently, its life time is guaranteed by the ref count, hence is safe to be sent
-// to other thread. However it's not `Sync`, as `BoxHandler` is neccessary not `Sync`.
+// to other thread. However it's not `Sync`, as `BoxHandler` is not neccessary `Sync`.
 unsafe impl Send for RequestCallContext {}
 
 /// Request notification of a new call.
@@ -481,7 +489,7 @@ impl Server {
                     .collect();
                 let rc = RequestCallContext {
                     server: self.core.clone(),
-                    registry: Arc::new(registry),
+                    registry: Arc::new(UnsafeCell::new(registry)),
                 };
                 for _ in 0..self.core.slots_per_cq {
                     request_call(rc.clone(), cq);

--- a/tests/cases/alarm.rs
+++ b/tests/cases/alarm.rs
@@ -26,7 +26,7 @@ struct GreeterService {
 }
 
 impl Greeter for GreeterService {
-    fn say_hello(&self, ctx: RpcContext, mut req: HelloRequest, sink: UnarySink<HelloReply>) {
+    fn say_hello(&mut self, ctx: RpcContext, mut req: HelloRequest, sink: UnarySink<HelloReply>) {
         let (tx, rx) = oneshot::channel();
         let tx_lock = self.tx.clone();
         let name = req.take_name();

--- a/tests/cases/health_check.rs
+++ b/tests/cases/health_check.rs
@@ -27,7 +27,7 @@ struct HealthService {
 
 impl Health for HealthService {
     fn check(
-        &self,
+        &mut self,
         ctx: RpcContext,
         req: HealthCheckRequest,
         sink: UnarySink<HealthCheckResponse>,

--- a/tests/cases/metadata.rs
+++ b/tests/cases/metadata.rs
@@ -25,7 +25,7 @@ struct GreeterService {
 }
 
 impl Greeter for GreeterService {
-    fn say_hello(&self, ctx: RpcContext, mut req: HelloRequest, sink: UnarySink<HelloReply>) {
+    fn say_hello(&mut self, ctx: RpcContext, mut req: HelloRequest, sink: UnarySink<HelloReply>) {
         for (key, value) in ctx.request_headers() {
             self.tx.send((key.to_owned(), value.to_owned())).unwrap();
         }


### PR DESCRIPTION
Because service is `Send` + `Clone` and kept only one copy on every
completion queue, it's possible to accept a mut reference instead of an
immutable reference. Accepting a mut reference also allows users to
mutate internal states easily.

This is an incompatible change, should not be merged before #223.