### PR TITLE
Use feature flags for Prost/protobuf in proto and compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,7 +78,7 @@ script:
   - if [[ $TRAVIS_RUST_VERSION == "stable" ]]; then rustup component add clippy && cargo clippy --all --all-features -- -D clippy::all; fi
   - cargo build --no-default-features
   - cargo build --no-default-features --features protobuf-codec
-  - cargo build --features prost-codec
+  - cargo build --no-default-features --features prost-codec
   - cargo build
   - cargo test --all
   - GRPCIO_SYS_USE_PKG_CONFIG=1 cargo test --all

--- a/.travis.yml
+++ b/.travis.yml
@@ -75,7 +75,7 @@ before_script:
 script:
   - rustup component add rustfmt && cargo fmt --all -- --check
   - if [[ $TRAVIS_OS_NAME == "linux" ]]; then scripts/lint-grpc-sys.sh && git diff-index --quiet HEAD; fi
-  - if [[ $TRAVIS_RUST_VERSION == "stable" ]]; then rustup component add clippy && cargo clippy --all --all-features -- -D clippy::all; fi
+  - if [[ $TRAVIS_RUST_VERSION == "stable" ]]; then rustup component add clippy && cargo clippy --all -- -D clippy::all && cargo clippy --all --no-default-features --features prost-codec -- -D clippy::all; fi
   - cargo build --no-default-features
   - cargo build --no-default-features --features protobuf-codec
   - cargo build --no-default-features --features prost-codec

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ path = "examples/hello_world/server.rs"
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
-grpcio-proto = { path = "proto", version = "0.5.0-alpha" }
+grpcio-proto = { path = "proto", features = ["prost-codec"], default-features = false }
 rand = "0.4"
 slog = "2.0"
 slog-async = "2.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,7 +57,7 @@ path = "examples/hello_world/server.rs"
 serde_json = "1.0"
 serde = "1.0"
 serde_derive = "1.0"
-grpcio-proto = { path = "proto", features = ["prost-codec"], default-features = false }
+grpcio-proto = { path = "proto", default-features = false }
 rand = "0.4"
 slog = "2.0"
 slog-async = "2.1"

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -11,7 +11,7 @@ prost-codec = ["grpcio/prost-codec", "grpcio-proto/prost-codec"]
 
 [dependencies]
 grpcio = { path = ".." }
-grpcio-proto = { path = "../proto" }
+grpcio-proto = { path = "../proto", default-features = false }
 futures = "0.1"
 libc = "0.2"
 grpcio-sys = { path = "../grpc-sys" }

--- a/benchmark/Cargo.toml
+++ b/benchmark/Cargo.toml
@@ -6,8 +6,8 @@ publish = false
 
 [features]
 default = ["protobuf-codec"]
-protobuf-codec = ["grpcio/protobuf-codec"]
-prost-codec = ["grpcio/prost-codec"]
+protobuf-codec = ["grpcio/protobuf-codec", "grpcio-proto/protobuf-codec"]
+prost-codec = ["grpcio/prost-codec", "grpcio-proto/prost-codec"]
 
 [dependencies]
 grpcio = { path = ".." }

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -29,7 +29,7 @@ use grpc_proto::util;
 
 fn gen_resp(req: &SimpleRequest) -> SimpleResponse {
     let payload = util::new_payload(req.get_response_size() as usize);
-    let mut resp = SimpleResponse::new_();
+    let mut resp = SimpleResponse::default();
     resp.set_payload(payload);
     resp
 }

--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -23,8 +23,8 @@ use grpc::{
     RpcContext, RpcStatus, RpcStatusCode, ServerStreamingSink, ServiceBuilder, UnarySink,
     WriteFlags,
 };
