### PR TITLE
server: check fail eagerly

### DIFF
--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -478,6 +478,9 @@ macro_rules! impl_stream_sink {
             }
 
             fn poll_complete(&mut self) -> Poll<(), Error> {
+                if let Async::Ready(_) = self.call.as_mut().unwrap().call(|c| c.poll_finish())? {
+                    return Err(Error::RemoteStopped);
+                }
                 self.base.poll_complete()
             }
 

--- a/tests/cases/cancel.rs
+++ b/tests/cases/cancel.rs
@@ -11,13 +11,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use std::sync::mpsc as std_mpsc;
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::time::Duration;
-use std::sync::mpsc as std_mpsc;
 
-use futures::{future, stream as streams, Async, Future, Poll, Sink, Stream};
 use futures::sync::mpsc;
+use futures::{future, stream as streams, Async, Future, Poll, Sink, Stream};
 use grpcio::*;
 use grpcio_proto::example::route_guide::*;
 use grpcio_proto::example::route_guide_grpc::*;
@@ -68,11 +68,11 @@ impl RouteGuide for CancelService {
             thread::sleep(Duration::from_secs(5));
         });
 
-        let f = rx.map(|_| {
-            let f = Feature::new();
-            (f, WriteFlags::default())
-        })
-            .forward(sink.sink_map_err(|_| ()))
+        let f = rx
+            .map(|_| {
+                let f = Feature::new();
+                (f, WriteFlags::default())
+            }).forward(sink.sink_map_err(|_| ()))
             .map(|_| ())
             .map_err(|_| ())
             .then(move |_| {
@@ -265,7 +265,7 @@ fn test_early_exit() {
         let l = client.list_features(&rect).unwrap();
         let f = l.into_future();
         match f.wait() {
-            Ok((Some(_), _)) => {},
+            Ok((Some(_), _)) => {}
             Ok((None, _)) => panic!("should have result"),
             Err((e, _)) => panic!("unexpected error {:?}", e),
         };

--- a/tests/cases/cancel.rs
+++ b/tests/cases/cancel.rs
@@ -12,8 +12,12 @@
 // limitations under the License.
 
 use std::sync::{Arc, Mutex};
+use std::thread;
+use std::time::Duration;
+use std::sync::mpsc as std_mpsc;
 
 use futures::{future, stream as streams, Async, Future, Poll, Sink, Stream};
+use futures::sync::mpsc;
 use grpcio::*;
 use grpcio_proto::example::route_guide::*;
 use grpcio_proto::example::route_guide_grpc::*;
@@ -27,6 +31,7 @@ type RouteChatHandler =
 
 #[derive(Clone)]
 struct CancelService {
+    list_feature_listener: Arc<Mutex<Option<std_mpsc::Sender<()>>>>,
     record_route_handler: RecordRouteHandler,
     route_chat_handler: RouteChatHandler,
 }
@@ -34,6 +39,7 @@ struct CancelService {
 impl CancelService {
     fn new() -> CancelService {
         CancelService {
+            list_feature_listener: Arc::default(),
             record_route_handler: Arc::new(Mutex::new(None)),
             route_chat_handler: Arc::new(Mutex::new(None)),
         }
@@ -46,9 +52,35 @@ impl RouteGuide for CancelService {
         drop(sink);
     }
 
-    fn list_features(&mut self, _: RpcContext, _: Rectangle, sink: ServerStreamingSink<Feature>) {
+    fn list_features(&mut self, ctx: RpcContext, _: Rectangle, sink: ServerStreamingSink<Feature>) {
         // Drop the sink, client should receive Cancelled.
-        drop(sink);
+        let listener = match self.list_feature_listener.lock().unwrap().take() {
+            Some(l) => l,
+            None => {
+                drop(sink);
+                return;
+            }
+        };
+        let (tx, rx) = mpsc::unbounded();
+
+        thread::spawn(move || loop {
+            tx.unbounded_send(1).unwrap();
+            thread::sleep(Duration::from_secs(5));
+        });
+
+        let f = rx.map(|_| {
+            let f = Feature::new();
+            (f, WriteFlags::default())
+        })
+            .forward(sink.sink_map_err(|_| ()))
+            .map(|_| ())
+            .map_err(|_| ())
+            .then(move |_| {
+                let _ = listener.send(());
+                Ok(())
+            });
+
+        ctx.spawn(f);
     }
 
     fn record_route(
@@ -221,4 +253,22 @@ fn test_server_cancel_on_dropping() {
         Some(Box::new(|stream, sink| drop_stream(stream, sink)));
     let (_tx, rx) = client.route_chat().unwrap();
     check_cancel(rx);
+}
+
+#[test]
+fn test_early_exit() {
+    let (service, client, _server) = prepare_suite();
+    let (tx, rx) = std_mpsc::channel();
+    *service.list_feature_listener.lock().unwrap() = Some(tx);
+    let rect = Rectangle::new();
+    {
+        let l = client.list_features(&rect).unwrap();
+        let f = l.into_future();
+        match f.wait() {
+            Ok((Some(_), _)) => {},
+            Ok((None, _)) => panic!("should have result"),
+            Err((e, _)) => panic!("unexpected error {:?}", e),
+        };
+    }
+    rx.recv_timeout(Duration::from_secs(1)).unwrap();
 }

--- a/tests/cases/cancel.rs
+++ b/tests/cases/cancel.rs
@@ -260,15 +260,15 @@ fn test_early_exit() {
     let (service, client, _server) = prepare_suite();
     let (tx, rx) = std_mpsc::channel();
     *service.list_feature_listener.lock().unwrap() = Some(tx);
+
     let rect = Rectangle::new();
-    {
-        let l = client.list_features(&rect).unwrap();
-        let f = l.into_future();
-        match f.wait() {
-            Ok((Some(_), _)) => {}
-            Ok((None, _)) => panic!("should have result"),
-            Err((e, _)) => panic!("unexpected error {:?}", e),
-        };
-    }
+    let l = client.list_features(&rect).unwrap();
+    let f = l.into_future();
+    match f.wait() {
+        Ok((Some(_), _)) => {}
+        Ok((None, _)) => panic!("should have result"),
+        Err((e, _)) => panic!("unexpected error {:?}", e),
+    };
+
     rx.recv_timeout(Duration::from_secs(1)).unwrap();
 }


### PR DESCRIPTION
It's possible that server stream is flushing messages when the connection is closed. So we need to check if the call is still valid inside `poll_complete`.

Close #175.