### PR TITLE
WIP: Adding Server::socket_mutator method

### DIFF
--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -134,6 +134,7 @@ fn build_grpc(cc: &mut Build, library: &str) {
     }
 
     cc.include("grpc/include");
+    cc.include("grpc");
 }
 
 fn get_env(name: &str) -> Option<String> {

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -255,6 +255,8 @@ pub struct GrpcEvent {
 
 pub enum GrpcChannelArgs {}
 
+pub enum GrpcSocketMutator {}
+
 /// Connectivity state of a channel.
 ///
 /// Based on `grpc_connectivity_state`.
@@ -403,6 +405,18 @@ extern "C" {
     ) -> GrpcEvent;
     pub fn grpc_completion_queue_shutdown(cq: *mut GrpcCompletionQueue);
     pub fn grpc_completion_queue_destroy(cq: *mut GrpcCompletionQueue);
+
+    pub fn grpcwrap_socket_mutator_create(
+        callback: *const c_void, // Box<Fn(i32)->bool>
+        linkage: extern fn(* const c_void, i32)->bool
+    ) -> *const GrpcSocketMutator;
+
+    pub fn grpcwrap_channel_args_set_socket_mutator(
+        args: *mut GrpcChannelArgs,
+        index: size_t,
+        key: *const c_char,
+        mutator: *const GrpcSocketMutator
+    );
 
     pub fn grpcwrap_channel_args_create(num_args: size_t) -> *mut GrpcChannelArgs;
     pub fn grpcwrap_channel_args_set_string(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,19 +58,15 @@ mod log_util;
 mod metadata;
 mod server;
 
-pub use call::client::{
-    CallOption, ClientCStreamReceiver, ClientCStreamSender, ClientDuplexReceiver,
-    ClientDuplexSender, ClientSStreamReceiver, ClientUnaryReceiver, StreamingCallSink,
-};
-pub use call::server::{
-    ClientStreamingSink, ClientStreamingSinkResult, Deadline, DuplexSink, DuplexSinkFailure,
-    RequestStream, RpcContext, ServerStreamingSink, ServerStreamingSinkFailure, UnarySink,
-    UnarySinkResult,
-};
 pub use call::{Method, MethodType, RpcStatus, RpcStatusCode, WriteFlags};
-pub use channel::{
-    Channel, ChannelBuilder, CompressionAlgorithms, CompressionLevel, LbPolicy, OptTarget,
-};
+pub use call::client::{CallOption, ClientCStreamReceiver, ClientCStreamSender,
+                       ClientDuplexReceiver, ClientDuplexSender, ClientSStreamReceiver,
+                       ClientUnaryReceiver, StreamingCallSink};
+pub use call::server::{ClientStreamingSink, ClientStreamingSinkResult, Deadline, DuplexSink,
+                       DuplexSinkFailure, RequestStream, RpcContext, ServerStreamingSink,
+                       ServerStreamingSinkFailure, UnarySink, UnarySinkResult};
+pub use channel::{LbPolicy, OptTarget, Channel, ChannelArgsBuilder, ChannelBuilder,
+                  CompressionAlgorithms, CompressionLevel};
 pub use client::Client;
 #[cfg(feature = "protobuf-codec")]
 pub use codec::pb_codec::{de as pb_de, ser as pb_ser};


### PR DESCRIPTION
Currently, there is no way to utilize the grpc_socket_mutator struct+vtable from rust. This PR adds support for doing that from ServerBuilder, and in the process I ended up separating out ChannelBuilder's members that pertained to building ChannelArgs into their own builder. There's also some C++ code in grpc_wrap.cc that needed to be added to hook a callback in.

This PR provides an api where the user, upon using ServerBuilder, can simply pass a closure which is called with the fd from the grpc_socket_mutator vtable.

Please let me know thoughts on reworking this into something acceptable for merging. Thanks for the great library!