### PR TITLE
Copy-paste CodeWriter from protobuf-codegen crate

### DIFF
--- a/compiler/Cargo.toml
+++ b/compiler/Cargo.toml
@@ -13,7 +13,7 @@ categories = ["network-programming"]
 
 [features]
 default = ["protobuf-codec"]
-protobuf-codec = ["protobuf-codegen"]
+protobuf-codec = []
 prost-codec = ["prost-build", "prost-types", "prost"]
 
 [dependencies]
@@ -21,7 +21,6 @@ protobuf = "2"
 prost = { version = "0.5", optional = true }
 prost-build = { version = "0.5", optional = true }
 prost-types = { version = "0.5", optional = true }
-protobuf-codegen = { version = "2", optional = true }
 derive-new = "0.5"
 tempfile = "3.0"
 


### PR DESCRIPTION
CodeWriter is not meant to be a public API of protobuf-codegen.

However, protobuf-codegen should export some API to map protobuf
types to rust types, but it doesn't have this API now, so I'm
removing protobuf-codegen dependency.