### PR TITLE
Cargo: remove tilde requirements of protobuf

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ all-features = true
 grpcio-sys = { path = "grpc-sys", version = "0.4.0" }
 libc = "0.2"
 futures = "^0.1.15"
-protobuf = { version = "~2.2", optional = true }
+protobuf = { version = "2.0", optional = true }
 log = "0.4"
 
 [workspace]

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -11,8 +11,8 @@ description = "gRPC compiler for grpcio"
 categories = ["network-programming"]
 
 [dependencies]
-protobuf = "~2.2"
-protobuf-codegen = "~2.2"
+protobuf = "2.0"
+protobuf-codegen = "2.0"
 
 [[bin]]
 name = "grpc_rust_plugin"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 grpcio = { path = ".." }
 grpcio-sys = { path = "../grpc-sys" }
 grpcio-proto = { path = "../proto" }
-protobuf = "~2.2"
+protobuf = "2.0"
 futures = "0.1"
 log = "0.3"
 clap = "2.23"


### PR DESCRIPTION
So users can select protobuf version from "2.0.0" to "3.0.0". 

Cc #272 