### PR TITLE
proto: replace slash to get it built on windows

### DIFF
--- a/proto/build.rs
+++ b/proto/build.rs
@@ -29,7 +29,7 @@ fn main() {
                 if !dent.file_type().is_file() {
                     return None;
                 }
-                Some(format!("{}", dent.path().display()))
+                Some(format!("{}", dent.path().display()).replace('\\', "/"))
             })
             .collect();
         protobuf_build::generate_files(&["proto".to_owned()], &files, &out_dir);

--- a/proto/build.rs
+++ b/proto/build.rs
@@ -29,6 +29,7 @@ fn main() {
                 if !dent.file_type().is_file() {
                     return None;
                 }
+                // rust-protobuf is bad at dealing with path, keep it the same style.
                 Some(format!("{}", dent.path().display()).replace('\\', "/"))
             })
             .collect();


### PR DESCRIPTION
rust-protobuf can't detect path correctly, this is a workaround for stepancheg/rust-protobuf#433.