### PR TITLE
grpc-sys: fix ssl path when using openssl

### DIFF
--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -218,7 +218,11 @@ fn figure_ssl_path(build_dir: &str) {
         let t = trim_start(&l, "OPENSSL_CRYPTO_LIBRARY:FILEPATH=")
             .or_else(|| trim_start(&l, "OPENSSL_SSL_LIBRARY:FILEPATH="));
         if let Some(s) = t {
-            println!("cargo:rustc-link-lib={}", s);
+            let path = Path::new(s);
+            println!(
+                "cargo:rustc-link-search=native={}",
+                path.parent().unwrap().display()
+            );
             cnt += 1;
         }
     }
@@ -228,6 +232,8 @@ fn figure_ssl_path(build_dir: &str) {
             path, cnt
         );
     }
+    println!("cargo:rustc-link-lib=ssl");
+    println!("cargo:rustc-link-lib=crypto");
 }
 
 #[cfg(feature = "openssl-vendored")]

--- a/grpc-sys/build.rs
+++ b/grpc-sys/build.rs
@@ -17,6 +17,7 @@ extern crate pkg_config;
 
 use std::env::VarError;
 use std::io::prelude::*;
+use std::io::BufReader;
 use std::path::{Path, PathBuf};
 use std::{env, fs, io};
 
@@ -66,8 +67,18 @@ fn is_directory_empty<P: AsRef<Path>>(p: P) -> Result<bool, io::Error> {
     Ok(entries.next().is_none())
 }
 
+fn trim_start<'a>(s: &'a str, prefix: &str) -> Option<&'a str> {
+    if s.starts_with(prefix) {
+        Some(s.trim_start_matches(prefix))
+    } else {
+        None
+    }
+}
+
 fn build_grpc(cc: &mut Build, library: &str) {
     prepare_grpc();
+
+    let mut third_party = vec!["cares/cares/lib", "zlib"];
 
     let dst = {
         let mut config = Config::new("grpc");
@@ -139,6 +150,8 @@ fn build_grpc(cc: &mut Build, library: &str) {
             // old Makefile, but not in CMake.
             config.cxxflag("-DTSI_OPENSSL_ALPN_SUPPORT=0");
             setup_openssl(&mut config)
+        } else if cfg!(feature = "secure") {
+            third_party.extend_from_slice(&["boringssl/ssl", "boringssl/crypto"]);
         }
         if cfg!(feature = "no-omit-frame-pointer") {
             config
@@ -150,12 +163,6 @@ fn build_grpc(cc: &mut Build, library: &str) {
 
     let mut zlib = "z";
     let build_dir = format!("{}/build", dst.display());
-    let third_party = vec![
-        "cares/cares/lib",
-        "zlib",
-        "boringssl/ssl",
-        "boringssl/crypto",
-    ];
     if get_env("CARGO_CFG_TARGET_OS").map_or(false, |s| s == "windows") {
         let profile = match &*env::var("PROFILE").unwrap_or("debug".to_owned()) {
             "bench" | "release" => {
@@ -192,8 +199,7 @@ fn build_grpc(cc: &mut Build, library: &str) {
 
     if cfg!(feature = "secure") {
         if cfg!(feature = "openssl") && !cfg!(feature = "openssl-vendored") {
-            println!("cargo:rustc-link-lib=ssl");
-            println!("cargo:rustc-link-lib=crypto");
+            figure_ssl_path(&build_dir);
         } else {
             println!("cargo:rustc-link-lib=static=ssl");
             println!("cargo:rustc-link-lib=static=crypto");
@@ -201,6 +207,27 @@ fn build_grpc(cc: &mut Build, library: &str) {
     }
 
     cc.include("grpc/include");
+}
+
+fn figure_ssl_path(build_dir: &str) {
+    let path = format!("{}/CMakeCache.txt", build_dir);
+    let f = BufReader::new(std::fs::File::open(&path).unwrap());
+    let mut cnt = 0;
+    for l in f.lines() {
+        let l = l.unwrap();
+        let t = trim_start(&l, "OPENSSL_CRYPTO_LIBRARY:FILEPATH=")
+            .or_else(|| trim_start(&l, "OPENSSL_SSL_LIBRARY:FILEPATH="));
+        if let Some(s) = t {
+            println!("cargo:rustc-link-lib={}", s);
+            cnt += 1;
+        }
+    }
+    if cnt != 2 {
+        panic!(
+            "CMake cache invalid, file {} contains {} ssl keys!",
+            path, cnt
+        );
+    }
 }
 
 #[cfg(feature = "openssl-vendored")]


### PR DESCRIPTION
We should not rely on the assumption that ssl library is in the search
path when enabling openssl features. This PR utilize the path figured by
cmake to link correctly.

Close #330.