### PR TITLE
Optionally use openssl instead of boring ssl.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,3 +48,5 @@ script:
   - cargo build
   - cargo test --all
   - GRPCIO_SYS_USE_PKG_CONFIG=1 cargo test --all
+  - sudo apt-get update && sudo apt-get -y install libssl-dev
+  - cargo test --features "openssl" --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_script:
     fi
   - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
       brew update && brew install openssl;
+      export OPENSSL_ROOT_DIR=$(brew --prefix openssl);
     else
       sudo apt-get update && sudo apt-get -y install libssl-dev;
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,11 @@ before_script:
       export CC=clang;
       brew update && brew install autoconf libtool shtool;
     fi
+  - if [[ $TRAVIS_OS_NAME == "osx" ]]; then
+      brew update && brew install openssl;
+    else
+      sudo apt-get update && sudo apt-get -y install libssl-dev;
+    fi
   - if [[ ! -f "$GRPC_HEADER" ]] ; then
       (
         git clone -b v$GRPC_VERSION https://github.com/grpc/grpc &&
@@ -48,5 +53,4 @@ script:
   - cargo build
   - cargo test --all
   - GRPCIO_SYS_USE_PKG_CONFIG=1 cargo test --all
-  - sudo apt-get update && sudo apt-get -y install libssl-dev
   - cargo test --features "openssl" --all

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = ["proto", "benchmark", "compiler", "interop"]
 default = ["protobuf-codec", "secure"]
 protobuf-codec = ["protobuf"]
 secure = ["grpcio-sys/secure"]
+openssl = ["secure", "grpcio-sys/openssl"]
 
 [[example]]
 name = "route_guide_client"

--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -47,10 +47,12 @@ exclude = [
 
 [dependencies]
 libc = "0.2"
+# openssl = { version = "*", optional = true }
 
 [features]
 default = []
 secure = []
+openssl = ["secure"]
 
 [build-dependencies]
 cc = "1.0"

--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -47,7 +47,6 @@ exclude = [
 
 [dependencies]
 libc = "0.2"
-# openssl = { version = "*", optional = true }
 
 [features]
 default = []

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -87,6 +87,10 @@ fn build_grpc(cc: &mut Build, library: &str) {
         config.define("gRPC_BUILD_CSHARP_EXT", "false");
         // We don't need to build codegen target.
         config.define("gRPC_BUILD_CODEGEN", "false");
+        if cfg!(feature = "openssl") {
+            config.define("gRPC_SSL_PROVIDER", "package");
+            config.define("EMBED_OPENSSL", "false");
+        }
         config.build_target(library).uses_cxx11().build()
     };
 
@@ -133,8 +137,13 @@ fn build_grpc(cc: &mut Build, library: &str) {
     println!("cargo:rustc-link-lib=static={}", library);
 
     if cfg!(feature = "secure") {
-        println!("cargo:rustc-link-lib=static=ssl");
-        println!("cargo:rustc-link-lib=static=crypto");
+        if cfg!(feature = "openssl") {
+            println!("cargo:rustc-link-lib=ssl");
+            println!("cargo:rustc-link-lib=crypto");
+        } else {
+            println!("cargo:rustc-link-lib=static=ssl");
+            println!("cargo:rustc-link-lib=static=crypto");
+        }
     }
 
     cc.include("grpc/include");

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -90,6 +90,10 @@ fn build_grpc(cc: &mut Build, library: &str) {
         if cfg!(feature = "openssl") {
             config.define("gRPC_SSL_PROVIDER", "package");
             config.define("EMBED_OPENSSL", "false");
+            // Problem is: Ubuntu Trusty shipped with openssl 1.0.1f. Which doesn't
+            // support alpn. And Google's gRPC checks for support of ALPN in plane
+            // old Makefile, but not in CMake.
+            config.cxxflag("-DTSI_OPENSSL_ALPN_SUPPORT=0");
         }
         config.build_target(library).uses_cxx11().build()
     };


### PR DESCRIPTION
This prevent link/runtime failure when you have a crate which uses both
grpc-rs and openssl-rs.

Based on feedback from #186. Build against fresh master.