### PR TITLE
grpcio: wrap the grpc status code

### DIFF
--- a/benchmark/src/bench.rs
+++ b/benchmark/src/bench.rs
@@ -63,10 +63,7 @@ impl BenchmarkService for Benchmark {
         _: RequestStream<SimpleRequest>,
         sink: ClientStreamingSink<SimpleResponse>,
     ) {
-        let f = sink.fail(RpcStatus::new(
-            RpcStatusCode::GRPC_STATUS_UNIMPLEMENTED,
-            None,
-        ));
+        let f = sink.fail(RpcStatus::new(RpcStatusCode::UNIMPLEMENTED, None));
         let keep_running = self.keep_running.clone();
         spawn!(ctx, keep_running, "reporting unimplemented method", f)
     }
@@ -77,10 +74,7 @@ impl BenchmarkService for Benchmark {
         _: SimpleRequest,
         sink: ServerStreamingSink<SimpleResponse>,
     ) {
-        let f = sink.fail(RpcStatus::new(
-            RpcStatusCode::GRPC_STATUS_UNIMPLEMENTED,
-            None,
-        ));
+        let f = sink.fail(RpcStatus::new(RpcStatusCode::UNIMPLEMENTED, None));
         let keep_running = self.keep_running.clone();
         spawn!(ctx, keep_running, "reporting unimplemented method", f)
     }
@@ -91,10 +85,7 @@ impl BenchmarkService for Benchmark {
         _: RequestStream<SimpleRequest>,
         sink: DuplexSink<SimpleResponse>,
     ) {
-        let f = sink.fail(RpcStatus::new(
-            RpcStatusCode::GRPC_STATUS_UNIMPLEMENTED,
-            None,
-        ));
+        let f = sink.fail(RpcStatus::new(RpcStatusCode::UNIMPLEMENTED, None));
         let keep_running = self.keep_running.clone();
         spawn!(ctx, keep_running, "reporting unimplemented method", f)
     }

