### PR TITLE
[Do not merge] Try reserving sized data in advance

### DIFF
--- a/src/call/client.rs
+++ b/src/call/client.rs
@@ -113,7 +113,7 @@ impl Call {
         mut opt: CallOption,
     ) -> Result<ClientUnaryReceiver<Resp>> {
         let call = channel.create_call(method, &opt)?;
-        let mut payload = vec![];
+        let mut payload = Vec::new();
         (method.req_ser())(req, &mut payload);
         let cq_f = check_run(BatchType::CheckRead, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_unary(
@@ -167,7 +167,7 @@ impl Call {
         mut opt: CallOption,
     ) -> Result<ClientSStreamReceiver<Resp>> {
         let call = channel.create_call(method, &opt)?;
-        let mut payload = vec![];
+        let mut payload = Vec::new();
         (method.req_ser())(req, &mut payload);
         let cq_f = check_run(BatchType::Finish, |ctx, tag| unsafe {
             grpc_sys::grpcwrap_call_start_server_streaming(

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -43,7 +43,7 @@ pub mod pb_codec {
     #[inline]
     pub fn ser<T: Message>(t: &T, buf: &mut Vec<u8>) {
         t.check_initialized().unwrap();
-        buf.reserve_exact(t.compute_size() as usize + 1);
+        buf.reserve_exact(t.compute_size() as usize);
         buf.with_coded_output_stream(|os|
             t.write_to_with_cached_sizes(os)).unwrap();
     }

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -42,6 +42,7 @@ pub mod pb_codec {
 
     #[inline]
     pub fn ser<T: Message>(t: &T, buf: &mut Vec<u8>) {
+        buf.reserve_exact(t.compute_size() as usize + 1);
         t.write_to_vec(buf).unwrap()
     }
 

--- a/src/codec.rs
+++ b/src/codec.rs
@@ -36,14 +36,16 @@ pub struct Marshaller<T> {
 
 #[cfg(feature = "protobuf-codec")]
 pub mod pb_codec {
-    use protobuf::{self, Message};
+    use protobuf::{self, Message, stream::WithCodedOutputStream};
 
     use error::Result;
 
     #[inline]
     pub fn ser<T: Message>(t: &T, buf: &mut Vec<u8>) {
+        t.check_initialized().unwrap();
         buf.reserve_exact(t.compute_size() as usize + 1);
-        t.write_to_vec(buf).unwrap()
+        buf.with_coded_output_stream(|os|
+            t.write_to_with_cached_sizes(os)).unwrap();
     }
 
     #[inline]


### PR DESCRIPTION
Signed-off-by: ice1000 <ice1000kotlin@foxmail.com>

This is just a test for trying to reserve a computed size of capacity for the `Vec`.
This can reduce possible unnecessary allocations and copies.

Created PR so we can discuss the benchmark, tests, etc.