### PR TITLE
Make the generated *Client classes clonable; This requires making grpcio::Client clonable too

### DIFF
--- a/compiler/src/codegen.rs
+++ b/compiler/src/codegen.rs
@@ -440,6 +440,7 @@ impl<'a> ServiceGen<'a> {
     }
 
     fn write_client(&self, w: &mut CodeWriter) {
+        w.write_line("#[derive(Clone)]");
         w.pub_struct(&self.client_name(), |w| {
             w.field_decl("client", "::grpcio::Client");
         });

--- a/src/client.rs
+++ b/src/client.rs
@@ -31,6 +31,12 @@ pub struct Client {
     kicker: Kicker,
 }
 
+impl Clone for Client {
+    fn clone(&self) -> Self {
+        Client::new(self.channel.clone())
+    }
+}
+
 impl Client {
     /// Initialize a new [`Client`].
     pub fn new(channel: Channel) -> Client {


### PR DESCRIPTION
This is especially useful for services connecting to other services as it allows to just make the client a member of the struct which implements the *Service trait while using `#[derive(Clone)]`.

Tests:
`cargo test` at the root folder and built one of my own projects with this. Do you have some other tests you would like me to run?