-use grpc_proto::testing::BenchmarkService;
-use grpc_proto::testing::{SimpleRequest, SimpleResponse};
+use grpc_proto::testing::messages::{SimpleRequest, SimpleResponse};
+use grpc_proto::testing::services_grpc::BenchmarkService;
 use grpc_proto::util;
 
 fn gen_resp(req: &SimpleRequest) -> SimpleResponse {

--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -23,10 +23,10 @@ use futures::{future, Async, Future, Sink, Stream};
 use grpc::{
     CallOption, Channel, ChannelBuilder, Client as GrpcClient, EnvBuilder, Environment, WriteFlags,
 };
-use grpc_proto::testing::BenchmarkServiceClient;
-use grpc_proto::testing::ClientStats;
-use grpc_proto::testing::SimpleRequest;
-use grpc_proto::testing::{ClientConfig, ClientType, RpcType};
+use grpc_proto::testing::control::{ClientConfig, ClientType, RpcType};
+use grpc_proto::testing::messages::SimpleRequest;
+use grpc_proto::testing::services_grpc::BenchmarkServiceClient;
+use grpc_proto::testing::stats::ClientStats;
 use grpc_proto::util as proto_util;
 use rand::distributions::Exp;
 use rand::distributions::Sample;
@@ -318,20 +318,20 @@ fn execute<B: Backoff + Send + 'static>(
     cfg: &ClientConfig,
 ) {
     match client_type {
-        ClientType::SyncClient => {
+        ClientType::SYNC_CLIENT => {
             if cfg.get_payload_config().has_bytebuf_params() {
                 panic!("only async_client is supported for generic service.");
             }
             RequestExecutor::new(ctx, ch, cfg).execute_unary()
         }
-        ClientType::AsyncClient => match cfg.get_rpc_type() {
-            RpcType::Unary => {
+        ClientType::ASYNC_CLIENT => match cfg.get_rpc_type() {
+            RpcType::UNARY => {
                 if cfg.get_payload_config().has_bytebuf_params() {
                     panic!("only streaming is supported for generic service.");
                 }
                 RequestExecutor::new(ctx, ch, cfg).execute_unary_async()
             }
-            RpcType::Streaming => {
+            RpcType::STREAMING => {
                 if cfg.get_payload_config().has_bytebuf_params() {
                     GenericExecutor::new(ctx, ch, cfg).execute_stream()
                 } else {

--- a/benchmark/src/client.rs
+++ b/benchmark/src/client.rs
@@ -40,7 +40,7 @@ use crate::util::{self, CpuRecorder, Histogram};
 type BoxFuture<T, E> = Box<dyn Future<Item = T, Error = E> + Send>;
 
 fn gen_req(cfg: &ClientConfig) -> SimpleRequest {
-    let mut req = SimpleRequest::new_();
+    let mut req = SimpleRequest::default();
     let payload_config = cfg.get_payload_config();
     let simple_params = payload_config.get_simple_params();
     req.set_payload(proto_util::new_payload(
@@ -438,7 +438,7 @@ impl Client {
     }
 
     pub fn get_stats(&mut self, reset: bool) -> ClientStats {
-        let mut stats = ClientStats::new_();
+        let mut stats = ClientStats::default();
 
         let sample = self.recorder.cpu_time(reset);
         stats.set_time_elapsed(sample.real_time);

--- a/benchmark/src/main.rs
+++ b/benchmark/src/main.rs
@@ -28,7 +28,7 @@ use clap::{App, Arg};
 use futures::sync::oneshot;
 use futures::Future;
 use grpc::{Environment, ServerBuilder};
-use grpc_proto::testing::create_worker_service;
+use grpc_proto::testing::services_grpc::create_worker_service;
 use rand::Rng;
 
 const LOG_FILE: &str = "GRPCIO_BENCHMARK_LOG_FILE";

--- a/benchmark/src/server.rs
+++ b/benchmark/src/server.rs
@@ -16,9 +16,9 @@ use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use grpc::{ChannelBuilder, EnvBuilder, Server as GrpcServer, ServerBuilder, ShutdownFuture};
-use grpc_proto::testing::create_benchmark_service;
-use grpc_proto::testing::ServerStats;
-use grpc_proto::testing::{ServerConfig, ServerStatus, ServerType};
+use grpc_proto::testing::control::{ServerConfig, ServerStatus, ServerType};
+use grpc_proto::testing::services_grpc::create_benchmark_service;
+use grpc_proto::testing::stats::ServerStats;
 use grpc_proto::util as proto_util;
 
 use crate::bench::{self, Benchmark, Generic};
@@ -46,11 +46,11 @@ impl Server {
         let keep_running = Arc::new(AtomicBool::new(true));
         let keep_running1 = keep_running.clone();
         let service = match cfg.get_server_type() {
-            ServerType::AsyncServer => {
+            ServerType::ASYNC_SERVER => {
                 let b = Benchmark { keep_running };
                 create_benchmark_service(b)
             }
-            ServerType::AsyncGenericServer => {
+            ServerType::ASYNC_GENERIC_SERVER => {
                 let g = Generic { keep_running };
                 bench::create_generic_service(g)
             }

--- a/benchmark/src/server.rs
+++ b/benchmark/src/server.rs
@@ -92,7 +92,7 @@ impl Server {
     pub fn get_stats(&mut self, reset: bool) -> ServerStats {
         let sample = self.recorder.cpu_time(reset);
 
-        let mut stats = ServerStats::new_();
+        let mut stats = ServerStats::default();
         stats.set_time_elapsed(sample.real_time);
         stats.set_time_user(sample.user_time);
         stats.set_time_system(sample.sys_time);
@@ -107,7 +107,7 @@ impl Server {
     }
 
     pub fn get_status(&self) -> ServerStatus {
-        let mut status = ServerStatus::new_();
+        let mut status = ServerStatus::default();
         status.set_port(i32::from(self.server.bind_addrs()[0].1));
         status.set_cores(util::cpu_num_cores() as i32);
         status

--- a/benchmark/src/util.rs
+++ b/benchmark/src/util.rs
@@ -14,7 +14,7 @@
 use std::f64;
 use std::time::{Duration, Instant};
 
-use grpc_proto::testing::HistogramData;
+use grpc_proto::testing::stats::HistogramData;
 use grpc_sys;
 
 #[path = "../../examples/log_util.rs"]

--- a/benchmark/src/util.rs
+++ b/benchmark/src/util.rs
@@ -206,7 +206,7 @@ impl Histogram {
     }
 
     pub fn report(&mut self, reset: bool) -> HistogramData {
-        let mut data = HistogramData::new_();
+        let mut data = HistogramData::default();
         data.set_count(f64::from(self.count));
         data.set_sum(self.sum);
         data.set_sum_of_squares(self.sum_of_squares);

--- a/benchmark/src/worker.rs
+++ b/benchmark/src/worker.rs
@@ -17,10 +17,10 @@ use crate::error::Error;
 use futures::sync::oneshot::Sender;
 use futures::{future, Future, Sink, Stream};
 use grpc::{DuplexSink, RequestStream, RpcContext, UnarySink, WriteFlags};
-use grpc_proto::testing::WorkerService;
-use grpc_proto::testing::{
+use grpc_proto::testing::control::{
     ClientArgs, ClientStatus, CoreRequest, CoreResponse, ServerArgs, ServerStatus, Void,
 };
+use grpc_proto::testing::services_grpc::WorkerService;
 
 use crate::client::Client;
 use crate::server::Server;

--- a/benchmark/src/worker.rs
+++ b/benchmark/src/worker.rs
@@ -90,13 +90,13 @@ impl WorkerService for Worker {
                 let cfg = arg.as_ref().unwrap().get_setup();
                 info!("receive client setup: {:?}", cfg);
                 let client = Client::new(cfg);
-                sink.send((ClientStatus::new_(), WriteFlags::default()))
+                sink.send((ClientStatus::default(), WriteFlags::default()))
                     .and_then(|sink| {
                         stream.fold((sink, client), |(sink, mut client), arg| {
                             let mark = arg.get_mark();
                             info!("receive client mark: {:?}", mark);
                             let stats = client.get_stats(mark.get_reset());
-                            let mut status = ClientStatus::new_();
+                            let mut status = ClientStatus::default();
                             status.set_stats(stats);
                             sink.send((status, WriteFlags::default()))
                                 .map(|sink| (sink, client))
@@ -116,7 +116,7 @@ impl WorkerService for Worker {
 
     fn core_count(&mut self, ctx: RpcContext, _: CoreRequest, sink: UnarySink<CoreResponse>) {
         let cpu_count = util::cpu_num_cores();
-        let mut resp = CoreResponse::new_();
+        let mut resp = CoreResponse::default();
         resp.set_cores(cpu_count as i32);
         ctx.spawn(
             sink.success(resp)
@@ -130,7 +130,7 @@ impl WorkerService for Worker {
             let _ = notifier.send(());
         }
         ctx.spawn(
-            sink.success(Void::new_())
+            sink.success(Void::default())
                 .map_err(|e| error!("failed to report quick worker: {:?}", e)),
         );
     }

--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -11,14 +11,20 @@ documentation = "https://docs.rs/grpcio-compiler"
 description = "gRPC compiler for grpcio"
 categories = ["network-programming"]
 
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = ["protobuf-codegen"]
+prost-codec = ["prost-build", "prost-types", "prost"]
+
 [dependencies]
-protobuf = "2.0"
-protobuf-codegen = "2.0"
-prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
-prost-build = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
-prost-types = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
+protobuf = "2"
+prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
+prost-build = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
+prost-types = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
+protobuf-codegen = { version = "2", optional = true }
 derive-new = "0.5"
 tempfile = "3.0"
 
 [[bin]]
 name = "grpc_rust_plugin"
+required-features = ["protobuf-codec"]

--- a/compiler/src/lib.rs
+++ b/compiler/src/lib.rs
@@ -11,6 +11,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "protobuf-codec")]
 pub mod codegen;
+#[cfg(feature = "prost-codec")]
 pub mod prost_codegen;
+
 mod util;

--- a/compiler/src/util.rs
+++ b/compiler/src/util.rs
@@ -81,6 +81,7 @@ pub fn to_snake_case(name: &str) -> String {
     snake_method_name
 }
 
+#[cfg(feature = "protobuf-codec")]
 pub fn to_camel_case(name: &str) -> String {
     let mut camel_case_name = String::with_capacity(name.len());
     for s in NameSpliter::new(name) {

--- a/examples/hello_world/client.rs
+++ b/examples/hello_world/client.rs
@@ -29,7 +29,7 @@ fn main() {
     let ch = ChannelBuilder::new(env).connect("localhost:50051");
     let client = GreeterClient::new(ch);
 
-    let mut req = HelloRequest::new_();
+    let mut req = HelloRequest::default();
     req.set_name("world".to_owned());
     let reply = client.say_hello(&req).expect("rpc");
     info!("Greeter received: {}", reply.get_message());

--- a/examples/hello_world/client.rs
+++ b/examples/hello_world/client.rs
@@ -20,8 +20,8 @@ mod log_util;
 use std::sync::Arc;
 
 use grpcio::{ChannelBuilder, EnvBuilder};
-use grpcio_proto::example::helloworld::GreeterClient;
 use grpcio_proto::example::helloworld::HelloRequest;
+use grpcio_proto::example::helloworld_grpc::GreeterClient;
 
 fn main() {
     let _guard = log_util::init_log(None);

--- a/examples/hello_world/server.rs
+++ b/examples/hello_world/server.rs
@@ -25,8 +25,8 @@ use futures::sync::oneshot;
 use futures::Future;
 use grpcio::{Environment, RpcContext, ServerBuilder, UnarySink};
 
-use grpcio_proto::example::helloworld::{self, Greeter};
 use grpcio_proto::example::helloworld::{HelloReply, HelloRequest};
+use grpcio_proto::example::helloworld_grpc::{create_greeter, Greeter};
 
 #[derive(Clone)]
 struct GreeterService;
@@ -46,7 +46,7 @@ impl Greeter for GreeterService {
 fn main() {
     let _guard = log_util::init_log(None);
     let env = Arc::new(Environment::new(1));
-    let service = helloworld::create_greeter(GreeterService);
+    let service = create_greeter(GreeterService);
     let mut server = ServerBuilder::new(env)
         .register_service(service)
         .bind("127.0.0.1", 50_051)

--- a/examples/hello_world/server.rs
+++ b/examples/hello_world/server.rs
@@ -34,7 +34,7 @@ struct GreeterService;
 impl Greeter for GreeterService {
     fn say_hello(&mut self, ctx: RpcContext<'_>, req: HelloRequest, sink: UnarySink<HelloReply>) {
         let msg = format!("Hello {}", req.get_name());
-        let mut resp = HelloReply::new_();
+        let mut resp = HelloReply::default();
         resp.set_message(msg);
         let f = sink
             .success(resp)

--- a/examples/route_guide/client.rs
+++ b/examples/route_guide/client.rs
@@ -32,21 +32,21 @@ use grpcio_proto::example::route_guide::{Point, Rectangle, RouteNote};
 use rand::Rng;
 
 fn new_point(lat: i32, lon: i32) -> Point {
-    let mut point = Point::new_();
+    let mut point = Point::default();
     point.set_latitude(lat);
     point.set_longitude(lon);
     point
 }
 
 fn new_rect(lat1: i32, lon1: i32, lat2: i32, lon2: i32) -> Rectangle {
-    let mut rect = Rectangle::new_();
+    let mut rect = Rectangle::default();
     rect.set_lo(new_point(lat1, lon1));
     rect.set_hi(new_point(lat2, lon2));
     rect
 }
 
 fn new_note(lat: i32, lon: i32, msg: &str) -> RouteNote {
-    let mut note = RouteNote::new_();
+    let mut note = RouteNote::default();
     note.set_location(new_point(lat, lon));
     note.set_message(msg.to_owned());
     note

--- a/examples/route_guide/client.rs
+++ b/examples/route_guide/client.rs
@@ -27,8 +27,8 @@ use std::time::Duration;
 
 use futures::{future, Future, Sink, Stream};
 use grpcio::*;
-use grpcio_proto::example::route_guide::RouteGuideClient;
 use grpcio_proto::example::route_guide::{Point, Rectangle, RouteNote};
+use grpcio_proto::example::route_guide_grpc::RouteGuideClient;
 use rand::Rng;
 
 fn new_point(lat: i32, lon: i32) -> Point {

--- a/examples/route_guide/server.rs
+++ b/examples/route_guide/server.rs
@@ -85,7 +85,7 @@ impl RouteGuide for RouteGuideService {
         let timer = Instant::now();
         let f = points
             .fold(
-                (None, 0f64, RouteSummary::new_()),
+                (None, 0f64, RouteSummary::default()),
                 move |(last, mut dis, mut summary), point| {
                     let total_count = summary.get_point_count();
                     summary.set_point_count(total_count + 1);

--- a/examples/route_guide/server.rs
+++ b/examples/route_guide/server.rs
@@ -30,8 +30,8 @@ use futures::*;
 use grpcio::*;
 
 use crate::util::*;
-use grpcio_proto::example::route_guide;
 use grpcio_proto::example::route_guide::*;
+use grpcio_proto::example::route_guide_grpc::*;
 
 #[derive(Clone)]
 struct RouteGuideService {
@@ -44,7 +44,7 @@ impl RouteGuide for RouteGuideService {
         let resp = data
             .iter()
             .find(|f| same_point(f.get_location(), &point))
-            .map_or_else(Feature::new_, ToOwned::to_owned);
+            .map_or_else(Feature::default, ToOwned::to_owned);
         let f = sink
             .success(resp)
             .map_err(|e| error!("failed to handle getfeature request: {:?}", e));
@@ -149,7 +149,7 @@ fn main() {
     let instance = RouteGuideService {
         data: Arc::new(load_db()),
     };
-    let service = route_guide::create_route_guide(instance);
+    let service = create_route_guide(instance);
     let mut server = ServerBuilder::new(env)
         .register_service(service)
         .bind("127.0.0.1", 50_051)

--- a/examples/route_guide/util.rs
+++ b/examples/route_guide/util.rs
@@ -36,7 +36,7 @@ struct FeatureRef {
 
 impl From<FeatureRef> for Feature {
     fn from(r: FeatureRef) -> Feature {
-        let mut f = Feature::new_();
+        let mut f = Feature::default();
         f.set_name(r.name);
         f.mut_location().set_latitude(r.location.latitude);
         f.mut_location().set_longitude(r.location.longitude);

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 [dependencies]
 grpcio = { path = ".." }
 grpcio-sys = { path = "../grpc-sys" }
-grpcio-proto = { path = "../proto", default-features = false, features = ["prost-codec"] }
+grpcio-proto = { path = "../proto" }
 protobuf = "2"
 futures = "0.1"
 log = "0.3"

--- a/interop/Cargo.toml
+++ b/interop/Cargo.toml
@@ -7,8 +7,8 @@ publish = false
 [dependencies]
 grpcio = { path = ".." }
 grpcio-sys = { path = "../grpc-sys" }
-grpcio-proto = { path = "../proto" }
-protobuf = "2.0"
+grpcio-proto = { path = "../proto", default-features = false, features = ["prost-codec"] }
+protobuf = "2"
 futures = "0.1"
 log = "0.3"
 clap = "2.23"

--- a/interop/src/bin/server.rs
+++ b/interop/src/bin/server.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use clap::{App, Arg};
 use futures::{future, Future};
 use grpc::{Environment, ServerBuilder};
-use grpc_proto::testing::create_test_service;
+use grpc_proto::testing::test_grpc::create_test_service;
 use grpc_proto::util;
 use interop::InteropTestService;
 

--- a/interop/src/client.rs
+++ b/interop/src/client.rs
@@ -39,7 +39,7 @@ impl Client {
 
     pub fn empty_unary(&self) {
         print!("testing empty unary ... ");
-        let req = Empty::new_();
+        let req = Empty::default();
         let resp = self.client.empty_call(&req).unwrap();
         assert_eq!(req, resp);
         println!("pass");
@@ -47,7 +47,7 @@ impl Client {
 
     pub fn large_unary(&self) {
         print!("testing large unary ... ");
-        let mut req = SimpleRequest::new_();
+        let mut req = SimpleRequest::default();
         req.set_response_size(314_159);
         req.set_payload(util::new_payload(271_828));
         let resp = self.client.unary_call(&req).unwrap();
@@ -58,7 +58,7 @@ impl Client {
     pub fn client_streaming(&self) {
         print!("testing client streaming ... ");
         let reqs = vec![27182, 8, 1828, 45904].into_iter().map(|s| {
-            let mut req = StreamingInputCallRequest::new_();
+            let mut req = StreamingInputCallRequest::default();
             req.set_payload(util::new_payload(s));
             (req, WriteFlags::default())
         });
@@ -75,7 +75,7 @@ impl Client {
 
     pub fn server_streaming(&self) {
         print!("testing server streaming ... ");
-        let mut req = StreamingOutputCallRequest::new_();
+        let mut req = StreamingOutputCallRequest::default();
         let sizes = vec![31415, 9, 2653, 58979];
         for size in &sizes {
             req.mut_response_parameters()
@@ -96,7 +96,7 @@ impl Client {
         let (mut sender, mut receiver) = self.client.full_duplex_call().unwrap();
         let cases = vec![(31415, 27182), (9, 8), (2653, 1828), (58979, 45904)];
         for (resp_size, payload_size) in cases {
-            let mut req = StreamingOutputCallRequest::new_();
+            let mut req = StreamingOutputCallRequest::default();
             req.mut_response_parameters()
                 .push(util::new_parameters(resp_size));
             req.set_payload(util::new_payload(payload_size));
@@ -145,7 +145,7 @@ impl Client {
     pub fn cancel_after_first_response(&self) {
         print!("testing cancel_after_first_response ... ");
         let (mut sender, mut receiver) = self.client.full_duplex_call().unwrap();
-        let mut req = StreamingOutputCallRequest::new_();
+        let mut req = StreamingOutputCallRequest::default();
         req.mut_response_parameters()
             .push(util::new_parameters(31415));
         req.set_payload(util::new_payload(27182));
@@ -174,7 +174,7 @@ impl Client {
         print!("testing timeout_of_sleeping_server ... ");
         let opt = CallOption::default().timeout(Duration::from_millis(1));
         let (sender, receiver) = self.client.full_duplex_call_opt(opt).unwrap();
-        let mut req = StreamingOutputCallRequest::new_();
+        let mut req = StreamingOutputCallRequest::default();
         req.set_payload(util::new_payload(27182));
         // Keep the sender, so that receiver will not receive Cancelled error.
         let _sender = sender.send((req, WriteFlags::default())).wait();
@@ -191,10 +191,10 @@ impl Client {
     pub fn status_code_and_message(&self) {
         print!("testing status_code_and_message ... ");
         let error_msg = "test status message";
-        let mut status = EchoStatus::new_();
+        let mut status = EchoStatus::default();
         status.set_code(2);
         status.set_message(error_msg.to_owned());
-        let mut req = SimpleRequest::new_();
+        let mut req = SimpleRequest::default();
         req.set_response_status(status.clone());
         match self.client.unary_call(&req).unwrap_err() {
             grpc::Error::RpcFailure(s) => {
@@ -203,7 +203,7 @@ impl Client {
             }
             e => panic!("expected rpc failure: {:?}", e),
         }
-        let mut req = StreamingOutputCallRequest::new_();
+        let mut req = StreamingOutputCallRequest::default();
         req.set_response_status(status);
         let (sender, receiver) = self.client.full_duplex_call().unwrap();
         // Keep the sender, so that receiver will not receive Cancelled error.
@@ -221,7 +221,11 @@ impl Client {
 
     pub fn unimplemented_method(&self) {
         print!("testing unimplemented_method ... ");
-        match self.client.unimplemented_call(&Empty::new_()).unwrap_err() {
+        match self
+            .client
+            .unimplemented_call(&Empty::default())
+            .unwrap_err()
+        {
             grpc::Error::RpcFailure(s) => {
                 assert_eq!(s.status, RpcStatusCode::GRPC_STATUS_UNIMPLEMENTED)
             }
@@ -233,7 +237,7 @@ impl Client {
     pub fn unimplemented_service(&self) {
         print!("testing unimplemented_service ... ");
         let client = UnimplementedServiceClient::new(self.channel.clone());
-        match client.unimplemented_call(&Empty::new_()).unwrap_err() {
+        match client.unimplemented_call(&Empty::default()).unwrap_err() {
             grpc::Error::RpcFailure(s) => {
                 assert_eq!(s.status, RpcStatusCode::GRPC_STATUS_UNIMPLEMENTED)
             }

--- a/interop/src/client.rs
+++ b/interop/src/client.rs
@@ -17,11 +17,11 @@ use std::time::Duration;
 use crate::grpc::{self, CallOption, Channel, RpcStatusCode, WriteFlags};
 use futures::{future, stream, Future, Sink, Stream};
 
-use grpc_proto::testing::Empty;
-use grpc_proto::testing::{
+use grpc_proto::testing::empty::Empty;
+use grpc_proto::testing::messages::{
     EchoStatus, SimpleRequest, StreamingInputCallRequest, StreamingOutputCallRequest,
 };
-use grpc_proto::testing::{TestServiceClient, UnimplementedServiceClient};
+use grpc_proto::testing::test_grpc::{TestServiceClient, UnimplementedServiceClient};
 use grpc_proto::util;
 
 pub struct Client {

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -20,12 +20,12 @@ use crate::grpc::{
 use futures::{future, stream, Async, Future, Poll, Sink, Stream};
 use futures_timer::Delay;
 
-use grpc_proto::testing::Empty;
-use grpc_proto::testing::TestService;
-use grpc_proto::testing::{
+use grpc_proto::testing::empty::Empty;
+use grpc_proto::testing::messages::{
     SimpleRequest, SimpleResponse, StreamingInputCallRequest, StreamingInputCallResponse,
     StreamingOutputCallRequest, StreamingOutputCallResponse,
 };
+use grpc_proto::testing::test_grpc::TestService;
 use grpc_proto::util;
 
 enum Error {

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -44,7 +44,7 @@ pub struct InteropTestService;
 
 impl TestService for InteropTestService {
     fn empty_call(&mut self, ctx: RpcContext, _: Empty, resp: UnarySink<Empty>) {
-        let res = Empty::new_();
+        let res = Empty::default();
         let f = resp
             .success(res)
             .map_err(|e| panic!("failed to send response: {:?}", e));
@@ -68,7 +68,7 @@ impl TestService for InteropTestService {
             return;
         }
         let resp_size = req.get_response_size();
-        let mut resp = SimpleResponse::new_();
+        let mut resp = SimpleResponse::default();
         resp.set_payload(util::new_payload(resp_size as usize));
         let f = sink
             .success(resp)
@@ -92,7 +92,7 @@ impl TestService for InteropTestService {
         sink: ServerStreamingSink<StreamingOutputCallResponse>,
     ) {
         let resps = req.take_response_parameters().into_iter().map(|param| {
-            let mut resp = StreamingOutputCallResponse::new_();
+            let mut resp = StreamingOutputCallResponse::default();
             resp.set_payload(util::new_payload(param.get_size() as usize));
             (resp, WriteFlags::default())
         });
@@ -114,7 +114,7 @@ impl TestService for InteropTestService {
                 Ok(s + req.get_payload().get_body().len()) as grpc::Result<_>
             })
             .and_then(|s| {
-                let mut resp = StreamingInputCallResponse::new_();
+                let mut resp = StreamingInputCallResponse::default();
                 resp.set_aggregated_payload_size(s as i32);
                 sink.success(resp)
             })
@@ -142,7 +142,7 @@ impl TestService for InteropTestService {
                     let status = RpcStatus::new(code, msg);
                     failure = Some(sink.fail(status));
                 } else {
-                    let mut resp = StreamingOutputCallResponse::new_();
+                    let mut resp = StreamingOutputCallResponse::default();
                     if let Some(param) = req.get_response_parameters().get(0) {
                         resp.set_payload(util::new_payload(param.get_size() as usize));
                     }

--- a/interop/tests/tests.rs
+++ b/interop/tests/tests.rs
@@ -56,7 +56,7 @@ macro_rules! mk_test {
             use std::sync::Arc;
 
             use grpc::{ChannelBuilder, Environment, ServerBuilder};
-            use grpc_proto::testing::create_test_service;
+            use grpc_proto::testing::test_grpc::create_test_service;
             use grpc_proto::util;
             use interop::{Client, InteropTestService};
 

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -14,8 +14,8 @@ build = "build.rs"
 
 [features]
 default = ["protobuf-codec"]
-protobuf-codec = ["grpcio/protobuf-codec", "protobuf-codegen", "protobuf"]
-prost-codec = ["prost-derive", "bytes", "lazy_static", "grpcio/prost-codec", "prost-types", "prost"]
+protobuf-codec = ["grpcio/protobuf-codec", "protobuf-codegen", "protobuf", "grpcio-compiler/protobuf-codec"]
+prost-codec = ["prost-derive", "bytes", "lazy_static", "grpcio/prost-codec", "prost-types", "prost", "grpcio-compiler/prost-codec"]
 
 [dependencies]
 futures = "0.1"
@@ -28,8 +28,7 @@ lazy_static = { version = "1.3", optional = true }
 
 [build-dependencies]
 protobuf-build = "0.7"
-grpcio-compiler = { path = "../compiler" }
-protobuf-build = "=0.6.2"
+grpcio-compiler = { path = "../compiler", default-features = false }
 prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
 prost-types = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
 protobuf = { version = "2", optional = true }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -12,19 +12,25 @@ description = "Public proto files for grpcio."
 categories = ["network-programming"]
 build = "build.rs"
 
+[features]
+default = ["protobuf-codec"]
+protobuf-codec = ["grpcio/protobuf-codec", "protobuf-codegen", "protobuf"]
+prost-codec = ["prost-derive", "bytes", "lazy_static", "grpcio/prost-codec", "prost-types", "prost"]
+
 [dependencies]
 futures = "0.1"
 grpcio = { path = "..", features = ["prost-codec"] }
-bytes = "0.4"
-prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
-prost-derive = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
-protobuf = "~2.2"
-lazy_static = "1.3"
+bytes = { version = "0.4", optional = true }
+prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
+prost-derive = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
+protobuf = "2"
+lazy_static = { version = "1.3", optional = true }
 
 [build-dependencies]
+protobuf-build = "0.7"
 grpcio-compiler = { path = "../compiler" }
 protobuf-build = "=0.6.2"
-prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
-prost-types = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77" }
-protobuf = "~2.2"
-protobuf-codegen = "~2.2"
+prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
+prost-types = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
+protobuf = { version = "2", optional = true }
+protobuf-codegen = { version = "2", optional = true }

--- a/proto/Cargo.toml
+++ b/proto/Cargo.toml
@@ -19,7 +19,7 @@ prost-codec = ["prost-derive", "bytes", "lazy_static", "grpcio/prost-codec", "pr
 
 [dependencies]
 futures = "0.1"
-grpcio = { path = "..", features = ["prost-codec"] }
+grpcio = { path = "..", features = ["secure"], default-features = false }
 bytes = { version = "0.4", optional = true }
 prost = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }
 prost-derive = { git = "https://github.com/danburkert/prost", rev = "1944c27c3029d01ff216e7b126d846b6cf8c7d77", optional = true }

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -11,131 +11,151 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::env;
-use std::fs::{self, File};
-use std::io::Write;
-use std::path::{Path, PathBuf};
-
-use grpcio_compiler::codegen as grpc_gen;
-use prost::Message;
-use prost_types::FileDescriptorSet as ProstFileDescriptorSet;
-use protobuf::compiler_plugin::GenResult;
-use protobuf::descriptor::{FileDescriptorProto, FileDescriptorSet};
-use protobuf_codegen::{self as pb_gen, Customize};
-
-fn write_files<W: Write>(
-    results: impl Iterator<Item = (String, Vec<u8>)>,
-    output_dir: &Path,
-    mut out: W,
-) {
-    if !output_dir.exists() {
-        fs::create_dir_all(output_dir).unwrap();
-    }
-
-    for (name, content) in results {
-        let out_file = output_dir.join(&name);
-        let mut f = File::create(&out_file).unwrap();
-        f.write_all(&content).unwrap();
-        let (module_name, _) = name.split_at(name.len() - 3); // ".rs".len() == 3
-        writeln!(out, "pub mod {};", module_name).unwrap();
-    }
-}
-
-/// Descriptor file to module file using rust-protobuf.
-fn desc_to_module_rust_protobuf<G, W>(
-    descriptor: &Path,
-    output_dir: &Path,
-    mut generate_files: G,
-    out: W,
-) where
-    G: FnMut(&[FileDescriptorProto], &[String]) -> Vec<GenResult>,
-    W: Write,
-{
-    let mut f = File::open(descriptor).unwrap();
-    let proto_set: FileDescriptorSet = protobuf::parse_from_reader(&mut f).unwrap();
-
-    let files: Vec<_> = proto_set
-        .get_file()
-        .into_iter()
-        .map(|f| f.get_name().to_owned())
-        .collect();
-
-    // All files need to be generated in our case.
-    let results = generate_files(proto_set.get_file(), &files);
-    write_files(
-        results.into_iter().map(|res| (res.name, res.content)),
-        output_dir,
-        out,
-    );
-}
-
-/// Descriptor file to module file using Prost.
-fn desc_to_module_prost(descriptor: &Path) {
-    let buf = fs::read(descriptor).unwrap();
-    let proto_set: ProstFileDescriptorSet = Message::decode(buf).unwrap();
-    let files: Vec<_> = proto_set
-        .file
-        .into_iter()
-        .map(|f| {
-            let mut path = PathBuf::new();
-            path.push("proto");
-            path.push(f.name.unwrap());
-            path.to_str().unwrap().to_owned()
-        })
-        .collect();
-
-    let packages = protobuf_build::generate_prost_files(&files, &env::var("OUT_DIR").unwrap());
-    assert!(!packages.is_empty());
-    protobuf_build::generate_wrappers(
-        &packages
-            .iter()
-            .map(|m| format!("{}/{}.rs", env::var("OUT_DIR").unwrap(), m))
-            .collect::<Vec<_>>(),
-        &env::var("OUT_DIR").unwrap(),
-        protobuf_build::GenOpt::all(),
-    );
-}
-
-/// Compile all related proto file to `FileDescriptorSet` and use it to generate
-/// rust source using rust-protobuf.
-///
-/// Using `FileDescriptorSet` here so we don't need to compile the binaries like
-/// protoc-gen-rust and grpc_rust_plugin.
-fn compile_protobuf<P: AsRef<Path>>(desc_path: P, package: &str) {
-    let out_dir = env::var("OUT_DIR").unwrap();
-    let module_path = Path::new(&out_dir).join(package);
-    if !module_path.exists() {
-        fs::create_dir_all(&module_path).unwrap();
-    }
-
-    let mod_rs = module_path.join("mod.rs");
-    let mut module_file = File::create(mod_rs).unwrap();
-
-    desc_to_module_rust_protobuf(
-        desc_path.as_ref(),
-        &module_path,
-        |a, b| {
-            let c = Customize::default();
-            pb_gen::gen(a, b, &c)
-        },
-        &mut module_file,
-    );
-    desc_to_module_rust_protobuf(
-        desc_path.as_ref(),
-        &module_path,
-        grpc_gen::gen,
-        &mut module_file,
-    );
-}
-
-// Generate Prost code.
-fn compile_prost<P: AsRef<Path>>(desc_path: P) {
-    desc_to_module_prost(desc_path.as_ref());
-}
-
 fn main() {
     for package in &["testing", "example", "health"] {
-        compile_protobuf(format!("{}.desc", package), package);
-        compile_prost(format!("{}.desc", package));
+        protobuf::compile(format!("{}.desc", package), package);
+        prost::compile(format!("{}.desc", package));
     }
+}
+
+#[cfg(feature = "prost-codec")]
+mod prost {
+    use std::env;
+    use std::fs;
+    use std::path::{Path, PathBuf};
+
+    use prost::Message;
+    use prost_types::FileDescriptorSet as ProstFileDescriptorSet;
+
+    pub fn compile<P: AsRef<Path>>(desc_path: P) {
+        desc_to_module(desc_path.as_ref());
+    }
+
+    /// Descriptor file to module file using Prost.
+    fn desc_to_module(descriptor: &Path) {
+        let buf = fs::read(descriptor).unwrap();
+        let proto_set: ProstFileDescriptorSet = Message::decode(buf).unwrap();
+        let files: Vec<_> = proto_set
+            .file
+            .into_iter()
+            .map(|f| {
+                let mut path = PathBuf::new();
+                path.push("proto");
+                path.push(f.name.unwrap());
+                path.to_str().unwrap().to_owned()
+            })
+            .collect();
+
+        let packages = protobuf_build::generate_prost_files(&files, &env::var("OUT_DIR").unwrap());
+        assert!(!packages.is_empty());
+        protobuf_build::generate_wrappers(
+            &packages
+                .iter()
+                .map(|m| format!("{}/{}.rs", env::var("OUT_DIR").unwrap(), m))
+                .collect::<Vec<_>>(),
+            &env::var("OUT_DIR").unwrap(),
+            protobuf_build::GenOpt::all(),
+        );
+    }
+}
+
+#[cfg(not(feature = "prost-codec"))]
+mod prost {
+    use std::path::Path;
+
+    pub fn compile<P: AsRef<Path>>(_desc_path: P) {}
+}
+
+#[cfg(feature = "protobuf-codec")]
+mod protobuf {
+    use std::env;
+    use std::fs::{self, File};
+    use std::io::Write;
+    use std::path::Path;
+
+    use grpcio_compiler::codegen as grpc_gen;
+    use protobuf::compiler_plugin::GenResult;
+    use protobuf::descriptor::{FileDescriptorProto, FileDescriptorSet};
+    use protobuf_codegen::{self as pb_gen, Customize};
+
+    /// Compile all related proto file to `FileDescriptorSet` and use it to generate
+    /// rust source using rust-protobuf.
+    ///
+    /// Using `FileDescriptorSet` here so we don't need to compile the binaries like
+    /// protoc-gen-rust and grpc_rust_plugin.
+    pub fn compile<P: AsRef<Path>>(desc_path: P, package: &str) {
+        let out_dir = env::var("OUT_DIR").unwrap();
+        let module_path = Path::new(&out_dir).join(package);
+        if !module_path.exists() {
+            fs::create_dir_all(&module_path).unwrap();
+        }
+
+        let mod_rs = module_path.join("mod.rs");
+        let mut module_file = File::create(mod_rs).unwrap();
+
+        desc_to_module(
+            desc_path.as_ref(),
+            &module_path,
+            |a, b| {
+                let c = Customize::default();
+                pb_gen::gen(a, b, &c)
+            },
+            &mut module_file,
+        );
+        desc_to_module(
+            desc_path.as_ref(),
+            &module_path,
+            grpc_gen::gen,
+            &mut module_file,
+        );
+    }
+
+    /// Descriptor file to module file using rust-protobuf.
+    fn desc_to_module<G, W>(descriptor: &Path, output_dir: &Path, mut generate_files: G, out: W)
+    where
+        G: FnMut(&[FileDescriptorProto], &[String]) -> Vec<GenResult>,
+        W: Write,
+    {
+        let mut f = File::open(descriptor).unwrap();
+        let proto_set: FileDescriptorSet = protobuf::parse_from_reader(&mut f).unwrap();
+
+        let files: Vec<_> = proto_set
+            .get_file()
+            .into_iter()
+            .map(|f| f.get_name().to_owned())
+            .collect();
+
+        // All files need to be generated in our case.
+        let results = generate_files(proto_set.get_file(), &files);
+        write_files(
+            results.into_iter().map(|res| (res.name, res.content)),
+            output_dir,
+            out,
+        );
+    }
+
+    fn write_files<W: Write>(
+        results: impl Iterator<Item = (String, Vec<u8>)>,
+        output_dir: &Path,
+        mut out: W,
+    ) {
+        if !output_dir.exists() {
+            fs::create_dir_all(output_dir).unwrap();
+        }
+
+        for (name, content) in results {
+            let out_file = output_dir.join(&name);
+            let mut f = File::create(&out_file).unwrap();
+            f.write_all(&content).unwrap();
+            let (module_name, _) = name.split_at(name.len() - 3); // ".rs".len() == 3
+            writeln!(out, "pub mod {};", module_name).unwrap();
+        }
+    }
+}
+
+#[cfg(not(feature = "protobuf-codec"))]
+mod protobuf {
+    use std::path::Path;
+
+    pub fn compile<P: AsRef<Path>>(_desc_path: P, _package: &str) {}
 }

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -136,21 +136,21 @@ pub mod health {
     }
 }
 
-#[cfg(feature = "protobuf-codec")]
+#[cfg(all(feature = "protobuf-codec", not(feature = "prost-codec")))]
 #[allow(bare_trait_objects)]
 #[allow(renamed_and_removed_lints)]
 pub mod testing {
     include!(concat!(env!("OUT_DIR"), "/testing/mod.rs"));
 }
 
-#[cfg(feature = "protobuf-codec")]
+#[cfg(all(feature = "protobuf-codec", not(feature = "prost-codec")))]
 #[allow(bare_trait_objects)]
 #[allow(renamed_and_removed_lints)]
 pub mod example {
     include!(concat!(env!("OUT_DIR"), "/example/mod.rs"));
 }
 
-#[cfg(feature = "protobuf-codec")]
+#[cfg(all(feature = "protobuf-codec", not(feature = "prost-codec")))]
 pub mod health {
     #[allow(bare_trait_objects)]
     #[allow(renamed_and_removed_lints)]

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -136,21 +136,21 @@ pub mod health {
     }
 }
 
-#[cfg(all(feature = "protobuf-codec", not(feature = "prost-codec")))]
+#[cfg(feature = "protobuf-codec")]
 #[allow(bare_trait_objects)]
 #[allow(renamed_and_removed_lints)]
 pub mod testing {
     include!(concat!(env!("OUT_DIR"), "/testing/mod.rs"));
 }
 
-#[cfg(all(feature = "protobuf-codec", not(feature = "prost-codec")))]
+#[cfg(feature = "protobuf-codec")]
 #[allow(bare_trait_objects)]
 #[allow(renamed_and_removed_lints)]
 pub mod example {
     include!(concat!(env!("OUT_DIR"), "/example/mod.rs"));
 }
 
-#[cfg(all(feature = "protobuf-codec", not(feature = "prost-codec")))]
+#[cfg(feature = "protobuf-codec")]
 pub mod health {
     #[allow(bare_trait_objects)]
     #[allow(renamed_and_removed_lints)]

--- a/proto/src/lib.rs
+++ b/proto/src/lib.rs
@@ -11,6 +11,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(feature = "prost-codec")]
 #[allow(clippy::large_enum_variant)]
 pub mod testing {
     include!(concat!(env!("OUT_DIR"), "/grpc.testing.rs"));
@@ -113,6 +114,7 @@ pub mod testing {
     }
 }
 
+#[cfg(feature = "prost-codec")]
 pub mod example {
     pub mod helloworld {
         include!(concat!(env!("OUT_DIR"), "/helloworld.rs"));
@@ -124,12 +126,36 @@ pub mod example {
     }
 }
 
+#[cfg(feature = "prost-codec")]
 pub mod health {
     pub mod v1 {
         pub mod health {
             include!(concat!(env!("OUT_DIR"), "/grpc.health.v1.rs"));
             include!(concat!(env!("OUT_DIR"), "/wrapper_grpc.health.v1.rs"));
         }
+    }
+}
+
+#[cfg(feature = "protobuf-codec")]
+#[allow(bare_trait_objects)]
+#[allow(renamed_and_removed_lints)]
+pub mod testing {
+    include!(concat!(env!("OUT_DIR"), "/testing/mod.rs"));
+}
+
+#[cfg(feature = "protobuf-codec")]
+#[allow(bare_trait_objects)]
+#[allow(renamed_and_removed_lints)]
+pub mod example {
+    include!(concat!(env!("OUT_DIR"), "/example/mod.rs"));
+}
+
+#[cfg(feature = "protobuf-codec")]
+pub mod health {
+    #[allow(bare_trait_objects)]
+    #[allow(renamed_and_removed_lints)]
+    pub mod v1 {
+        include!(concat!(env!("OUT_DIR"), "/health/mod.rs"));
     }
 }
 

--- a/proto/src/util.rs
+++ b/proto/src/util.rs
@@ -15,33 +15,22 @@ use grpcio::{
     ChannelCredentials, ChannelCredentialsBuilder, ServerCredentials, ServerCredentialsBuilder,
 };
 
+#[cfg(feature = "protobuf-codec")]
+use crate::testing::messages::{Payload, ResponseParameters};
+#[cfg(feature = "prost-codec")]
 use crate::testing::{Payload, ResponseParameters};
-use crate::testing::{Payload as ProstPayload, ResponseParameters as ProstResponseParams};
 
 /// Create a payload with the specified size.
 pub fn new_payload(size: usize) -> Payload {
-    let mut payload = Payload::new_();
+    let mut payload = Payload::default();
     payload.set_body(vec![0; size]);
     payload
 }
-pub fn new_payload_prost(size: usize) -> ProstPayload {
-    ProstPayload {
-        r#type: 0,
-        body: vec![0; size],
-    }
-}
 
 pub fn new_parameters(size: i32) -> ResponseParameters {
-    let mut parameter = ResponseParameters::new_();
+    let mut parameter = ResponseParameters::default();
     parameter.set_size(size);
     parameter
-}
-pub fn new_parameters_prost(size: i32) -> ProstResponseParams {
-    ProstResponseParams {
-        size,
-        interval_us: 0,
-        compressed: None,
-    }
 }
 
 pub fn create_test_server_credentials() -> ServerCredentials {

--- a/proto/src/util.rs
+++ b/proto/src/util.rs
@@ -15,7 +15,7 @@ use grpcio::{
     ChannelCredentials, ChannelCredentialsBuilder, ServerCredentials, ServerCredentialsBuilder,
 };
 
-#[cfg(feature = "protobuf-codec")]
+#[cfg(all(feature = "protobuf-codec", not(feature = "prost-codec")))]
 use crate::testing::messages::{Payload, ResponseParameters};
 #[cfg(feature = "prost-codec")]
 use crate::testing::{Payload, ResponseParameters};

--- a/tests/cases/cancel.rs
+++ b/tests/cases/cancel.rs
@@ -20,6 +20,7 @@ use futures::sync::mpsc;
 use futures::{future, stream as streams, Async, Future, Poll, Sink, Stream};
 use grpcio::*;
 use grpcio_proto::example::route_guide::*;
+use grpcio_proto::example::route_guide_grpc::*;
 
 type Handler<T> = Arc<Mutex<Option<Box<T>>>>;
 type BoxFuture = Box<dyn Future<Item = (), Error = ()> + Send + 'static>;

--- a/tests/cases/cancel.rs
+++ b/tests/cases/cancel.rs
@@ -74,7 +74,7 @@ impl RouteGuide for CancelService {
 
         let f = rx
             .map(|_| {
-                let f = Feature::new_();
+                let f = Feature::default();
                 (f, WriteFlags::default())
             })
             .forward(sink.sink_map_err(|_| ()))
@@ -269,7 +269,7 @@ fn test_early_exit() {
     let (tx, rx) = std_mpsc::channel();
     *service.list_feature_listener.lock().unwrap() = Some(tx);
 
-    let rect = Rectangle::new_();
+    let rect = Rectangle::default();
     let l = client.list_features(&rect).unwrap();
     let f = l.into_future();
     match f.wait() {

--- a/tests/cases/health_check.rs
+++ b/tests/cases/health_check.rs
@@ -14,10 +14,11 @@
 use futures::*;
 use grpcio::*;
 use grpcio_proto::health::v1::health::*;
+use grpcio_proto::health::v1::health_grpc::*;
 use std::collections::*;
 use std::sync::*;
 
-type StatusRegistry = HashMap<String, health_check_response::ServingStatus>;
+type StatusRegistry = HashMap<String, HealthCheckResponse_ServingStatus>;
 
 #[derive(Clone)]
 struct HealthService {
@@ -36,7 +37,7 @@ impl Health for HealthService {
             None => sink.fail(RpcStatus::new(RpcStatusCode::GRPC_STATUS_NOT_FOUND, None)),
             Some(s) => {
                 let mut resp = HealthCheckResponse::default();
-                resp.set_status_(*s);
+                resp.set_status(*s);
                 sink.success(resp)
             }
         };
@@ -48,7 +49,7 @@ fn check_health(
     client: &HealthClient,
     status: &Arc<RwLock<StatusRegistry>>,
     service: &str,
-    exp: health_check_response::ServingStatus,
+    exp: HealthCheckResponse_ServingStatus,
 ) {
     status.write().unwrap().insert(service.to_owned(), exp);
     let mut req = HealthCheckRequest::default();
@@ -79,19 +80,19 @@ fn test_health_check() {
         &client,
         &status,
         "test",
-        health_check_response::ServingStatus::Serving,
+        HealthCheckResponse_ServingStatus::SERVING,
     );
     check_health(
         &client,
         &status,
         "test",
-        health_check_response::ServingStatus::NotServing,
+        HealthCheckResponse_ServingStatus::NOT_SERVING,
     );
     check_health(
         &client,
         &status,
         "test",
-        health_check_response::ServingStatus::Unknown,
+        HealthCheckResponse_ServingStatus::UNKNOWN,
     );
 
     let mut req = HealthCheckRequest::default();

--- a/tests/cases/health_check.rs
+++ b/tests/cases/health_check.rs
@@ -35,7 +35,7 @@ impl Health for HealthService {
         let res = match status.get(req.get_service()) {
             None => sink.fail(RpcStatus::new(RpcStatusCode::GRPC_STATUS_NOT_FOUND, None)),
             Some(s) => {
-                let mut resp = HealthCheckResponse::new_();
+                let mut resp = HealthCheckResponse::default();
                 resp.set_status_(*s);
                 sink.success(resp)
             }
@@ -51,7 +51,7 @@ fn check_health(
     exp: health_check_response::ServingStatus,
 ) {
     status.write().unwrap().insert(service.to_owned(), exp);
-    let mut req = HealthCheckRequest::new_();
+    let mut req = HealthCheckRequest::default();
     req.set_service(service.to_owned());
     let status = client.check(&req).unwrap().get_status();
     assert_eq!(status, exp);
@@ -94,7 +94,7 @@ fn test_health_check() {
         health_check_response::ServingStatus::Unknown,
     );
 
-    let mut req = HealthCheckRequest::new_();
+    let mut req = HealthCheckRequest::default();
     req.set_service("not-exist".to_owned());
     let err = client.check(&req).unwrap_err();
     match err {

--- a/tests/cases/kick.rs
+++ b/tests/cases/kick.rs
@@ -15,6 +15,7 @@ use futures::sync::oneshot::{self, Sender};
 use futures::*;
 use grpcio::*;
 use grpcio_proto::example::helloworld::*;
+use grpcio_proto::example::helloworld_grpc::*;
 use std::sync::*;
 use std::thread;
 use std::time::*;

--- a/tests/cases/kick.rs
+++ b/tests/cases/kick.rs
@@ -41,7 +41,7 @@ impl Greeter for GreeterService {
                 Ok(())
             }))
             .and_then(move |(greet, _)| {
-                let mut resp = HelloReply::new_();
+                let mut resp = HelloReply::default();
                 resp.set_message(format!("{} {}", greet, name));
                 sink.success(resp)
                     .map_err(|e| panic!("failed to reply {:?}", e))
@@ -64,7 +64,7 @@ fn test_kick() {
     let port = server.bind_addrs()[0].1;
     let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
     let client = GreeterClient::new(ch);
-    let mut req = HelloRequest::new_();
+    let mut req = HelloRequest::default();
     req.set_name("world".to_owned());
     let f = client.say_hello_async(&req).unwrap();
     loop {

--- a/tests/cases/metadata.rs
+++ b/tests/cases/metadata.rs
@@ -14,6 +14,7 @@
 use futures::*;
 use grpcio::*;
 use grpcio_proto::example::helloworld::*;
+use grpcio_proto::example::helloworld_grpc::*;
 use std::sync::mpsc::{self, Sender};
 use std::sync::*;
 use std::time::*;

--- a/tests/cases/metadata.rs
+++ b/tests/cases/metadata.rs
@@ -34,7 +34,7 @@ impl Greeter for GreeterService {
             self.tx.send((key.to_owned(), value.to_owned())).unwrap();
         }
 
-        let mut resp = HelloReply::new_();
+        let mut resp = HelloReply::default();
         resp.set_message(format!("hello {}", req.take_name()));
         ctx.spawn(
             sink.success(resp)
@@ -68,7 +68,7 @@ fn test_metadata() {
     let metadata = builder.build();
     let call_opt = CallOption::default().headers(metadata);
 
-    let mut req = HelloRequest::new_();
+    let mut req = HelloRequest::default();
     req.set_name("world".to_owned());
     let resp = client.say_hello_opt(&req, call_opt).unwrap();
 

--- a/tests/cases/misc.rs
+++ b/tests/cases/misc.rs
@@ -27,7 +27,7 @@ fn test_peer() {
     impl Greeter for PeerService {
         fn say_hello(&mut self, ctx: RpcContext<'_>, _: HelloRequest, sink: UnarySink<HelloReply>) {
             let peer = ctx.peer();
-            let mut resp = HelloReply::new_();
+            let mut resp = HelloReply::default();
             resp.set_message(peer);
             ctx.spawn(
                 sink.success(resp)
@@ -48,7 +48,7 @@ fn test_peer() {
     let ch = ChannelBuilder::new(env).connect(&format!("127.0.0.1:{}", port));
     let client = GreeterClient::new(ch);
 
-    let req = HelloRequest::new_();
+    let req = HelloRequest::default();
     let resp = client.say_hello(&req).unwrap();
 
     assert!(resp.get_message().contains("127.0.0.1"), "{:?}", resp);
@@ -87,7 +87,7 @@ fn test_soundness() {
     impl Greeter for CounterService {
         fn say_hello(&mut self, ctx: RpcContext<'_>, _: HelloRequest, sink: UnarySink<HelloReply>) {
             self.c.incr();
-            let resp = HelloReply::new_();
+            let resp = HelloReply::default();
             ctx.spawn(
                 sink.success(resp)
                     .map_err(|e| panic!("failed to reply {:?}", e)),
@@ -117,7 +117,7 @@ fn test_soundness() {
         let mut resps = Vec::with_capacity(3000);
         thread::spawn(move || {
             for _ in 0..3000 {
-                resps.push(client.say_hello_async(&HelloRequest::new_()).unwrap());
+                resps.push(client.say_hello_async(&HelloRequest::default()).unwrap());
             }
             future::join_all(resps).wait().unwrap();
         })

--- a/tests/cases/misc.rs
+++ b/tests/cases/misc.rs
@@ -14,6 +14,7 @@
 use futures::*;
 use grpcio::*;
 use grpcio_proto::example::helloworld::*;
+use grpcio_proto::example::helloworld_grpc::*;
 use std::sync::atomic::*;
 use std::sync::*;
 use std::thread::{self, JoinHandle};


### PR DESCRIPTION
Let the protos and compiler depend on either Prost or rust-protobuf without needing both as deps (note that the compatibility layer for Prost is based on the `protobuf::Message` trait, so we still need the `protobuf` dep in the Prost case). Fixes some slightly silly code in proto::utils