### PR TITLE
Fix Environment thread leak.

### DIFF
--- a/src/env.rs
+++ b/src/env.rs
@@ -140,6 +140,10 @@ impl Drop for Environment {
             // it's safe to shutdown more than once.
             cq.shutdown()
         }
+
+        for handle in self._handles.drain(..) {
+            handle.join().unwrap();
+        }
     }
 }
 


### PR DESCRIPTION
`EnvBuilder::build` spawns threads, but those threads are never joined.  This becomes a problem, say, when you fuzz an application that calls `EnvBuilder::build`.  More specifically, in long runs of `cargo-fuzz`, AddressSanitizer will complain that too many threads have been created.  This pull request has the `Environment` join with the threads in its `drop` method.