--- a/interop/src/client.rs
+++ b/interop/src/client.rs
@@ -134,9 +134,7 @@ impl Client {
         thread::sleep(Duration::from_millis(10));
         sender.cancel();
         match receiver.wait().unwrap_err() {
-            grpc::Error::RpcFailure(s) => {
-                assert_eq!(s.status, RpcStatusCode::GRPC_STATUS_CANCELLED)
-            }
+            grpc::Error::RpcFailure(s) => assert_eq!(s.status, RpcStatusCode::CANCELLED),
             e => panic!("expected cancel, but got: {:?}", e),
         }
         println!("pass");
@@ -161,9 +159,7 @@ impl Client {
         assert_eq!(resp.get_payload().get_body().len(), 31415);
         sender.cancel();
         match receiver.into_future().wait() {
-            Err((grpc::Error::RpcFailure(s), _)) => {
-                assert_eq!(s.status, RpcStatusCode::GRPC_STATUS_CANCELLED)
-            }
+            Err((grpc::Error::RpcFailure(s), _)) => assert_eq!(s.status, RpcStatusCode::CANCELLED),
             Err((e, _)) => panic!("expected cancel, but got: {:?}", e),
             Ok((r, _)) => panic!("expected error, but got: {:?}", r),
         }
@@ -180,7 +176,7 @@ impl Client {
         let _sender = sender.send((req, WriteFlags::default())).wait();
         match receiver.into_future().wait() {
             Err((grpc::Error::RpcFailure(s), _)) => {
-                assert_eq!(s.status, RpcStatusCode::GRPC_STATUS_DEADLINE_EXCEEDED)
+                assert_eq!(s.status, RpcStatusCode::DEADLINE_EXCEEDED)
             }
             Err((e, _)) => panic!("expected timeout, but got: {:?}", e),
             Ok((r, _)) => panic!("expected error: {:?}", r),
@@ -198,7 +194,7 @@ impl Client {
         req.set_response_status(status.clone());
         match self.client.unary_call(&req).unwrap_err() {
             grpc::Error::RpcFailure(s) => {
-                assert_eq!(s.status, RpcStatusCode::GRPC_STATUS_UNKNOWN);
+                assert_eq!(s.status, RpcStatusCode::UNKNOWN);
                 assert_eq!(s.details.as_ref().unwrap(), error_msg);
             }
             e => panic!("expected rpc failure: {:?}", e),
@@ -210,7 +206,7 @@ impl Client {
         let _sender = sender.send((req, WriteFlags::default())).wait();
         match receiver.into_future().wait() {
             Err((grpc::Error::RpcFailure(s), _)) => {
-                assert_eq!(s.status, RpcStatusCode::GRPC_STATUS_UNKNOWN);
+                assert_eq!(s.status, RpcStatusCode::UNKNOWN);
                 assert_eq!(s.details.as_ref().unwrap(), error_msg);
             }
             Err((e, _)) => panic!("expected rpc failure: {:?}", e),
@@ -226,9 +222,7 @@ impl Client {
             .unimplemented_call(&Empty::default())
             .unwrap_err()
         {
-            grpc::Error::RpcFailure(s) => {
-                assert_eq!(s.status, RpcStatusCode::GRPC_STATUS_UNIMPLEMENTED)
-            }
+            grpc::Error::RpcFailure(s) => assert_eq!(s.status, RpcStatusCode::UNIMPLEMENTED),
             e => panic!("expected rpc failure: {:?}", e),
         }
         println!("pass");
@@ -238,9 +232,7 @@ impl Client {
         print!("testing unimplemented_service ... ");
         let client = UnimplementedServiceClient::new(self.channel.clone());
         match client.unimplemented_call(&Empty::default()).unwrap_err() {
-            grpc::Error::RpcFailure(s) => {
-                assert_eq!(s.status, RpcStatusCode::GRPC_STATUS_UNIMPLEMENTED)
-            }
+            grpc::Error::RpcFailure(s) => assert_eq!(s.status, RpcStatusCode::UNIMPLEMENTED),
             e => panic!("expected rpc failure: {:?}", e),
         }
         println!("pass");

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -60,7 +60,7 @@ impl TestService for InteropTestService {
         if req.has_response_status() {
             let code = req.get_response_status().get_code();
             let msg = Some(req.take_response_status().take_message());
-            let status = RpcStatus::new(RpcStatusCode::new(code), msg);
+            let status = RpcStatus::new(code.into(), msg);
             let f = sink
                 .fail(status)
                 .map_err(|e| panic!("failed to send response: {:?}", e));
@@ -139,7 +139,7 @@ impl TestService for InteropTestService {
                 if req.has_response_status() {
                     let code = req.get_response_status().get_code();
                     let msg = Some(req.take_response_status().take_message());
-                    let status = RpcStatus::new(RpcStatusCode::new(code), msg);
+                    let status = RpcStatus::new(code.into(), msg);
                     failure = Some(sink.fail(status));
                 } else {
                     let mut resp = StreamingOutputCallResponse::default();

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -60,7 +60,7 @@ impl TestService for InteropTestService {
         if req.has_response_status() {
             let code = req.get_response_status().get_code();
             let msg = Some(req.take_response_status().take_message());
-            let status = RpcStatus::new(code.into(), msg);
+            let status = RpcStatus::new(code, msg);
             let f = sink
                 .fail(status)
                 .map_err(|e| panic!("failed to send response: {:?}", e));
@@ -139,7 +139,7 @@ impl TestService for InteropTestService {
                 if req.has_response_status() {
                     let code = req.get_response_status().get_code();
                     let msg = Some(req.take_response_status().take_message());
-                    let status = RpcStatus::new(code.into(), msg);
+                    let status = RpcStatus::new(code, msg);
                     failure = Some(sink.fail(status));
                 } else {
                     let mut resp = StreamingOutputCallResponse::default();

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -60,7 +60,7 @@ impl TestService for InteropTestService {
         if req.has_response_status() {
             let code = req.get_response_status().get_code();
             let msg = Some(req.take_response_status().take_message());
-            let status = RpcStatus::new(RpcStatusCode::from(code), msg);
+            let status = RpcStatus::new(RpcStatusCode::new(code), msg);
             let f = sink
                 .fail(status)
                 .map_err(|e| panic!("failed to send response: {:?}", e));
@@ -139,7 +139,7 @@ impl TestService for InteropTestService {
                 if req.has_response_status() {
                     let code = req.get_response_status().get_code();
                     let msg = Some(req.take_response_status().take_message());
-                    let status = RpcStatus::new(RpcStatusCode::from(code), msg);
+                    let status = RpcStatus::new(RpcStatusCode::new(code), msg);
                     failure = Some(sink.fail(status));
                 } else {
                     let mut resp = StreamingOutputCallResponse::default();

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -60,7 +60,7 @@ impl TestService for InteropTestService {
         if req.has_response_status() {
             let code = req.get_response_status().get_code();
             let msg = Some(req.take_response_status().take_message());
-            let status = RpcStatus::new(code, msg);
+            let status = RpcStatus::new(RpcStatusCode::from(code), msg);
             let f = sink
                 .fail(status)
                 .map_err(|e| panic!("failed to send response: {:?}", e));
@@ -139,7 +139,7 @@ impl TestService for InteropTestService {
                 if req.has_response_status() {
                     let code = req.get_response_status().get_code();
                     let msg = Some(req.take_response_status().take_message());
-                    let status = RpcStatus::new(code, msg);
+                    let status = RpcStatus::new(RpcStatusCode::from(code), msg);
                     failure = Some(sink.fail(status));
                 } else {
                     let mut resp = StreamingOutputCallResponse::default();

--- a/interop/src/server.rs
+++ b/interop/src/server.rs
@@ -195,10 +195,7 @@ impl TestService for InteropTestService {
 
     fn unimplemented_call(&mut self, ctx: RpcContext, _: Empty, sink: UnarySink<Empty>) {
         let f = sink
-            .fail(RpcStatus::new(
-                RpcStatusCode::GRPC_STATUS_UNIMPLEMENTED,
-                None,
-            ))
+            .fail(RpcStatus::new(RpcStatusCode::UNIMPLEMENTED, None))
             .map_err(|e| error!("failed to report unimplemented method: {:?}", e));
         ctx.spawn(f)
     }

--- a/src/call/server.rs
+++ b/src/call/server.rs
@@ -225,10 +225,7 @@ impl UnaryRequestContext {
             return execute(self.request, cq, reader, handler);
         }
 
-        let status = RpcStatus::new(
-            RpcStatusCode::GRPC_STATUS_INTERNAL,
-            Some("No payload".to_owned()),
-        );
+        let status = RpcStatus::new(RpcStatusCode::INTERNAL, Some("No payload".to_owned()));
         self.request.call(cq.clone()).abort(&status)
     }
 }
@@ -661,7 +658,7 @@ pub fn execute_unary<P, Q, F>(
         Ok(f) => f,
         Err(e) => {
             let status = RpcStatus::new(
-                RpcStatusCode::GRPC_STATUS_INTERNAL,
+                RpcStatusCode::INTERNAL,
                 Some(format!("Failed to deserialize response message: {:?}", e)),
             );
             call.abort(&status);
@@ -707,7 +704,7 @@ pub fn execute_server_streaming<P, Q, F>(
         Ok(t) => t,
         Err(e) => {
             let status = RpcStatus::new(
-                RpcStatusCode::GRPC_STATUS_INTERNAL,
+                RpcStatusCode::INTERNAL,
                 Some(format!("Failed to deserialize response message: {:?}", e)),
             );
             call.abort(&status);
@@ -743,10 +740,7 @@ pub fn execute_unimplemented(ctx: RequestContext, cq: CompletionQueue) {
     let ctx = ctx;
     let mut call = ctx.call(cq);
     accept_call!(call);
-    call.abort(&RpcStatus::new(
-        RpcStatusCode::GRPC_STATUS_UNIMPLEMENTED,
-        None,
-    ))
+    call.abort(&RpcStatus::new(RpcStatusCode::UNIMPLEMENTED, None))
 }
 
 // Helper function to call handler.

--- a/src/task/promise.rs
+++ b/src/task/promise.rs
@@ -68,7 +68,7 @@ impl Batch {
             let mut guard = self.inner.lock();
             if succeed {
                 let status = self.ctx.rpc_status();
-                if status.status == RpcStatusCode::GRPC_STATUS_OK {
+                if status.status == RpcStatusCode::OK {
                     guard.set_result(Ok(None))
                 } else {
                     guard.set_result(Err(Error::RpcFailure(status)))
@@ -84,7 +84,7 @@ impl Batch {
         let task = {
             let mut guard = self.inner.lock();
             let status = self.ctx.rpc_status();
-            if status.status == RpcStatusCode::GRPC_STATUS_OK {
+            if status.status == RpcStatusCode::OK {
                 guard.set_result(Ok(self.ctx.recv_message()))
             } else {
                 guard.set_result(Err(Error::RpcFailure(status)))

--- a/tests-and-examples/tests/cases/cancel.rs
+++ b/tests-and-examples/tests/cases/cancel.rs
@@ -122,7 +122,7 @@ where
 {
     match rx.into_future().wait() {
         Err((Error::RpcFailure(s), _)) | Err((Error::RpcFinished(Some(s)), _)) => {
-            assert_eq!(s.status, RpcStatusCode::GRPC_STATUS_CANCELLED)
+            assert_eq!(s.status, RpcStatusCode::CANCELLED)
         }
         Err((e, _)) => panic!("expected cancel, but got: {:?}", e),
         Ok(_) => panic!("expected error, but got: Ok(_)"),

--- a/tests-and-examples/tests/cases/health_check.rs
+++ b/tests-and-examples/tests/cases/health_check.rs
@@ -34,7 +34,7 @@ impl Health for HealthService {
     ) {
         let status = self.status.read().unwrap();
         let res = match status.get(req.get_service()) {
-            None => sink.fail(RpcStatus::new(RpcStatusCode::GRPC_STATUS_NOT_FOUND, None)),
+            None => sink.fail(RpcStatus::new(RpcStatusCode::NOT_FOUND, None)),
             Some(s) => {
                 let mut resp = HealthCheckResponse::default();
                 resp.set_status(*s);
@@ -99,7 +99,7 @@ fn test_health_check() {
     req.set_service("not-exist".to_owned());
     let err = client.check(&req).unwrap_err();
     match err {
-        Error::RpcFailure(s) => assert_eq!(s.status, RpcStatusCode::GRPC_STATUS_NOT_FOUND),
+        Error::RpcFailure(s) => assert_eq!(s.status, RpcStatusCode::NOT_FOUND),
         e => panic!("unexpected error: {:?}", e),
     }
 }


### PR DESCRIPTION
Give the variable a more descriptive name so we know what kind of a code it is and what the valid values are. Leave grpc-sys untouch and define the type `RpcStatusCode` in grpcio itself.