### PR TITLE
Allow '.' characters in metadata keys

### DIFF
--- a/src/metadata.rs
+++ b/src/metadata.rs
@@ -31,7 +31,12 @@ fn normalize_key(key: &str, binary: bool) -> Result<Cow<str>> {
         if b >= b'A' && b <= b'Z' {
             is_upper_case = true;
             continue;
-        } else if b >= b'a' && b <= b'z' || b >= b'0' && b <= b'9' || b == b'_' || b == b'-' {
+        } else if b >= b'a' && b <= b'z'
+            || b >= b'0' && b <= b'9'
+            || b == b'_'
+            || b == b'-'
+            || b == b'.'
+        {
             continue;
         }
         return Err(Error::InvalidMetadata(format!("key {:?} is invalid", key)));
@@ -263,7 +268,7 @@ mod tests {
         assert!(builder.add_bytes("key", b"value").is_err());
         // Key should not be empty.
         assert!(builder.add_str("", "value").is_err());
-        // Key should follow the rule ^[a-z0-9_-]+$
+        // Key should follow the rule ^[a-z0-9_-.]+$
         assert!(builder.add_str(":key", "value").is_err());
         assert!(builder.add_str("key~", "value").is_err());
         assert!(builder.add_str("ke+y", "value").is_err());
@@ -275,6 +280,7 @@ mod tests {
         builder.add_str("key", "value").unwrap();
         builder.add_str("_", "value").unwrap();
         builder.add_str("-", "value").unwrap();
+        builder.add_str(".", "value").unwrap();
         builder.add_bytes("key-bin", b"value").unwrap();
     }
 


### PR DESCRIPTION
In the current state, grpc-rs does not allow '.' as a valid character in the key validation function, even though it is a valid character for keys in many other GRPC clients, notably Go, Ruby, and Java.

The most restrictive language I have seen regarding keys is within the official GPRC clients, this for [Java](https://grpc.io/grpc-java/javadoc/io/grpc/Metadata.Key.html) and [Go](https://godoc.org/google.golang.org/grpc/metadata#Pairs) -- it is in alignment to grpc-rs but also allows for '.' characters.

This is currently breaking the addition of a required security header (workload.spiffe.io=true) for the [SPIFFE standard](https://github.com/spiffe/spiffe/blob/master/standards/SPIFFE_Workload_Endpoint.md#3-transport) workload API with this client.