### PR TITLE
grpcio-sys: fix warnings in nightly

### DIFF
--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -37,7 +37,7 @@ use crate::bench;
 use crate::error::Error;
 use crate::util::{self, CpuRecorder, Histogram};
 
-type BoxFuture<T, E> = Box<Future<Item = T, Error = E> + Send>;
+type BoxFuture<T, E> = Box<dyn Future<Item = T, Error = E> + Send>;
 
 fn gen_req(cfg: &ClientConfig) -> SimpleRequest {
     let mut req = SimpleRequest::new_();

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -610,9 +610,8 @@ extern "C" {
     pub fn grpcwrap_batch_context_recv_status_on_client_trailing_metadata(
         ctx: *mut GrpcBatchContext,
     ) -> *const GrpcMetadataArray;
-    pub fn grpcwrap_batch_context_recv_close_on_server_cancelled(
-        ctx: *mut GrpcBatchContext,
-    ) -> i32;
+    pub fn grpcwrap_batch_context_recv_close_on_server_cancelled(ctx: *mut GrpcBatchContext)
+        -> i32;
 
     pub fn grpcwrap_call_kick_completion_queue(
         call: *mut GrpcCall,

--- a/grpc-sys/src/lib.rs
+++ b/grpc-sys/src/lib.rs
@@ -15,7 +15,7 @@
 #![allow(renamed_and_removed_lints)]
 // remove this after Rust's tool_lints is stabilized
 
-use libc::{c_char, c_int, c_uint, c_void, int32_t, int64_t, size_t, uint32_t, uint8_t};
+use libc::{c_char, c_int, c_uint, c_void, size_t};
 use std::time::Duration;
 use std::{mem, slice};
 
@@ -46,8 +46,8 @@ pub enum GprClockType {
 #[derive(Clone, Copy)]
 #[repr(C)]
 pub struct GprTimespec {
-    pub tv_sec: int64_t,
-    pub tv_nsec: int32_t,
+    pub tv_sec: i64,
+    pub tv_nsec: i32,
 
     /// Against which clock was this time measured? (or [`GprClockType::Timespan`] if this is a
     /// relative time measure)
@@ -63,8 +63,8 @@ impl GprTimespec {
 impl From<Duration> for GprTimespec {
     fn from(dur: Duration) -> GprTimespec {
         GprTimespec {
-            tv_sec: dur.as_secs() as int64_t,
-            tv_nsec: dur.subsec_nanos() as int32_t,
+            tv_sec: dur.as_secs() as i64,
+            tv_nsec: dur.subsec_nanos() as i32,
             clock_type: GprClockType::Timespan,
         }
     }
@@ -352,19 +352,19 @@ pub struct GrpcMetadataArray {
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct GrpcSliceRefCounted {
-    bytes: *mut uint8_t,
+    bytes: *mut u8,
     length: size_t,
 }
 
 #[repr(C)]
 #[derive(Clone, Copy)]
 pub struct GrpcSliceInlined {
-    length: uint8_t,
+    length: u8,
     // TODO: use size_of when it becomes a const function.
     #[cfg(target_pointer_width = "64")]
-    bytes: [uint8_t; 23],
+    bytes: [u8; 23],
     #[cfg(target_pointer_width = "32")]
-    bytes: [uint8_t; 11],
+    bytes: [u8; 11],
 }
 
 #[repr(C)]
@@ -463,12 +463,12 @@ impl GrpcByteBufferReader {
     }
 }
 
-pub const GRPC_INITIAL_METADATA_IDEMPOTENT_REQUEST: uint32_t = 0x0000_0010;
-pub const GRPC_INITIAL_METADATA_WAIT_FOR_READY: uint32_t = 0x0000_0020;
-pub const GRPC_INITIAL_METADATA_CACHEABLE_REQUEST: uint32_t = 0x0000_0040;
+pub const GRPC_INITIAL_METADATA_IDEMPOTENT_REQUEST: u32 = 0x0000_0010;
+pub const GRPC_INITIAL_METADATA_WAIT_FOR_READY: u32 = 0x0000_0020;
+pub const GRPC_INITIAL_METADATA_CACHEABLE_REQUEST: u32 = 0x0000_0040;
 
-pub const GRPC_WRITE_BUFFER_HINT: uint32_t = 0x0000_0001;
-pub const GRPC_WRITE_NO_COMPRESS: uint32_t = 0x0000_0002;
+pub const GRPC_WRITE_BUFFER_HINT: u32 = 0x0000_0001;
+pub const GRPC_WRITE_NO_COMPRESS: u32 = 0x0000_0002;
 
 pub enum GrpcMetadata {}
 pub enum GrpcCallDetails {}
@@ -552,7 +552,7 @@ extern "C" {
     pub fn grpcwrap_channel_create_call(
         channel: *mut GrpcChannel,
         parent_call: *mut GrpcCall,
-        propagation_mask: uint32_t,
+        propagation_mask: u32,
         cq: *mut GrpcCompletionQueue,
         method: *const c_char,
         method_len: size_t,
@@ -612,7 +612,7 @@ extern "C" {
     ) -> *const GrpcMetadataArray;
     pub fn grpcwrap_batch_context_recv_close_on_server_cancelled(
         ctx: *mut GrpcBatchContext,
-    ) -> int32_t;
+    ) -> i32;
 
     pub fn grpcwrap_call_kick_completion_queue(
         call: *mut GrpcCall,
@@ -624,16 +624,16 @@ extern "C" {
         ctx: *mut GrpcBatchContext,
         send_buffer: *const c_char,
         send_buffer_len: size_t,
-        write_flags: uint32_t,
+        write_flags: u32,
         initial_metadata: *mut GrpcMetadataArray,
-        initial_metadata_flags: uint32_t,
+        initial_metadata_flags: u32,
         tag: *mut c_void,
     ) -> GrpcCallStatus;
     pub fn grpcwrap_call_start_client_streaming(
         call: *mut GrpcCall,
         ctx: *mut GrpcBatchContext,
         initial_metadata: *mut GrpcMetadataArray,
-        initial_metadata_flags: uint32_t,
+        initial_metadata_flags: u32,
         tag: *mut c_void,
     ) -> GrpcCallStatus;
     pub fn grpcwrap_call_start_server_streaming(
@@ -641,16 +641,16 @@ extern "C" {
         ctx: *mut GrpcBatchContext,
         send_buffer: *const c_char,
         send_buffer_len: size_t,
-        write_flags: uint32_t,
+        write_flags: u32,
         initial_metadata: *mut GrpcMetadataArray,
-        initial_metadata_flags: uint32_t,
+        initial_metadata_flags: u32,
         tag: *mut c_void,
     ) -> GrpcCallStatus;
     pub fn grpcwrap_call_start_duplex_streaming(
         call: *mut GrpcCall,
         ctx: *mut GrpcBatchContext,
         initial_metadata: *mut GrpcMetadataArray,
-        initial_metadata_flags: uint32_t,
+        initial_metadata_flags: u32,
         tag: *mut c_void,
     ) -> GrpcCallStatus;
     pub fn grpcwrap_call_recv_initial_metadata(
@@ -663,8 +663,8 @@ extern "C" {
         ctx: *mut GrpcBatchContext,
         send_buffer: *const c_char,
         send_buffer_len: size_t,
-        write_flags: uint32_t,
-        send_empty_initial_metadata: uint32_t,
+        write_flags: u32,
+        send_empty_initial_metadata: u32,
         tag: *mut c_void,
     ) -> GrpcCallStatus;
     pub fn grpcwrap_call_send_close_from_client(
@@ -678,10 +678,10 @@ extern "C" {
         status_details: *const c_char,
         status_details_len: size_t,
         trailing_metadata: *mut GrpcMetadataArray,
-        send_empty_metadata: int32_t,
+        send_empty_metadata: i32,
         optional_send_buffer: *const c_char,
         buffer_len: size_t,
-        write_flags: uint32_t,
+        write_flags: u32,
         tag: *mut c_void,
     ) -> GrpcCallStatus;
     pub fn grpcwrap_call_recv_message(
@@ -717,7 +717,7 @@ extern "C" {
         method: *const c_char,
         host: *const c_char,
         payload_handling: GrpcServerRegisterMethodPayloadHandling,
-        flags: uint32_t,
+        flags: u32,
     ) -> *mut c_void;
     pub fn grpc_server_create(
         args: *const GrpcChannelArgs,

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -19,10 +19,11 @@ bytes = "0.4"
 prost = "0.5"
 prost-derive = "0.5"
 protobuf = "~2.2"
+lazy_static = "1.3"
 
 [build-dependencies]
 grpcio-compiler = { path = "../compiler" }
-protobuf-build = "0.2"
+protobuf-build = "0.6"
 prost = "0.5"
 prost-types = "0.5"
 protobuf = "~2.2"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = "1.3"
 
 [build-dependencies]
 grpcio-compiler = { path = "../compiler" }
-protobuf-build = "0.6.2"
+protobuf-build = "0.6"
 prost = "0.5"
 prost-types = "0.5"
 protobuf = "~2.2"

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -23,7 +23,7 @@ lazy_static = "1.3"
 
 [build-dependencies]
 grpcio-compiler = { path = "../compiler" }
-protobuf-build = "0.6"
+protobuf-build = "0.6.2"
 prost = "0.5"
 prost-types = "0.5"
 protobuf = "~2.2"

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -92,6 +92,7 @@ fn desc_to_module_prost(descriptor: &Path) {
             .map(|m| format!("{}/{}.rs", env::var("OUT_DIR").unwrap(), m))
             .collect::<Vec<_>>(),
         &env::var("OUT_DIR").unwrap(),
+        protobuf_build::GenOpt::all(),
     );
 }
 

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -11,8 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#[allow(dead_code)]
-#[allow(clippy::all)]
+#[allow(clippy::large_enum_variant)]
 pub mod testing {
     include!(concat!(env!("OUT_DIR"), "/grpc.testing.rs"));
     include!(concat!(env!("OUT_DIR"), "/wrapper_grpc.testing.rs"));
@@ -114,7 +113,6 @@ pub mod testing {
     }
 }
 
-#[allow(dead_code)]
 pub mod example {
     pub mod helloworld {
         include!(concat!(env!("OUT_DIR"), "/helloworld.rs"));
@@ -126,7 +124,6 @@ pub mod example {
     }
 }
 
-#[allow(dead_code)]
 pub mod health {
     pub mod v1 {
         pub mod health {

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -13,6 +13,7 @@
 
 #[allow(dead_code)]
 #[allow(clippy::all)]
+#[allow(bare_trait_objects)]
 pub mod testing {
     include!(concat!(env!("OUT_DIR"), "/grpc.testing.rs"));
     include!(concat!(env!("OUT_DIR"), "/wrapper_grpc.testing.rs"));
@@ -115,6 +116,7 @@ pub mod testing {
 }
 
 #[allow(dead_code)]
+#[allow(bare_trait_objects)]
 pub mod example {
     pub mod helloworld {
         include!(concat!(env!("OUT_DIR"), "/helloworld.rs"));
@@ -127,6 +129,7 @@ pub mod example {
 }
 
 #[allow(dead_code)]
+#[allow(bare_trait_objects)]
 pub mod health {
     pub mod v1 {
         pub mod health {

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -13,7 +13,6 @@
 
 #[allow(dead_code)]
 #[allow(clippy::all)]
-#[allow(bare_trait_objects)]
 pub mod testing {
     include!(concat!(env!("OUT_DIR"), "/grpc.testing.rs"));
     include!(concat!(env!("OUT_DIR"), "/wrapper_grpc.testing.rs"));
@@ -116,7 +115,6 @@ pub mod testing {
 }
 
 #[allow(dead_code)]
-#[allow(bare_trait_objects)]
 pub mod example {
     pub mod helloworld {
         include!(concat!(env!("OUT_DIR"), "/helloworld.rs"));
@@ -129,7 +127,6 @@ pub mod example {
 }
 
 #[allow(dead_code)]
-#[allow(bare_trait_objects)]
 pub mod health {
     pub mod v1 {
         pub mod health {


### PR DESCRIPTION
1. error: trait objects without an explicit `dyn` are deprecated
2. `Box<trait>` to `Box<dyb trait>`
3. libc has deprecated several types, which are used in grpcio.