### PR TITLE
grpcio: add resource quota support

### DIFF
--- a/grpc-sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
+++ b/grpc-sys/bindings/x86_64-unknown-linux-gnu-bindings.rs
@@ -5947,6 +5947,15 @@ extern "C" {
     );
 }
 extern "C" {
+    pub fn grpcwrap_channel_args_set_pointer_vtable(
+        args: *mut grpc_channel_args,
+        index: usize,
+        key: *const ::std::os::raw::c_char,
+        value: *mut ::std::os::raw::c_void,
+        vtable: *const grpc_arg_pointer_vtable,
+    );
+}
+extern "C" {
     pub fn grpcwrap_channel_args_destroy(args: *mut grpc_channel_args);
 }
 extern "C" {

--- a/grpc-sys/grpc_wrap.cc
+++ b/grpc-sys/grpc_wrap.cc
@@ -105,7 +105,7 @@ typedef struct grpcwrap_batch_context {
 GPR_EXPORT grpcwrap_batch_context* GPR_CALLTYPE
 grpcwrap_batch_context_create() {
   auto* ctx =
-    (grpcwrap_batch_context*)gpr_malloc(sizeof(grpcwrap_batch_context));
+      (grpcwrap_batch_context*)gpr_malloc(sizeof(grpcwrap_batch_context));
   memset(ctx, 0, sizeof(grpcwrap_batch_context));
   return ctx;
 }
@@ -118,8 +118,8 @@ typedef struct {
 
 GPR_EXPORT grpcwrap_request_call_context* GPR_CALLTYPE
 grpcwrap_request_call_context_create() {
-  auto * ctx = (grpcwrap_request_call_context*)
-    gpr_malloc(sizeof(grpcwrap_request_call_context));
+  auto* ctx = (grpcwrap_request_call_context*)gpr_malloc(
+      sizeof(grpcwrap_request_call_context));
   memset(ctx, 0, sizeof(grpcwrap_request_call_context));
   return ctx;
 }
@@ -295,35 +295,32 @@ grpcwrap_batch_context_recv_initial_metadata(
   return &(ctx->recv_initial_metadata);
 }
 
-GPR_EXPORT const char *GPR_CALLTYPE
-grpcwrap_slice_raw_offset(const grpc_slice *slice, size_t offset, size_t *len) {
+GPR_EXPORT const char* GPR_CALLTYPE
+grpcwrap_slice_raw_offset(const grpc_slice* slice, size_t offset, size_t* len) {
   *len = GRPC_SLICE_LENGTH(*slice) - offset;
-  return (const char *)(GRPC_SLICE_START_PTR(*slice)) + offset;
+  return (const char*)(GRPC_SLICE_START_PTR(*slice)) + offset;
 }
 
 GPR_EXPORT grpc_slice GPR_CALLTYPE
-grpcwrap_slice_copy(const grpc_slice *slice) {
+grpcwrap_slice_copy(const grpc_slice* slice) {
   return grpc_slice_copy(*slice);
 }
 
-GPR_EXPORT void GPR_CALLTYPE
-grpcwrap_slice_unref(const grpc_slice *slice) {
+GPR_EXPORT void GPR_CALLTYPE grpcwrap_slice_unref(const grpc_slice* slice) {
   grpc_slice_unref(*slice);
 }
 
-GPR_EXPORT grpc_slice GPR_CALLTYPE
-grpcwrap_slice_ref(const grpc_slice *slice) {
+GPR_EXPORT grpc_slice GPR_CALLTYPE grpcwrap_slice_ref(const grpc_slice* slice) {
   return grpc_slice_ref(*slice);
 }
 
-GPR_EXPORT size_t GPR_CALLTYPE
-grpcwrap_slice_length(const grpc_slice *slice) {
+GPR_EXPORT size_t GPR_CALLTYPE grpcwrap_slice_length(const grpc_slice* slice) {
   return GRPC_SLICE_LENGTH(*slice);
 }
 
-GPR_EXPORT grpc_byte_buffer *GPR_CALLTYPE
-grpcwrap_batch_context_take_recv_message(grpcwrap_batch_context *ctx) {
-  grpc_byte_buffer *buf = nullptr;
+GPR_EXPORT grpc_byte_buffer* GPR_CALLTYPE
+grpcwrap_batch_context_take_recv_message(grpcwrap_batch_context* ctx) {
+  grpc_byte_buffer* buf = nullptr;
   if (ctx->recv_message) {
     buf = ctx->recv_message;
     ctx->recv_message = nullptr;
@@ -422,8 +419,7 @@ GPR_EXPORT grpc_call* GPR_CALLTYPE grpcwrap_channel_create_call(
 
 GPR_EXPORT grpc_channel_args* GPR_CALLTYPE
 grpcwrap_channel_args_create(size_t num_args) {
-  auto * args =
-      (grpc_channel_args*)gpr_malloc(sizeof(grpc_channel_args));
+  auto* args = (grpc_channel_args*)gpr_malloc(sizeof(grpc_channel_args));
   memset(args, 0, sizeof(grpc_channel_args));
 
   args->num_args = num_args;
@@ -451,7 +447,8 @@ GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_integer(
 }
 
 GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_pointer_vtable(
-    grpc_channel_args* args, size_t index, const char* key, void* value, const grpc_arg_pointer_vtable* vtable) {
+    grpc_channel_args* args, size_t index, const char* key, void* value,
+    const grpc_arg_pointer_vtable* vtable) {
   GPR_ASSERT(args);
   GPR_ASSERT(index < args->num_args);
   args->args[index].type = GRPC_ARG_POINTER;
@@ -468,6 +465,10 @@ grpcwrap_channel_args_destroy(grpc_channel_args* args) {
       gpr_free(args->args[i].key);
       if (args->args[i].type == GRPC_ARG_STRING) {
         gpr_free(args->args[i].value.string);
+      }
+      if (args->args[i].type == GRPC_ARG_POINTER) {
+        args->args[i].value.pointer.vtable->destroy(
+            args->args[i].value.pointer.p);
       }
     }
     gpr_free(args->args);
@@ -774,8 +775,8 @@ GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_send_initial_metadata(
     ready to poll.
     THREAD SAFETY: grpcwrap_call_kick_completion_queue is thread-safe
     because it does not change the call's state. */
-GPR_EXPORT grpc_call_error GPR_CALLTYPE grpcwrap_call_kick_completion_queue(
-    grpc_call* call, void* tag) {
+GPR_EXPORT grpc_call_error GPR_CALLTYPE
+grpcwrap_call_kick_completion_queue(grpc_call* call, void* tag) {
   // Empty batch grpc_op kicks call's completion queue immediately.
   return grpc_call_start_batch(call, nullptr, 0, tag, nullptr);
 }
@@ -825,7 +826,8 @@ grpcwrap_ssl_credentials_create(const char* pem_root_certs,
   if (key_cert_pair_cert_chain || key_cert_pair_private_key) {
     key_cert_pair.cert_chain = key_cert_pair_cert_chain;
     key_cert_pair.private_key = key_cert_pair_private_key;
-    return grpc_ssl_credentials_create(pem_root_certs, &key_cert_pair, NULL, NULL);
+    return grpc_ssl_credentials_create(pem_root_certs, &key_cert_pair, NULL,
+                                       NULL);
   } else {
     GPR_ASSERT(!key_cert_pair_cert_chain);
     GPR_ASSERT(!key_cert_pair_private_key);

--- a/grpc-sys/grpc_wrap.cc
+++ b/grpc-sys/grpc_wrap.cc
@@ -450,6 +450,16 @@ GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_integer(
   args->args[index].value.integer = value;
 }
 
+GPR_EXPORT void GPR_CALLTYPE grpcwrap_channel_args_set_pointer_vtable(
+    grpc_channel_args* args, size_t index, const char* key, void* value, const grpc_arg_pointer_vtable* vtable) {
+  GPR_ASSERT(args);
+  GPR_ASSERT(index < args->num_args);
+  args->args[index].type = GRPC_ARG_POINTER;
+  args->args[index].key = gpr_strdup(key);
+  args->args[index].value.pointer.p = vtable->copy(value);
+  args->args[index].value.pointer.vtable = vtable;
+}
+
 GPR_EXPORT void GPR_CALLTYPE
 grpcwrap_channel_args_destroy(grpc_channel_args* args) {
   size_t i;

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -132,8 +132,9 @@ impl ChannelBuilder {
         self
     }
 
-    pub fn set_resource_quota(mut self, quota: ResourceQuota) -> ChannelBuilder {
-        let raw_quota = quota.raw;
+    /// Set resource quota to be attached to the constructed channel.
+    pub fn set_resource_quota(mut self, quota: &ResourceQuota) -> ChannelBuilder {
+        let raw_quota = quota.get_raw();
         unsafe {
             self.options.insert(
                 Cow::Borrowed(grpc_sys::GRPC_ARG_RESOURCE_QUOTA),

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -138,7 +138,7 @@ impl ChannelBuilder {
         unsafe {
             self.options.insert(
                 Cow::Borrowed(grpc_sys::GRPC_ARG_RESOURCE_QUOTA),
-                Options::Pointer(quota, grpc_sys::grpc_resource_quota_arg_vtable() as _),
+                Options::Pointer(quota, grpc_sys::grpc_resource_quota_arg_vtable()),
             );
         }
         self
@@ -460,7 +460,7 @@ impl ChannelBuilder {
                         i,
                         key,
                         quota.get_ptr() as _,
-                        vtable as _,
+                        vtable,
                     )
                 },
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,6 +50,7 @@ mod env;
 mod error;
 mod log_util;
 mod metadata;
+mod quota;
 mod server;
 mod task;
 
@@ -83,4 +84,5 @@ pub use crate::env::{EnvBuilder, Environment};
 pub use crate::error::{Error, Result};
 pub use crate::log_util::redirect_log;
 pub use crate::metadata::{Metadata, MetadataBuilder, MetadataIter};
+pub use crate::quota::ResourceQuota;
 pub use crate::server::{Server, ServerBuilder, Service, ServiceBuilder, ShutdownFuture};

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -1,0 +1,29 @@
+use crate::grpc_sys::{self, grpc_resource_quota};
+use std::ptr;
+
+/// ResourceQuota represents a bound on memory and thread usage by the gRPC,
+/// Now grpc-rs only supports setting memory bound. A ResourceQuota can be
+/// consumed by a ChannelBuilder.
+pub struct ResourceQuota {
+    pub raw: *mut grpc_resource_quota,
+}
+
+impl ResourceQuota {
+    /// Create a control block for resource quota
+    pub fn new(name: Option<String>) -> ResourceQuota {
+        match name {
+            Some(name_str) => ResourceQuota {
+                raw: unsafe { grpc_sys::grpc_resource_quota_create(name_str.as_ptr() as _) },
+            },
+            None => ResourceQuota {
+                raw: unsafe { grpc_sys::grpc_resource_quota_create(ptr::null()) },
+            },
+        }
+    }
+
+    /// Resize this ResourceQuota to a new memory size.
+    pub fn resize(self, new_size: usize) -> ResourceQuota {
+        unsafe { grpc_sys::grpc_resource_quota_resize(self.raw, new_size) };
+        self
+    }
+}

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -2,7 +2,9 @@ use crate::grpc_sys::{self, grpc_resource_quota};
 use std::ffi::CString;
 use std::ptr;
 
-/// ResourceQuota represents a bound on memory and thread usage by the gRPC
+/// ResourceQuota represents a bound on memory and thread usage by the gRPC.
+/// NOTE: The management of threads created in grpc-core don't use ResourceQuota.
+/// TODO: Manage the poller threads created in grpc-rs with this ResourceQuota later.
 pub struct ResourceQuota {
     raw: *mut grpc_resource_quota,
 }
@@ -26,7 +28,7 @@ impl ResourceQuota {
     }
 
     /// Resize this ResourceQuota to a new memory size.
-    pub fn resize(self, new_size: usize) -> ResourceQuota {
+    pub fn resize_memory(self, new_size: usize) -> ResourceQuota {
         unsafe { grpc_sys::grpc_resource_quota_resize(self.raw, new_size) };
         self
     }

--- a/src/quota.rs
+++ b/src/quota.rs
@@ -1,20 +1,24 @@
 use crate::grpc_sys::{self, grpc_resource_quota};
+use std::ffi::CString;
 use std::ptr;
 
-/// ResourceQuota represents a bound on memory and thread usage by the gRPC,
-/// A ResourceQuota need to be ensure lifetime when the attached Channel is
-/// working or the program is aborted.
+/// ResourceQuota represents a bound on memory and thread usage by the gRPC
 pub struct ResourceQuota {
     raw: *mut grpc_resource_quota,
 }
 
 impl ResourceQuota {
-    /// Create a control block for resource quota
+    /// Create a control block for resource quota. If a name is
+    /// not declared for this control block, a name is automatically
+    /// generated in grpc core.
     pub fn new(name: Option<&str>) -> ResourceQuota {
         match name {
-            Some(name_str) => ResourceQuota {
-                raw: unsafe { grpc_sys::grpc_resource_quota_create(name_str.as_ptr() as _) },
-            },
+            Some(name_str) => {
+                let name_cstr = CString::new(name_str).unwrap();
+                ResourceQuota {
+                    raw: unsafe { grpc_sys::grpc_resource_quota_create(name_cstr.as_ptr() as _) },
+                }
+            }
             None => ResourceQuota {
                 raw: unsafe { grpc_sys::grpc_resource_quota_create(ptr::null()) },
             },
@@ -27,14 +31,13 @@ impl ResourceQuota {
         self
     }
 
-    pub fn get_raw(&self) -> *mut grpc_resource_quota {
+    pub(crate) fn get_ptr(&self) -> *mut grpc_resource_quota {
         self.raw
     }
 }
 
 impl Drop for ResourceQuota {
     fn drop(&mut self) {
-        println!("drop ResourceQuota");
         unsafe {
             grpc_sys::grpc_resource_quota_unref(self.raw);
         }

--- a/tests-and-examples/examples/hello_world/server.rs
+++ b/tests-and-examples/examples/hello_world/server.rs
@@ -49,7 +49,7 @@ fn main() {
     let service = create_greeter(GreeterService);
 
     let quota = ResourceQuota::new(None).resize(1024 * 1024);
-    let ch_builder = ChannelBuilder::new(env.clone()).set_resource_quota(quota);
+    let ch_builder = ChannelBuilder::new(env.clone()).set_resource_quota(&quota);
 
     let mut server = ServerBuilder::new(env)
         .register_service(service)

--- a/tests-and-examples/examples/hello_world/server.rs
+++ b/tests-and-examples/examples/hello_world/server.rs
@@ -48,7 +48,7 @@ fn main() {
     let env = Arc::new(Environment::new(1));
     let service = create_greeter(GreeterService);
 
-    let quota = ResourceQuota::new(Some("HelloServerQuota")).resize(1024 * 1024);
+    let quota = ResourceQuota::new(Some("HelloServerQuota")).resize_memory(1024 * 1024);
     let ch_builder = ChannelBuilder::new(env.clone()).set_resource_quota(quota);
 
     let mut server = ServerBuilder::new(env)

--- a/tests-and-examples/examples/hello_world/server.rs
+++ b/tests-and-examples/examples/hello_world/server.rs
@@ -48,8 +48,8 @@ fn main() {
     let env = Arc::new(Environment::new(1));
     let service = create_greeter(GreeterService);
 
-    let quota = ResourceQuota::new(None).resize(1024 * 1024);
-    let ch_builder = ChannelBuilder::new(env.clone()).set_resource_quota(&quota);
+    let quota = ResourceQuota::new(Some("HelloServerQuota")).resize(1024 * 1024);
+    let ch_builder = ChannelBuilder::new(env.clone()).set_resource_quota(quota);
 
     let mut server = ServerBuilder::new(env)
         .register_service(service)

--- a/tests-and-examples/examples/hello_world/server.rs
+++ b/tests-and-examples/examples/hello_world/server.rs
@@ -23,7 +23,7 @@ use std::{io, thread};
 
 use futures::sync::oneshot;
 use futures::Future;
-use grpcio::{Environment, RpcContext, ServerBuilder, UnarySink};
+use grpcio::{ChannelBuilder, Environment, ResourceQuota, RpcContext, ServerBuilder, UnarySink};
 
 use grpcio_proto::example::helloworld::{HelloReply, HelloRequest};
 use grpcio_proto::example::helloworld_grpc::{create_greeter, Greeter};
@@ -47,9 +47,14 @@ fn main() {
     let _guard = log_util::init_log(None);
     let env = Arc::new(Environment::new(1));
     let service = create_greeter(GreeterService);
+
+    let quota = ResourceQuota::new(None).resize(1024 * 1024);
+    let ch_builder = ChannelBuilder::new(env.clone()).set_resource_quota(quota);
+
     let mut server = ServerBuilder::new(env)
         .register_service(service)
         .bind("127.0.0.1", 50_051)
+        .channel_args(ch_builder.build_args())
         .build()
         .unwrap();
     server.start();


### PR DESCRIPTION
* Add the `ResourceQuota` struct to control the bound on memory usage.
* Wrap `set_pointer_vtable` to configure channel args.
* Format `grpc_wrap.cc` code style.