### PR TITLE
Bump protobuf and protobuf-codegen from ~2.1 -> ~2.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 grpcio-sys = { path = "grpc-sys", version = "0.4.0" }
 libc = "0.2"
 futures = "^0.1.15"
-protobuf = { version = "~2.1", optional = true }
+protobuf = { version = "~2.2", optional = true }
 log = "0.4"
 
 [workspace]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -11,8 +11,8 @@ description = "gRPC compiler for grpcio"
 categories = ["network-programming"]
 
 [dependencies]
-protobuf = "~2.1"
-protobuf-codegen = "~2.1"
+protobuf = "~2.2"
+protobuf-codegen = "~2.2"
 
 [[bin]]
 name = "grpc_rust_plugin"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 grpcio = { path = ".." }
 grpcio-sys = { path = "../grpc-sys" }
 grpcio-proto = { path = "../proto" }
-protobuf = "~2.1"
+protobuf = "~2.2"
 futures = "0.1"
 log = "0.3"
 clap = "2.23"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -12,11 +12,11 @@ categories = ["network-programming"]
 build = "build.rs"
 
 [dependencies]
-protobuf = "~2.1"
+protobuf = "~2.2"
 futures = "0.1"
 grpcio = { path = "..", version = "0.4.0" }
 
 [build-dependencies]
-protobuf = "~2.1"
-protobuf-codegen = "~2.1"
+protobuf = "~2.2"
+protobuf-codegen = "~2.2"
 grpcio-compiler = { path = "../compiler", version = "0.4.0" }


### PR DESCRIPTION
Changelog: https://github.com/stepancheg/rust-protobuf/blob/master/CHANGELOG.md#221---2018-12-25