### PR TITLE
make it possible to cross-compile for iOS and Android targets

### DIFF
--- a/cross_compile.md
+++ b/cross_compile.md
@@ -47,20 +47,6 @@ yum install mingw64-openssl-static mingw64-zlib-static mingw64-winpthreads-stati
     let mut zlib = "zlibstaticd";
 ```
 
-## Fix try_run
-
-```
-# grpc-rs/grpc-sys/grpc/third_party/benchmark/cmake/CXXFeatureCheck.cmake
-# add these code to fix try_run
-SET( RUN_HAVE_STD_REGEX
-     0
-     CACHE STRING "Result from TRY_RUN" FORCE)
-
-SET( RUN_HAVE_STEADY_CLOCK
-     0
-     CACHE STRING "Result from TRY_RUN" FORCE)
-```
-
 ## Fix WIN32 API
 
 ```

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -84,18 +84,40 @@ fn build_grpc(cc: &mut Build, library: &str) {
 
         // Cross-compile support for iOS
         match env::var("TARGET").unwrap_or("".to_owned()).as_str() {
-            "aarch64-apple-ios" => { config.define("CMAKE_OSX_SYSROOT", "iphoneos").define("CMAKE_OSX_ARCHITECTURES", "arm64"); }
-            "armv7-apple-ios" => { config.define("CMAKE_OSX_SYSROOT", "iphoneos").define("CMAKE_OSX_ARCHITECTURES", "armv7"); }
-            "armv7s-apple-ios" => { config.define("CMAKE_OSX_SYSROOT", "iphoneos").define("CMAKE_OSX_ARCHITECTURES", "armv7s"); }
-            "i386-apple-ios" => { config.define("CMAKE_OSX_SYSROOT", "iphonesimulator").define("CMAKE_OSX_ARCHITECTURES", "i386"); }
-            "x86_64-apple-ios" => { config.define("CMAKE_OSX_SYSROOT", "iphonesimulator").define("CMAKE_OSX_ARCHITECTURES", "x86_64"); }
-            _ => {},
+            "aarch64-apple-ios" => {
+                config
+                    .define("CMAKE_OSX_SYSROOT", "iphoneos")
+                    .define("CMAKE_OSX_ARCHITECTURES", "arm64");
+            }
+            "armv7-apple-ios" => {
+                config
+                    .define("CMAKE_OSX_SYSROOT", "iphoneos")
+                    .define("CMAKE_OSX_ARCHITECTURES", "armv7");
+            }
+            "armv7s-apple-ios" => {
+                config
+                    .define("CMAKE_OSX_SYSROOT", "iphoneos")
+                    .define("CMAKE_OSX_ARCHITECTURES", "armv7s");
+            }
+            "i386-apple-ios" => {
+                config
+                    .define("CMAKE_OSX_SYSROOT", "iphonesimulator")
+                    .define("CMAKE_OSX_ARCHITECTURES", "i386");
+            }
+            "x86_64-apple-ios" => {
+                config
+                    .define("CMAKE_OSX_SYSROOT", "iphonesimulator")
+                    .define("CMAKE_OSX_ARCHITECTURES", "x86_64");
+            }
+            _ => {}
         };
 
         // Allow overriding of the target passed to cmake
         // (needed for Android crosscompile)
         match env::var("CMAKE_TARGET_OVERRIDE") {
-            Ok(val) => { config.target(&val); }
+            Ok(val) => {
+                config.target(&val);
+            }
             Err(_) => {}
         };
 


### PR DESCRIPTION
Heya,

This PR makes it possible to cross-compile this crate to Android and iOS, both simulator and real hardware. I have tested it and the resulting code works flawlessly (tested on iPhone 7, iPhone XS, Nexus6P, iPhone simulator and Android simulator).

Building for iOS is as simple as cargo build --target i386-apple-ios/x86_64-apple-ios/armv7-apple-ios armv7s-apple-ios/aarch64-apple-ios

Android is more complicated and requires a bunch of environment variables. For example, on my machine, this is what I used for aarch64-linux-android:
```
	PATH=$(PATH):$(NDK_HOME)/toolchains/llvm/prebuilt/darwin-x86_64/bin \
	LDFLAGS=-stdlib=libstdc++ \
	CFLAGS="-Wno-unused-command-line-argument -DMDB_USE_ROBUST=0" \
	CXXFLAGS="-Wno-unused-command-line-argument" \
	CXX=aarch64-linux-android26-clang++ \
	CC=aarch64-linux-android26-clang \
	ISYSROOT=$(NDK_HOME)/toolchains/llvm/prebuilt/darwin-x86_64/sysroot \
	ISYSTEM=$(NDK_HOME)/toolchains/llvm/prebuilt/darwin-x86_64/sysroot/usr/include/aarch64-linux-android \
	CMAKE_TARGET_OVERRIDE=aarch64-linux-android26 \
	cargo build --target aarch64-linux-android --release
```
