### PR TITLE
grpcio-sys: fix openssl vendor build

### DIFF
--- a/grpc-sys/Cargo.toml
+++ b/grpc-sys/Cargo.toml
@@ -48,16 +48,16 @@ exclude = [
 
 [dependencies]
 libc = "0.2"
+openssl-sys = { version = "0.9", optional = true, features = ["vendored"] }
 
 [features]
 default = []
 secure = []
 openssl = ["secure"]
-openssl-vendored = ["openssl", "openssl-src"]
+openssl-vendored = ["openssl", "openssl-sys"]
 no-omit-frame-pointer = []
 
 [build-dependencies]
 cc = "1.0"
 cmake = "0.1.27"
 pkg-config = "0.3"
-openssl-src = { version = "111.0.1", optional = true }

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -69,6 +69,7 @@ fn build_grpc(cc: &mut Build, library: &str) {
 
     let dst = {
         let mut config = Config::new("grpc");
+
         if !cfg!(feature = "secure") {
             // boringssl's configuration is still included, but targets
             // will never be built, hence specify a fake go to get rid of
@@ -203,14 +204,21 @@ fn build_grpc(cc: &mut Build, library: &str) {
 
 #[cfg(feature = "openssl-vendored")]
 fn setup_openssl(config: &mut Config) {
-    let artifacts = openssl_src::Build::new().build();
-    let include_dir = artifacts.include_dir().to_path_buf();
-    config.define("OPENSSL_INCLUDE_DIR", include_dir.as_os_str());
-    println!(
-        "cargo:rustc-link-search=native={}",
-        artifacts.lib_dir().to_path_buf().to_string_lossy()
-    );
-    println!("cargo:include={}", include_dir.to_string_lossy());
+    // openssl-sys uses openssl-src to build the library. openssl-src uses
+    // configure/make to build the library which makes it hard to detect
+    // what's the actual path of the library. Here assumes the directory
+    // structure as follow (which is the behavior of 0.9.47):
+    // install_dir/
+    //     include/
+    //     lib/
+    // Remove the hack when sfackler/rust-openssl#1117 is resolved.
+    config.register_dep("openssl");
+    if env::var("DEP_OPENSSL_ROOT").is_err() {
+        let include_str = env::var("DEP_OPENSSL_INCLUDE").unwrap();
+        let include_dir = Path::new(&include_str);
+        let root_dir = format!("{}", include_dir.parent().unwrap().display());
+        env::set_var("DEP_OPENSSL_ROOT", &root_dir);
+    }
 }
 
 #[cfg(not(feature = "openssl-vendored"))]

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -69,7 +69,6 @@ fn build_grpc(cc: &mut Build, library: &str) {
 
     let dst = {
         let mut config = Config::new("grpc");
-
         if !cfg!(feature = "secure") {
             // boringssl's configuration is still included, but targets
             // will never be built, hence specify a fake go to get rid of


### PR DESCRIPTION
Vendor build implemented in #262 is not configured properly, compiler
will use the system library during compilation. This PR fixes the
problem by configuring package searching path for openssl.